### PR TITLE
refactor(tx-indexer): Add tracing-instrumentation feature to the tx-indexer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5107,6 +5107,8 @@ dependencies = [
  "near-lake-framework",
  "num-bigint",
  "num-traits",
+ "opentelemetry",
+ "opentelemetry-jaeger",
  "prometheus",
  "readnode-primitives",
  "scylla",
@@ -5115,6 +5117,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
+ "tracing-opentelemetry",
  "tracing-subscriber",
 ]
 

--- a/tx-indexer/Cargo.toml
+++ b/tx-indexer/Cargo.toml
@@ -26,7 +26,10 @@ serde_json = "1.0.85"
 tokio = { version = "1.19.2", features = ["sync", "time", "macros", "rt-multi-thread"] }
 tokio-stream = { version = "0.1.12" }
 tracing = "0.1.34"
-tracing-subscriber = { version = "0.3.16", features = ["json"] }
+tracing-subscriber = { version = "0.3.15", features = ["fmt", "env-filter", "std", "json"] }
+opentelemetry = { version = "0.17", features = ["rt-tokio-current-thread"] }
+opentelemetry-jaeger = { version = "0.16", features = ["rt-tokio-current-thread"] }
+tracing-opentelemetry = { version = "0.17" }
 
 database = { path = "../database"}
 readnode-primitives = { path = "../readnode-primitives"}
@@ -36,4 +39,5 @@ near-jsonrpc-client = "0.5.1"
 near-lake-framework = "0.7.1"
 
 [features]
+tracing-instrumentation = []
 scylla_db_tracing = ["database/scylla_db_tracing"]

--- a/tx-indexer/src/collector.rs
+++ b/tx-indexer/src/collector.rs
@@ -8,6 +8,7 @@ use crate::{config, storage};
 
 // TODO: Handle known TX hash collision case for mainnet
 // ref: https://github.com/near/near-indexer-for-explorer/issues/84
