### PR TITLE
feat(state-indexer): Add concurrency config parameter

### DIFF
--- a/state-indexer/src/configs.rs
+++ b/state-indexer/src/configs.rs
@@ -33,6 +33,8 @@ pub(crate) struct Opts {
     /// Metrics HTTP server port
     #[clap(long, default_value = "8080", env)]
     pub port: u16,
+    #[clap(long, default_value = "1", env)]
+    pub concurrency: usize,
     /// Chain ID: testnet or mainnet
     #[clap(subcommand)]
     pub chain_id: ChainId,

--- a/state-indexer/src/main.rs
+++ b/state-indexer/src/main.rs
@@ -223,7 +223,7 @@ async fn main() -> anyhow::Result<()> {
 
     let mut handlers = tokio_stream::wrappers::ReceiverStream::new(stream)
         .map(|streamer_message| handle_streamer_message(streamer_message, &scylla_storage, &opts.indexer_id))
-        .buffer_unordered(1usize);
+        .buffer_unordered(opts.concurrency);
 
     while let Some(_handle_message) = handlers.next().await {
         if let Err(err) = _handle_message {


### PR DESCRIPTION
This PR adds the `concurrency` parameter to the `state-indexer`.

It can be provided either via CLI arg:

```
state-indexer --concurrency 100 mainnet from-interruption
```

OR

via environmental variable:

```
env CONCURRENCY=100 state-indexer mainnet from-interruption
```