### PR TITLE
DPLT-1018: Introduce retries to the indexers writes to ScyllaDB

### DIFF
--- a/rpc-server/src/config.rs
+++ b/rpc-server/src/config.rs
@@ -45,6 +45,16 @@ pub struct Opts {
     // AWS default region
     #[clap(long, env, default_value = "8000")]
     pub server_port: u16,
+
+    /// Max retry count for ScyllaDB if `strict_mode` is `false`
+    #[clap(long, default_value = "2", env)]
+    pub max_retry: u8,
+
+    /// Attempts to store data in the database should be infinite to ensure no data is missing.
+    /// Disable it to perform a limited write attempts (`max_retry`)
+    /// before skipping giving up and moving to the next piece of data
+    #[clap(long, default_value = "false", env)]
+    pub strict_mode: bool,
 }
 
 pub struct ServerContext {

--- a/rpc-server/src/main.rs
+++ b/rpc-server/src/main.rs
@@ -100,6 +100,8 @@ async fn main() -> anyhow::Result<()> {
             opts.scylla_user.as_deref(),
             opts.scylla_password.as_deref(),
             Some(opts.scylla_keepalive_interval),
+            opts.max_retry,
+            opts.strict_mode,
         )
         .await?,
     );

--- a/state-indexer/src/configs.rs
+++ b/state-indexer/src/configs.rs
@@ -39,6 +39,14 @@ pub(crate) struct Opts {
     /// Chain ID: testnet or mainnet
     #[clap(subcommand)]
     pub chain_id: ChainId,
+    /// Max retry count for ScyllaDB if `strict_mode` is `false`
+    #[clap(long, default_value = "5", env)]
+    pub max_retry: u8,
+    /// Attempts to store data in the database should be infinite to ensure no data is missing.
+    /// Disable it to perform a limited write attempts (`max_retry`)
+    /// before skipping giving up and moving to the next piece of data
+    #[clap(long, default_value = "true", env)]
+    pub strict_mode: bool,
 }
 
 #[derive(Subcommand, Debug, Clone)]

--- a/state-indexer/src/main.rs
+++ b/state-indexer/src/main.rs
@@ -249,6 +249,8 @@ async fn main() -> anyhow::Result<()> {
         opts.scylla_user.as_deref(),
         opts.scylla_password.as_deref(),
         None,
+        opts.max_retry,
+        opts.strict_mode,
     )
     .await?;
     let scylla_session = scylla_storage.scylla_session().await;

--- a/tx-indexer/src/config.rs
+++ b/tx-indexer/src/config.rs
@@ -41,6 +41,14 @@ pub(crate) struct Opts {
     /// Chain ID: testnet or mainnet
     #[clap(subcommand)]
     pub chain_id: ChainId,
+    /// Max retry count for ScyllaDB if `strict_mode` is `false`
+    #[clap(long, default_value = "5", env)]
+    pub max_retry: u8,
+    /// Attempts to store data in the database should be infinite to ensure no data is missing.
+    /// Disable it to perform a limited write attempts (`max_retry`)
+    /// before skipping giving up and moving to the next piece of data
+    #[clap(long, default_value = "true", env)]
+    pub strict_mode: bool,
 }
 
 #[derive(Subcommand, Debug, Clone)]

--- a/tx-indexer/src/main.rs
+++ b/tx-indexer/src/main.rs
@@ -29,6 +29,8 @@ async fn main() -> anyhow::Result<()> {
             opts.scylla_user.as_deref(),
             opts.scylla_password.as_deref(),
             None,
+            opts.max_retry,
+            opts.strict_mode,
         )
         .await?,
     );


### PR DESCRIPTION
This pr implement  a retry logic for the cases when we get an error from ScyllaDB and we cannot miss the data.

For indexers works in so-called “strict” mode when we retry infinitely though throwing a warning about it. In addition, we have a “non-strict” mode that limits the number of retries to N (5 by default).

For rpc-server works “non-strict” mode with limits the number of retries to 2.