### PR TITLE
feat(indexers): Add optional fallback value to the `from-interruption` start mode

### DIFF
--- a/state-indexer/README.md
+++ b/state-indexer/README.md
@@ -32,8 +32,16 @@ docker exec -it some-scylla cqlsh
 use state_indexer;
 ```
 
-## Build state-indexer and run
+### Command to run
 
 ```
-$ env RUST_LOG="state_indexer=debug" cargo run --release -- testnet from-interruption
+cargo run --release -- <chain_id> <start_options>
 ```
+
+- `chain_id` (\*) `testnet` or `mainnet`
+- `start_options`:
+    - `from-latest` fetches the final block height from the RPC and starts indexing from that block
+    - `from-interruption <N?>` is used to retrieve the `last_processed_block_height` from the Scylla database. This value is used as the starting point for processing blocks. If a specific value `<N?>` is provided, it will be used as the fallback option. If `<N?>` is not provided or if the database does not have a record (for example, in the case of a fresh start with an empty storage), the fallback option will be `from-latest`.
+    - `from-block <N>` starts indexing from the block height `<N>`
+
+

--- a/tx-indexer/README.md
+++ b/tx-indexer/README.md
@@ -73,6 +73,6 @@ cargo run --release -- <chain_id> <start_options>
 - `chain_id` (\*) `testnet` or `mainnet`
 - `start_options`:
     - `from-latest` fetches the final block height from the RPC and starts indexing from that block
-    - `from-interruption` will fetch the `last_processed_block_height` from scylla-db in order to start from that block (will fallback to `from-latest` if scylla-db doesn't have a record, for instance in case of fresh start with empty storage)
+    - `from-interruption <N?>` is used to retrieve the `last_processed_block_height` from the Scylla database. This value is used as the starting point for processing blocks. If a specific value `<N?>` is provided, it will be used as the fallback option. If `<N?>` is not provided or if the database does not have a record (for example, in the case of a fresh start with an empty storage), the fallback option will be `from-latest`.
     - `from-block <N>` starts indexing from the block height `<N>`
 


### PR DESCRIPTION
This PR introduces an optional fallback start from the block value to the `from-interruption` start mode.

One can run the following command:

```
$ env INDEXER_ID="state-indexer-1" state-indexer mainnet from-interruption 90000000
```

The value `90000000` will be used if the database has no record for the `last_processed_block_height` value stored for the indexer with ID `state-indexer-1`.

The fallback value is optional. If not provided in case of error the indexer will fall back to the `from-latest` value.