### PR TITLE
change scylla db consistency level from All to LocalQuorum

### DIFF
--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -138,7 +138,7 @@ pub trait ScyllaStorageManager {
         query_text: &str,
     ) -> anyhow::Result<PreparedStatement> {
         let mut query = scylla::statement::query::Query::new(query_text);
-        query.set_consistency(scylla::frame::types::Consistency::All);
+        query.set_consistency(scylla::frame::types::Consistency::LocalQuorum);
 
         #[cfg(not(feature = "scylla_db_tracing"))]
         {


### PR DESCRIPTION
We need to consistency level from All to LocalQuorum because for All record don't consider a write complete until its replicated to all nodes in all regions. 

It should be speedup to write.