### PR TITLE
fix(tx-indexer): Drop redundant unwrap in `final_block_height` function leding to errors

### DIFF
--- a/tx-indexer/src/config.rs
+++ b/tx-indexer/src/config.rs
@@ -130,7 +130,7 @@ pub async fn final_block_height(rpc_url: &str) -> anyhow::Result<u64> {
         block_reference: BlockReference::Finality(Finality::Final),
     };
 
-    let latest_block = client.call(request).await.unwrap();
+    let latest_block = client.call(request).await?;
 
     Ok(latest_block.header.height)
 }


### PR DESCRIPTION
I've noticed an error appearing from time to time:

```
thread 'tokio-runtime-worker' panicked at 'called `Result::unwrap()` on an `Err` value: TransportError(SendError(PayloadSendError(reqwest::Error { kin
d: Request, url: Url { scheme: "https", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("rpc.mainnet.near.org")), port: None, path: "/", query:
None, fragment: None }, source: hyper::Error(Io, Os { code: 104, kind: ConnectionReset, message: "Connection reset by peer" }) })))', tx-indexer/src/config.rs:133:51
tx-indexer_1     | note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

And then I found the `.unwrap` where it didn't belong to.