+#[cfg_attr(feature = "tracing-instrumentation", tracing::instrument(skip_all))]
 pub(crate) async fn index_transactions(
     streamer_message: &near_indexer_primitives::StreamerMessage,
     scylla_db_client: &std::sync::Arc<config::ScyllaDBManager>,
@@ -39,6 +40,7 @@ pub(crate) async fn index_transactions(
 
 // Extracts all Transactions from the given `StreamerMessage` and pushes them to the memory storage
 // by calling the function `new_transaction_details_to_collecting_pool`.
+#[cfg_attr(feature = "tracing-instrumentation", tracing::instrument(skip_all))]
 async fn extract_transactions_to_collect(
     streamer_message: &near_indexer_primitives::StreamerMessage,
     scylla_db_client: &std::sync::Arc<config::ScyllaDBManager>,
@@ -68,6 +70,7 @@ async fn extract_transactions_to_collect(
 // Converts Transaction into CollectingTransactionDetails and puts it into memory storage.
 // Also, adds the Receipt produced by ExecutionOutcome of the given Transaction to the watching list
 // in memory storage
+#[cfg_attr(feature = "tracing-instrumentation", tracing::instrument(skip_all))]
 async fn new_transaction_details_to_collecting_pool(
     transaction: &IndexerTransactionWithOutcome,
     block_height: u64,
@@ -122,6 +125,7 @@ async fn new_transaction_details_to_collecting_pool(
     Ok(())
 }
 
+#[cfg_attr(feature = "tracing-instrumentation", tracing::instrument(skip_all))]
 async fn collect_receipts_and_outcomes(
     streamer_message: &near_indexer_primitives::StreamerMessage,
     scylla_db_client: &std::sync::Arc<config::ScyllaDBManager>,
@@ -139,6 +143,7 @@ async fn collect_receipts_and_outcomes(
     Ok(())
 }
 
+#[cfg_attr(feature = "tracing-instrumentation", tracing::instrument(skip_all))]
 async fn process_shard(
     scylla_db_client: &std::sync::Arc<config::ScyllaDBManager>,
     hash_storage: &std::sync::Arc<futures_locks::RwLock<storage::HashStorage>>,
@@ -164,6 +169,7 @@ async fn process_shard(
     Ok(())
 }
 
+#[cfg_attr(feature = "tracing-instrumentation", tracing::instrument(skip_all))]
 async fn push_receipt_to_watching_list(
     hash_storage: &std::sync::Arc<futures_locks::RwLock<storage::HashStorage>>,
     receipt_id: String,
@@ -177,6 +183,7 @@ async fn push_receipt_to_watching_list(
         .await
 }
 
+#[cfg_attr(feature = "tracing-instrumentation", tracing::instrument(skip_all))]
 async fn process_receipt_execution_outcome(
     scylla_db_client: &std::sync::Arc<config::ScyllaDBManager>,
     hash_storage: &std::sync::Arc<futures_locks::RwLock<storage::HashStorage>>,
@@ -249,6 +256,7 @@ async fn process_receipt_execution_outcome(
 }
 
 // Save transaction detail into the scylla db
+#[cfg_attr(feature = "tracing-instrumentation", tracing::instrument(skip_all))]
 async fn save_transaction_details(
     scylla_db_client: &std::sync::Arc<config::ScyllaDBManager>,
     tx_details: readnode_primitives::CollectingTransactionDetails,
@@ -281,6 +289,7 @@ async fn save_transaction_details(
 }
 
 // Save receipt_id, parent_transaction_hash, block_height and shard_id to the ScyllaDb
+#[cfg_attr(feature = "tracing-instrumentation", tracing::instrument(skip_all))]
 async fn save_receipt(
     scylla_db_client: &std::sync::Arc<config::ScyllaDBManager>,
     receipt_id: &str,

--- a/tx-indexer/src/main.rs
+++ b/tx-indexer/src/main.rs
@@ -77,6 +77,7 @@ async fn main() -> anyhow::Result<()> {
     }
 }
 
+#[cfg_attr(feature = "tracing-instrumentation", tracing::instrument(skip_all))]
 async fn handle_streamer_message(
     streamer_message: near_indexer_primitives::StreamerMessage,
     scylla_db_client: &std::sync::Arc<config::ScyllaDBManager>,

--- a/tx-indexer/src/storage.rs
+++ b/tx-indexer/src/storage.rs
@@ -21,6 +21,7 @@ impl HashStorage {
         }
     }
 
+    #[cfg_attr(feature = "tracing-instrumentation", tracing::instrument(skip(self)))]
     pub fn push_receipt_to_watching_list(
         &mut self,
         receipt_id: String,
@@ -37,6 +38,7 @@ impl HashStorage {
         Ok(())
     }
 
+    #[cfg_attr(feature = "tracing-instrumentation", tracing::instrument(skip(self)))]
     pub fn remove_receipt_from_watching_list(
         &mut self,
         receipt_id: &str,
@@ -52,6 +54,7 @@ impl HashStorage {
         }
     }
 
+    #[cfg_attr(feature = "tracing-instrumentation", tracing::instrument(skip(self)))]
     pub fn receipts_transaction_hash_count(&self, transaction_hash: &str) -> anyhow::Result<u64> {
         self.receipts_counters
             .get(transaction_hash)
@@ -62,6 +65,7 @@ impl HashStorage {
             ))
     }
 
+    #[cfg_attr(feature = "tracing-instrumentation", tracing::instrument(skip(self)))]
     pub fn set_tx(
         &mut self,
         transaction_details: readnode_primitives::CollectingTransactionDetails,
@@ -75,6 +79,7 @@ impl HashStorage {
         Ok(())
     }
 
+    #[cfg_attr(feature = "tracing-instrumentation", tracing::instrument(skip(self)))]
     pub fn get_tx(
         &self,
         transaction_hash: &str,
@@ -82,6 +87,7 @@ impl HashStorage {
         self.transactions.get(transaction_hash).cloned()
     }
 
+    #[cfg_attr(feature = "tracing-instrumentation", tracing::instrument(skip(self)))]
     pub fn push_tx_to_save(
         &mut self,
         transaction_details: readnode_primitives::CollectingTransactionDetails,
@@ -93,6 +99,7 @@ impl HashStorage {
         Ok(())
     }
 
+    #[cfg_attr(feature = "tracing-instrumentation", tracing::instrument(skip(self)))]
     pub fn get_transaction_hash_by_receipt_id(
         &self,
         receipt_id: &str,
@@ -100,6 +107,7 @@ impl HashStorage {
         Ok(self.receipts_watching_list.get(receipt_id).cloned())
     }
 
+    #[cfg_attr(feature = "tracing-instrumentation", tracing::instrument(skip(self)))]
     pub fn transactions_to_save(
         &mut self,
     ) -> anyhow::Result<Vec<readnode_primitives::CollectingTransactionDetails>> {
@@ -115,6 +123,7 @@ impl HashStorage {
         Ok(transactions)
     }
 
+    #[cfg_attr(feature = "tracing-instrumentation", tracing::instrument(skip(self)))]
     pub fn push_outcome_and_receipt(
         &mut self,
         transaction_hash: &str,


### PR DESCRIPTION
This PR introduces the `tracing-instrumentation` feature to the `tx-indexer` crate, following the same approach as PR #58.

I have tested the changes locally, and there don't seem to be any major issues. Most of the tasks have been properly parallelized, with the exception of `update_meta`, which doesn't add significant overhead.