### PR TITLE
DPLT-968: Indexer BPS log

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5069,6 +5069,7 @@ dependencies = [
  "dotenv",
  "futures",
  "futures-locks",
+ "humantime",
  "lazy_static",
  "near-indexer-primitives",
  "near-jsonrpc-client",

--- a/state-indexer/src/main.rs
+++ b/state-indexer/src/main.rs
@@ -25,7 +25,7 @@ async fn handle_streamer_message(
     streamer_message: near_indexer_primitives::StreamerMessage,
     scylla_storage: &configs::ScyllaDBManager,
     indexer_id: &str,
-    stats: std::sync::Arc<tokio::sync::RwLock<metrics::Stats>>
+    stats: std::sync::Arc<tokio::sync::RwLock<metrics::Stats>>,
 ) -> anyhow::Result<()> {
     let block_height = streamer_message.block.header.height;
     let block_hash = streamer_message.block.header.hash;
@@ -255,9 +255,10 @@ async fn main() -> anyhow::Result<()> {
     tokio::spawn(metrics::state_logger(std::sync::Arc::clone(&stats), opts.rpc_url().to_string()));
 
     let mut handlers = tokio_stream::wrappers::ReceiverStream::new(stream)
-        .map(|streamer_message| handle_streamer_message(streamer_message, &scylla_storage, &opts.indexer_id, std::sync::Arc::clone(&stats)))
+        .map(|streamer_message| {
+            handle_streamer_message(streamer_message, &scylla_storage, &opts.indexer_id, std::sync::Arc::clone(&stats))
+        })
         .buffer_unordered(opts.concurrency);
-
 
     while let Some(_handle_message) = handlers.next().await {
         if let Err(err) = _handle_message {

--- a/state-indexer/src/metrics.rs
+++ b/state-indexer/src/metrics.rs
@@ -56,3 +56,70 @@ pub(crate) fn init_server(port: u16) -> anyhow::Result<actix_web::dev::Server> {
         .disable_signals()
         .run())
 }
+
+#[derive(Debug, Clone)]
+pub struct Stats {
+    pub block_heights_processing: std::collections::BTreeSet<u64>,
+    pub blocks_processed_count: u64,
+    pub last_processed_block_height: u64,
+}
+
+impl Stats {
+    pub fn new() -> Self {
+        Self {
+            block_heights_processing: std::collections::BTreeSet::new(),
+            blocks_processed_count: 0,
+            last_processed_block_height: 0,
+        }
+    }
+
+}
+
+pub async fn state_logger(
+    stats: std::sync::Arc<tokio::sync::RwLock<Stats>>,
+    rpc_url: String,
+) {
+    let interval_secs = 10;
+    let mut prev_blocks_processed_count: u64 = 0;
+
+    loop {
+        tokio::time::sleep(std::time::Duration::from_secs(interval_secs)).await;
+        let stats_lock = stats.read().await;
+
+        let block_processing_speed: f64 = ((stats_lock.blocks_processed_count
+            - prev_blocks_processed_count) as f64)
+            / (interval_secs as f64);
+
+        let time_to_catch_the_tip_duration = if block_processing_speed > 0.0 {
+            if let Ok(block_height) = crate::configs::final_block_height(&rpc_url).await {
+                Some(std::time::Duration::from_millis(
+                    (((block_height - stats_lock.last_processed_block_height) as f64
+                        / block_processing_speed)
+                        * 1000f64) as u64,
+                ))
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        tracing::info!(
+            target: crate::INDEXER,
+            "# {} | Blocks processing: {}| Blocks done: {}. Bps {:.2} b/s {}",
+            stats_lock.last_processed_block_height,
+            stats_lock.block_heights_processing.len(),
+            stats_lock.blocks_processed_count,
+            block_processing_speed,
+            if let Some(duration) = time_to_catch_the_tip_duration {
+                format!(
+                    " | {} to catch up the tip",
+                    humantime::format_duration(duration)
+                )
+            } else {
+                "".to_string()
+            }
+        );
+        prev_blocks_processed_count = stats_lock.blocks_processed_count;
+    };
+}

--- a/tx-indexer/Cargo.toml
+++ b/tx-indexer/Cargo.toml
@@ -15,6 +15,7 @@ clap = { version = "3.2.22", features = ["color", "derive", "env"] }
 dotenv = "0.15.0"
 futures = "0.3.5"
 futures-locks = "0.7.1"
+humantime = "2.1.0"
 lazy_static = "1.4.0"
 num-bigint = "0.3"
 num-traits = "0.2.15"

--- a/tx-indexer/src/config.rs
+++ b/tx-indexer/src/config.rs
@@ -116,22 +116,22 @@ async fn get_start_block_height(
                     .to_u64()
                     .expect("Failed to convert BigInt to u64"))
             } else {
-                Ok(final_block_height(opts).await)
+                Ok(final_block_height(opts.rpc_url()).await?)
             }
         }
-        StartOptions::FromLatest => Ok(final_block_height(opts).await),
+        StartOptions::FromLatest => Ok(final_block_height(opts.rpc_url()).await?),
     }
 }
 
-async fn final_block_height(opts: &Opts) -> u64 {
-    let client = JsonRpcClient::connect(opts.rpc_url().to_string());
+pub async fn final_block_height(rpc_url: &str) -> anyhow::Result<u64> {
+    let client = JsonRpcClient::connect(rpc_url.to_string());
     let request = methods::block::RpcBlockRequest {
         block_reference: BlockReference::Finality(Finality::Final),
     };
 
     let latest_block = client.call(request).await.unwrap();
 
-    latest_block.header.height
+    Ok(latest_block.header.height)
 }
 
 pub fn init_tracing() -> anyhow::Result<()> {

--- a/tx-indexer/src/metrics.rs
+++ b/tx-indexer/src/metrics.rs
@@ -63,3 +63,70 @@ pub(crate) fn init_server(port: u16) -> anyhow::Result<actix_web::dev::Server> {
         .disable_signals()
         .run())
 }
+
+#[derive(Debug, Clone)]
+pub struct Stats {
+    pub block_heights_processing: std::collections::BTreeSet<u64>,
+    pub blocks_processed_count: u64,
+    pub last_processed_block_height: u64,
+}
+
+impl Stats {
+    pub fn new() -> Self {
+        Self {
+            block_heights_processing: std::collections::BTreeSet::new(),
+            blocks_processed_count: 0,
+            last_processed_block_height: 0,
+        }
+    }
+
+}
+
+pub async fn state_logger(
+    stats: std::sync::Arc<tokio::sync::RwLock<Stats>>,
+    rpc_url: String,
+) {
+    let interval_secs = 10;
+    let mut prev_blocks_processed_count: u64 = 0;
+
+    loop {
+        tokio::time::sleep(std::time::Duration::from_secs(interval_secs)).await;
+        let stats_lock = stats.read().await;
+
+        let block_processing_speed: f64 = ((stats_lock.blocks_processed_count
+            - prev_blocks_processed_count) as f64)
+            / (interval_secs as f64);
+
+        let time_to_catch_the_tip_duration = if block_processing_speed > 0.0 {
+            if let Ok(block_height) = crate::config::final_block_height(&rpc_url).await {
+                Some(std::time::Duration::from_millis(
+                    (((block_height - stats_lock.last_processed_block_height) as f64
+                        / block_processing_speed)
+                        * 1000f64) as u64,
+                ))
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        tracing::info!(
+            target: crate::INDEXER,
+            "# {} | Blocks processing: {}| Blocks done: {}. Bps {:.2} b/s {}",
+            stats_lock.last_processed_block_height,
+            stats_lock.block_heights_processing.len(),
+            stats_lock.blocks_processed_count,
+            block_processing_speed,
+            if let Some(duration) = time_to_catch_the_tip_duration {
+                format!(
+                    " | {} to catch up the tip",
+                    humantime::format_duration(duration)
+                )
+            } else {
+                "".to_string()
+            }
+        );
+        prev_blocks_processed_count = stats_lock.blocks_processed_count;
+    };
+}

--- a/tx-indexer/src/metrics.rs
+++ b/tx-indexer/src/metrics.rs
@@ -79,13 +79,9 @@ impl Stats {
             last_processed_block_height: 0,
         }
     }
-
 }
 
-pub async fn state_logger(
-    stats: std::sync::Arc<tokio::sync::RwLock<Stats>>,
-    rpc_url: String,
-) {
+pub async fn state_logger(stats: std::sync::Arc<tokio::sync::RwLock<Stats>>, rpc_url: String) {
     let interval_secs = 10;
     let mut prev_blocks_processed_count: u64 = 0;
 
@@ -128,5 +124,5 @@ pub async fn state_logger(
             }
         );
         prev_blocks_processed_count = stats_lock.blocks_processed_count;
-    };
+    }
 }


### PR DESCRIPTION
Sometimes it’s necessary to have a quick look to get the blocks per second speed of the indexer.
This pr implements calculator the BPS(blocks per second) and report it in the log message once in 10 second.