### PR TITLE
refactor(rpc-server): Hide send transaction methods under the feature `send_tx_methods` (default)

### DIFF
--- a/rpc-server/Cargo.toml
+++ b/rpc-server/Cargo.toml
@@ -51,6 +51,8 @@ near-vm-runner = "0.17.0"
 near-vm-logic = "0.17.0"
 
 [features]
+default = ["submit_tx_methods"]
+submit_tx_methods = []
 tracing-instrumentation = []
 scylla_db_tracing = ["database/scylla_db_tracing"]
 shadow_data_consistency = ["dep:assert-json-diff",]

--- a/rpc-server/Dockerfile
+++ b/rpc-server/Dockerfile
@@ -13,7 +13,7 @@ RUN mkdir rpc-server/src && echo 'fn main() {}' > rpc-server/src/main.rs cargo b
 COPY rpc-server/src ./rpc-server/src
 
 # build for release
-RUN cargo build --release --features "$features"
+RUN cargo build --release --no-default-features --features "$features"
 
 FROM ubuntu:20.04
 RUN apt update && apt install -yy openssl ca-certificates

--- a/rpc-server/README.md
+++ b/rpc-server/README.md
@@ -48,3 +48,34 @@ $ ./target/release/read-rpc-server
 ```asm
 https://docs.near.org/api/rpc/introduction
 ```
+
+## Feature flags
+
+### `send_tx_methods` (default: `true`)
+
+This feature flag enabled the methods for sending transactions to the network. This includes the following methods:
+
+- `broadcast_tx_commit`
+- `broadcast_tx_async`
+
+Might be useful to disable if you want to run a totally read-only node that doesn't even proxies transactions to the network.
+
+**Note** the methods will be still available in the API, but will return an error if the feature flag is disabled.
+
+### `tracing-instrumentation` (default: `false`)
+
+This feature flag enables the tracing instrumentation for the RPC server. See the [Logging](#logging) section for more details.
+
+### `scylla_db_tracing` (default: `false`)
+
+This feature flag enables the tracing instrumentation for the ScyllaDB client ([`database` crate](../database)). Database tracing means additional debug-level logs for all the database queries.
+
+### `shadow_data_consistency` (default: `false`)
+
+This feature flag enables the shadow data consistency checks. With this feature on, all the queries to the read-rpc-server will be executed twice: once against the main database, and once against the real NEAR RPC. If the results are different, warning-level logs are emitted. **Note** we've decided that read-rpc-server will return its own response if the results are incorrect to make the debugging easier.
+
+**Warning** This feature is created for the early-stage of lunching the read-rpc-server to catch all the bugs and inconsistencies. You don't need this feature if you are not a contributor to the read-rpc-server.
+
+### `account_access_keys` (default: `false`)
+
+We encountered a problem with the design of the table `account_access_keys` and overall design of the logic around it. We had to disable the table and proxy the calls of the `query.access_key_list` method to the real NEAR RPC. However, we still aren't ready to get rid of the code and that's why we hid it under the feature flag. We are planning to remove the code in the future and remove the feature flag.

--- a/rpc-server/src/modules/transactions/methods.rs
+++ b/rpc-server/src/modules/transactions/methods.rs
@@ -19,17 +19,23 @@ pub async fn send_tx_async(
     Params(params): Params<Value>,
 ) -> Result<near_primitives::hash::CryptoHash, RPCError> {
     tracing::debug!("`send_tx_async` call. Params: {:?}", params);
-    let signed_transaction = match parse_signed_transaction(params).await {
-        Ok(signed_transaction) => signed_transaction,
-        Err(err) => return Err(RPCError::parse_error(&err.to_string())),
-    };
-    let proxy_params =
-        near_jsonrpc_client::methods::broadcast_tx_async::RpcBroadcastTxAsyncRequest {
-            signed_transaction,
+    if cfg!(feature = "send_tx_methods") {
+        let signed_transaction = match parse_signed_transaction(params).await {
+            Ok(signed_transaction) => signed_transaction,
+            Err(err) => return Err(RPCError::parse_error(&err.to_string())),
         };
-    match proxy_rpc_call(&data.near_rpc_client, proxy_params).await {
-        Ok(resp) => Ok(resp),
-        Err(err) => Err(RPCError::internal_error(&err.to_string())),
+        let proxy_params =
+            near_jsonrpc_client::methods::broadcast_tx_async::RpcBroadcastTxAsyncRequest {
+                signed_transaction,
+            };
+        match proxy_rpc_call(&data.near_rpc_client, proxy_params).await {
+            Ok(resp) => Ok(resp),
+            Err(err) => Err(RPCError::internal_error(&err.to_string())),
+        }
+    } else {
+        Err(RPCError::internal_error(
+            "This method is not available because the `send_tx_methods` feature flag is disabled",
+        ))
     }
 }
 
@@ -39,21 +45,27 @@ pub async fn send_tx_commit(
     Params(params): Params<Value>,
 ) -> Result<near_jsonrpc_primitives::types::transactions::RpcTransactionResponse, RPCError> {
     tracing::debug!("`send_tx_commit` call. Params: {:?}", params);
-    let signed_transaction = match parse_signed_transaction(params).await {
-        Ok(signed_transaction) => signed_transaction,
-        Err(err) => return Err(RPCError::parse_error(&err.to_string())),
-    };
-    let proxy_params =
-        near_jsonrpc_client::methods::broadcast_tx_commit::RpcBroadcastTxCommitRequest {
-            signed_transaction,
+    if cfg!(feature = "send_tx_methods") {
+        let signed_transaction = match parse_signed_transaction(params).await {
+            Ok(signed_transaction) => signed_transaction,
+            Err(err) => return Err(RPCError::parse_error(&err.to_string())),
         };
-    match proxy_rpc_call(&data.near_rpc_client, proxy_params).await {
-        Ok(resp) => Ok(
-            near_jsonrpc_primitives::types::transactions::RpcTransactionResponse {
-                final_execution_outcome: FinalExecutionOutcome(resp),
-            },
-        ),
-        Err(err) => Err(RPCError::from(err)),
+        let proxy_params =
+            near_jsonrpc_client::methods::broadcast_tx_commit::RpcBroadcastTxCommitRequest {
+                signed_transaction,
+            };
+        match proxy_rpc_call(&data.near_rpc_client, proxy_params).await {
+            Ok(resp) => Ok(
+                near_jsonrpc_primitives::types::transactions::RpcTransactionResponse {
+                    final_execution_outcome: FinalExecutionOutcome(resp),
+                },
+            ),
+            Err(err) => Err(RPCError::from(err)),
+        }
+    } else {
+        Err(RPCError::internal_error(
+            "This method is not available because the `send_tx_methods` feature flag is disabled",
+        ))
     }
 }
 


### PR DESCRIPTION
We are preparing for the test lunch of the project. We're not going to make it public yet, but instead, we're going to mirror the traffic to the read-rpc-server to catch bugs and inconsistencies.

We want to disable methods that send transactions to the real NEAR RPC to avoid potential problems for the users.

This PR introduces a default feature flag `send_tx_methods` that enables methods:
- `broadcast_tx_commit`
- `broadcast_tx_async`

Once the feature is disabled those methods are still available in the API but respond with errors instead.

Also in this PR, I did the following:
- Added section "Feature flags" to the `rpc-server`'s README
- Updated the `rpc-server`'s `Dockerfile` for our deployment to disable the default feature I've added