### PR TITLE
chore: Add a support for ENABLE_JSON_LOGS for all the crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5083,12 +5083,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/rpc-server/Cargo.toml
+++ b/rpc-server/Cargo.toml
@@ -28,7 +28,7 @@ serde_json = "1.0.85"
 tokio = { version = "1.19.2", features = ["full", "tracing"] }  # selected package `tokio = "~1.19"` satisfies dependency of package `near-o11y v0.16.0`
 tracing = { version = "0.1.36", features = ["std"] }
 tracing-actix-web = "0.6.1"
-tracing-subscriber = { version = "0.3.15", features = ["fmt", "env-filter", "std"] }
+tracing-subscriber = { version = "0.3.15", features = ["fmt", "env-filter", "std", "json"] }
 opentelemetry = { version = "0.17", features = ["rt-tokio-current-thread"] }
 opentelemetry-jaeger = { version = "0.16", features = ["rt-tokio-current-thread"] }
 tracing-opentelemetry = { version = "0.17" }

--- a/tx-indexer/Cargo.toml
+++ b/tx-indexer/Cargo.toml
@@ -25,7 +25,7 @@ serde_json = "1.0.85"
 tokio = { version = "1.19.2", features = ["sync", "time", "macros", "rt-multi-thread"] }
 tokio-stream = { version = "0.1.12" }
 tracing = "0.1.34"
-tracing-subscriber = "0.3.16"
+tracing-subscriber = { version = "0.3.16", features = ["json"] }
 
 database = { path = "../database"}
 readnode-primitives = { path = "../readnode-primitives"}

--- a/tx-indexer/src/config.rs
+++ b/tx-indexer/src/config.rs
@@ -137,7 +137,7 @@ async fn final_block_height(opts: &Opts) -> u64 {
     latest_block.header.height
 }
 
-pub fn init_tracing() {
+pub fn init_tracing() -> anyhow::Result<()> {
     let mut env_filter = EnvFilter::new("near_lake_framework=info,tx_indexer=info");
 
     if let Ok(rust_log) = std::env::var("RUST_LOG") {
@@ -154,10 +154,17 @@ pub fn init_tracing() {
         }
     }
 
-    tracing_subscriber::fmt::Subscriber::builder()
+    let subscriber = tracing_subscriber::fmt::Subscriber::builder()
         .with_env_filter(env_filter)
-        .with_writer(std::io::stderr)
-        .init();
+        .with_writer(std::io::stderr);
+
+    if std::env::var("ENABLE_JSON_LOGS").is_ok() {
+        subscriber.json().init();
+    } else {
+        subscriber.compact().init();
+    }
+
+    Ok(())
 }
 
 pub(crate) struct ScyllaDBManager {

--- a/tx-indexer/src/main.rs
+++ b/tx-indexer/src/main.rs
@@ -15,7 +15,9 @@ pub(crate) const INDEXER: &str = "tx_indexer";
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     dotenv::dotenv().ok();
-    init_tracing();
+
+    init_tracing()?;
+
     let opts: Opts = Opts::parse();
     tracing::info!(target: INDEXER, "Connecting to redis...");
     let redis_connection_manager = storage::connect(&opts.redis_connection_string).await?;


### PR DESCRIPTION
This PRs updates `init_tracing` function in all the crates:
- `rpc-server`
- `state-indexer`
- `tx-indexer`

If the environmental variable `ENABLE_JSON_LOGS` is provided it changes the mode `tracing-subscriber` prints the logs to `fmt::Json` which is necessary for our infra.