### PR TITLE
chore(indexers): Add metrics servers with base metrics (num of blocks processed, last processed block height)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4501,6 +4501,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 name = "state-indexer"
 version = "0.1.0"
 dependencies = [
+ "actix-web",
  "anyhow",
  "async-trait",
  "aws-sdk-s3",
@@ -4515,12 +4516,14 @@ dependencies = [
  "http",
  "humantime",
  "itertools",
+ "lazy_static",
  "near-indexer-primitives",
  "near-jsonrpc-client",
  "near-lake-framework",
  "near-primitives-core",
  "num-bigint",
  "openssl-probe",
+ "prometheus",
  "scylla",
  "serde",
  "serde_json",
@@ -5107,6 +5110,7 @@ dependencies = [
 name = "tx-indexer"
 version = "0.1.0"
 dependencies = [
+ "actix-web",
  "anyhow",
  "async-trait",
  "aws-credential-types",
@@ -5117,10 +5121,12 @@ dependencies = [
  "database",
  "dotenv",
  "futures",
+ "lazy_static",
  "near-indexer-primitives",
  "near-jsonrpc-client",
  "near-lake-framework",
  "num-bigint",
+ "prometheus",
  "readnode-primitives",
  "redis",
  "scylla",

--- a/state-indexer/Cargo.toml
+++ b/state-indexer/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 rust-version = "1.61.0"
 
 [dependencies]
+actix-web = "4.2.1"
 aws-sdk-s3 = "0.23.0"
 aws-types = "0.53.0"
 anyhow = "1.0.70"
@@ -19,8 +20,10 @@ hex = "0.4.3"
 http = "0.2"
 humantime = "2.1.0"
 itertools = "0.10.0"
+lazy_static = "1.4.0"
 num-bigint = "0.3"
 openssl-probe = "0.1.5"
+prometheus = "0.13.1"
 scylla = "0.7.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0.55"

--- a/state-indexer/src/configs.rs
+++ b/state-indexer/src/configs.rs
@@ -29,6 +29,9 @@ pub(crate) struct Opts {
     /// ScyllaDB password
     #[clap(long, env)]
     pub scylla_password: Option<String>,
+    /// Metrics HTTP server port
+    #[clap(long, default_value = "8080", env)]
+    pub port: u16,
     /// Chain ID: testnet or mainnet
     #[clap(subcommand)]
     pub chain_id: ChainId,

--- a/state-indexer/src/metrics.rs
+++ b/state-indexer/src/metrics.rs
@@ -1,0 +1,58 @@
+use actix_web::{get, App, HttpServer, Responder};
+use prometheus::{Encoder, IntCounter, IntGauge, Opts};
+
+type Result<T, E> = std::result::Result<T, E>;
+
+fn try_create_int_counter(name: &str, help: &str) -> Result<IntCounter, prometheus::Error> {
+    let opts = Opts::new(name, help);
+    let counter = IntCounter::with_opts(opts)?;
+    prometheus::register(Box::new(counter.clone()))?;
+    Ok(counter)
+}
+
+fn try_create_int_gauge(name: &str, help: &str) -> Result<IntGauge, prometheus::Error> {
+    let opts = Opts::new(name, help);
+    let gauge = IntGauge::with_opts(opts)?;
+    prometheus::register(Box::new(gauge.clone()))?;
+    Ok(gauge)
+}
+
+lazy_static! {
+    pub(crate) static ref BLOCK_PROCESSED_TOTAL: IntCounter = try_create_int_counter(
+        "indexer_events_total_blocks_processed",
+        "Total number of blocks processed by indexer regardless of restarts. Used to calculate Block Processing Rate(BPS)"
+    )
+    .unwrap();
+    pub(crate) static ref LATEST_BLOCK_HEIGHT: IntGauge = try_create_int_gauge(
+        "indexer_events_latest_block_height",
+        "Last seen block height by indexer"
+    )
+    .unwrap();
+}
+
+#[get("/metrics")]
+async fn get_metrics() -> impl Responder {
+    let encoder = prometheus::TextEncoder::new();
+
+    let mut buffer = Vec::new();
+    if let Err(e) = encoder.encode(&prometheus::gather(), &mut buffer) {
+        tracing::error!(target: crate::INDEXER, "could not encode metrics: {}", e);
+    };
+
+    match String::from_utf8(buffer.clone()) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::error!(target: crate::INDEXER, "custom metrics could not be from_utf8'd: {}", e);
+            String::default()
+        }
+    }
+}
+
+pub(crate) fn init_server(port: u16) -> anyhow::Result<actix_web::dev::Server> {
+    tracing::info!(target: crate::INDEXER, "Starting metrics server on http://0.0.0.0:{port}/metrics");
+
+    Ok(HttpServer::new(|| App::new().service(get_metrics))
+        .bind(("0.0.0.0", port))?
+        .disable_signals()
+        .run())
+}

--- a/tx-indexer/Cargo.toml
+++ b/tx-indexer/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+actix-web = "4.2.1"
 anyhow = "1.0.70"
 async-trait = "0.1.66"
 aws-credential-types = "0.53.0"
@@ -13,7 +14,9 @@ borsh = "0.10.2"
 clap = { version = "3.2.22", features = ["color", "derive", "env"] }
 dotenv = "0.15.0"
 futures = "0.3.5"
+lazy_static = "1.4.0"
 num-bigint = "0.3"
+prometheus = "0.13.1"
 redis = { version = "0.22.3", features = ["tokio-comp", "connection-manager"] }
 scylla = "0.7.0"
 serde = { version = "1.0.145", features = ["derive"] }

--- a/tx-indexer/src/config.rs
+++ b/tx-indexer/src/config.rs
@@ -25,6 +25,9 @@ pub(crate) struct Opts {
     /// Indexer ID to handle meta data about the instance
     #[clap(long, env)]
     pub indexer_id: String,
+    /// Port for metrics server
+    #[clap(long, default_value = "8080", env)]
+    pub port: u16,
     /// ScyllaDB connection string. Default: "127.0.0.1:9042"
     #[clap(long, default_value = "127.0.0.1:9042", env)]
     pub scylla_url: String,

--- a/tx-indexer/src/metrics.rs
+++ b/tx-indexer/src/metrics.rs
@@ -1,0 +1,65 @@
+use actix_web::{get, App, HttpServer, Responder};
+use prometheus::{Encoder, IntCounter, IntGauge, Opts};
+
+type Result<T, E> = std::result::Result<T, E>;
+
+fn try_create_int_counter(name: &str, help: &str) -> Result<IntCounter, prometheus::Error> {
+    let opts = Opts::new(name, help);
+    let counter = IntCounter::with_opts(opts)?;
+    prometheus::register(Box::new(counter.clone()))?;
+    Ok(counter)
+}
+
+fn try_create_int_gauge(name: &str, help: &str) -> Result<IntGauge, prometheus::Error> {
+    let opts = Opts::new(name, help);
+    let gauge = IntGauge::with_opts(opts)?;
+    prometheus::register(Box::new(gauge.clone()))?;
+    Ok(gauge)
+}
+
+lazy_static! {
+    pub(crate) static ref BLOCK_PROCESSED_TOTAL: IntCounter = try_create_int_counter(
+        "indexer_events_total_blocks_processed",
+        "Total number of blocks processed by indexer regardless of restarts. Used to calculate Block Processing Rate(BPS)"
+    )
+    .unwrap();
+    pub(crate) static ref LATEST_BLOCK_HEIGHT: IntGauge = try_create_int_gauge(
+        "indexer_events_latest_block_height",
+        "Last seen block height by indexer"
+    )
+    .unwrap();
+}
+
+#[get("/metrics")]
+async fn get_metrics() -> impl Responder {
+    let encoder = prometheus::TextEncoder::new();
+
+    let mut buffer = Vec::new();
+    if let Err(e) = encoder.encode(&prometheus::gather(), &mut buffer) {
+        tracing::error!(target: crate::INDEXER, "could not encode metrics: {}", e);
+    };
+
+    match String::from_utf8(buffer.clone()) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::error!(
+                target: crate::INDEXER,
+                "custom metrics could not be from_utf8'd: {}",
+                e
+            );
+            String::default()
+        }
+    }
+}
+
+pub(crate) fn init_server(port: u16) -> anyhow::Result<actix_web::dev::Server> {
+    tracing::info!(
+        target: crate::INDEXER,
+        "Starting metrics server on http://0.0.0.0:{port}/metrics"
+    );
+
+    Ok(HttpServer::new(|| App::new().service(get_metrics))
+        .bind(("0.0.0.0", port))?
+        .disable_signals()
+        .run())
+}


### PR DESCRIPTION
This PR introduces metrics servers to the indexers in this project. For now, these metrics are only:
- number of blocks processed by the instance
- last processed block height

Mostly it's needed to finish up the infra setup using CloudRun.