### PR TITLE
feat: Docker-compose file to run the project locally

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,6 +414,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-channel"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf46fee83e5ccffc220104713af3292ff9bc7c64c7de289f66dae8e38d826833"
+dependencies = [
+ "concurrent-queue",
+ "event-listener",
+ "futures-core",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1138,6 +1149,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "castaway"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2698f953def977c68f935bb0dfa959375ad4638570e969e2f1e9f433cbf1af6"
+
+[[package]]
 name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1278,6 +1295,15 @@ name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
+name = "concurrent-queue"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62ec6771ecfa0762d24683ee5a32ad78487a3d3afdc0fb8cae19d2c5deb50b7c"
+dependencies = [
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "constant_time_eq"
@@ -1555,6 +1581,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "curl"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "509bd11746c7ac09ebd19f0b17782eae80aadee26237658a6b4808afb5c11a22"
+dependencies = [
+ "curl-sys",
+ "libc",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "socket2",
+ "winapi",
+]
+
+[[package]]
+name = "curl-sys"
+version = "0.4.63+curl-8.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aeb0fef7046022a1e2ad67a004978f0e3cacb9e3123dc62ce768f92197b771dc"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+ "winapi",
 ]
 
 [[package]]
@@ -1941,6 +1997,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
 name = "extensions"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2098,6 +2160,21 @@ name = "futures-io"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
+
+[[package]]
+name = "futures-lite"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite",
+ "waker-fn",
+]
 
 [[package]]
 name = "futures-locks"
@@ -2526,6 +2603,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "isahc"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "334e04b4d781f436dc315cb1e7515bd96826426345d498149e4bde36b67f8ee9"
+dependencies = [
+ "async-channel",
+ "castaway",
+ "crossbeam-utils",
+ "curl",
+ "curl-sys",
+ "event-listener",
+ "futures-lite",
+ "http",
+ "log",
+ "once_cell",
+ "polling",
+ "slab",
+ "sluice",
+ "tracing",
+ "tracing-futures",
+ "url",
+ "waker-fn",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2615,6 +2717,18 @@ name = "libc"
 version = "0.2.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
+
+[[package]]
+name = "libz-sys"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56ee889ecc9568871456d42f603d6a0ce59ff328d291063a45cbdf0036baf6db"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -3533,14 +3647,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry-http"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "449048140ee61e28f57abe6e9975eedc1f3a29855c7407bd6c12b18578863379"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http",
+ "isahc",
+ "opentelemetry",
+]
+
+[[package]]
 name = "opentelemetry-jaeger"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8c0b12cd9e3f9b35b52f6e0dac66866c519b26f424f4bbf96e3fe8bfbdc5229"
 dependencies = [
  "async-trait",
+ "http",
+ "isahc",
  "lazy_static",
  "opentelemetry",
+ "opentelemetry-http",
  "opentelemetry-semantic-conventions",
  "thiserror",
  "thrift",
@@ -3622,6 +3752,12 @@ name = "parity-wasm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be5e13c266502aadf83426d87d81a0f5d1ef45b8027f5a471c360abfe4bfae92"
+
+[[package]]
+name = "parking"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14f2252c834a40ed9bb5422029649578e63aa341ac401f74e719dd1afda8394e"
 
 [[package]]
 name = "parking_lot"
@@ -3729,6 +3865,22 @@ name = "pkg-config"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
+
+[[package]]
+name = "polling"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
+dependencies = [
+ "autocfg",
+ "bitflags",
+ "cfg-if 1.0.0",
+ "concurrent-queue",
+ "libc",
+ "log",
+ "pin-project-lite",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -4783,6 +4935,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
 
 [[package]]
+name = "sluice"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d7400c0eff44aa2fcb5e31a5f24ba9716ed90138769e4977a2ba6014ae63eb5"
+dependencies = [
+ "async-channel",
+ "futures-core",
+ "futures-io",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5622,6 +5785,12 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "waker-fn"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
 
 [[package]]
 name = "want"

--- a/README.md
+++ b/README.md
@@ -20,6 +20,39 @@ The indexer built on top of Lake Framework that watches the network and stores t
 The indexer built on top of Lake Framework that watches the network and stores the `Transactions` along with all the related entities (`Receipts`, `ExecutionOutcomes`) into the Storage (ScyllaDB) using the specifically defined `TransactionDetails` structure in a dumped way (using the simplest key-value schema)
 
 
+## Docker compose
+
+**Note!** The docker compose is not fully ready yet. It's still in progress. However, you can run the entire project to play around with it. It is still not convenient for development or debugging purposes. We are working on improving it.
+
+### Run the entire project
+
+Add the `.env` file (update the credentials with your own to access the S3 bucket)
+
+```
+AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
+AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+AWS_DEFAULT_REGION=eu-central-1
+```
+
+Run the docker compose:
+
+```
+$ docker-compose up
+```
+
+This will spin up:
+- `read-rpc-server` - the JSON RPC server
+- `state-indexer` - the indexer that watches the network and stores the `StateChanges` into the Storage (ScyllaDB) using the designed data schemas.
+- `tx-indexer` - the indexer that watches the network and stores the `Transactions` along with all the related entities (`Receipts`, `ExecutionOutcomes`) into the Storage (ScyllaDB) using the specifically defined `TransactionDetails` structure in a dumped way (using the simplest key-value schema)
+- `jaeger` - the Jaeger instance for tracing (http://localhost:16686)
+
+### TODO:
+
+- [ ] Setup all the services to use volumes for the codebase and using `cargo watch` to recompile the code on the fly
+- [ ] Come up with the way of changin the configuration for the indexers in a convenient way
+- [ ] Robust documentation for the docker compose setup
+
+
 ## Development
 
 ### Check the entire product

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,18 @@
-version: '3'
+version: '3.4'
+
+x-common-variables:
+  &common-variables
+  SCYLLA_URL: scylla:9042
+  SCYLLA_USER: ${SCYLLA_USER}
+  SCYLLA_PASSWORD: ${SCYLLA_PASSWORD}
+  AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
+  AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
+  AWS_DEFAULT_REGION: ${AWS_DEFAULT_REGION}
+  OTEL_EXPORTER_JAEGER_AGENT_HOST: jaeger
+  OTEL_EXPORTER_JAEGER_AGENT_PORT: 6831
+
+  NEAR_RPC_URL: https://archival-rpc.mainnet.near.org
+  AWS_BUCKET_NAME: near-lake-data-mainnet
 
 services:
   rpc-server:
@@ -8,16 +22,8 @@ services:
       args:
         features: "tracing-instrumentation,shadow_data_consistency"
     environment:
-      SCYLLA_URL: scylla:9042
-      SCYLLA_USER: ${SCYLLA_USER}
-      SCYLLA_PASSWORD: ${SCYLLA_PASSWORD}
+      <<: *common-variables
       AWS_BUCKET_NAME: near-lake-data-mainnet
-      NEAR_RPC_URL: https://archival-rpc.mainnet.near.org
-      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
-      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
-      AWS_DEFAULT_REGION: ${AWS_DEFAULT_REGION}
-      OTEL_EXPORTER_JAEGER_AGENT_HOST: jaeger
-      OTEL_EXPORTER_JAEGER_AGENT_PORT: 6831
       SERVER_PORT: 8080
       RUST_LOG: "read_rpc_server=debug,is_data_consistency=debug"
     restart: on-failure
@@ -34,15 +40,8 @@ services:
       args:
         features: tracing-instrumentation
     environment:
+      <<: *common-variables
       INDEXER_ID: state-indexer-local
-      SCYLLA_URL: scylla:9042
-      SCYLLA_USER: cassandra
-      SCYLLA_PASSWORD: cassandra
-      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
-      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
-      AWS_DEFAULT_REGION: ${AWS_DEFAULT_REGION}
-      OTEL_EXPORTER_JAEGER_AGENT_HOST: jaeger
-      OTEL_EXPORTER_JAEGER_AGENT_PORT: 6831
     command: [ "mainnet", "from-interruption" ]
     depends_on:
       - scylla
@@ -56,15 +55,8 @@ services:
       args:
         features: tracing-instrumentation
     environment:
+      <<: *common-variables
       INDEXER_ID: tx-indexer-local
-      SCYLLA_URL: scylla:9042
-      SCYLLA_USER: cassandra
-      SCYLLA_PASSWORD: cassandra
-      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
-      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
-      AWS_DEFAULT_REGION: ${AWS_DEFAULT_REGION}
-      OTEL_EXPORTER_JAEGER_AGENT_HOST: jaeger
-      OTEL_EXPORTER_JAEGER_AGENT_PORT: 6831
     command: [ "mainnet", "from-interruption" ]
     depends_on:
       - scylla

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,89 @@
+version: '3'
+
+services:
+  rpc-server:
+    build:
+      context: .
+      dockerfile: rpc-server/Dockerfile
+      args:
+        features: "tracing-instrumentation,shadow_data_consistency"
+    environment:
+      SCYLLA_URL: scylla:9042
+      SCYLLA_USER: ${SCYLLA_USER}
+      SCYLLA_PASSWORD: ${SCYLLA_PASSWORD}
+      AWS_BUCKET_NAME: near-lake-data-mainnet
+      NEAR_RPC_URL: https://archival-rpc.mainnet.near.org
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
+      AWS_DEFAULT_REGION: ${AWS_DEFAULT_REGION}
+      OTEL_EXPORTER_JAEGER_AGENT_HOST: jaeger
+      OTEL_EXPORTER_JAEGER_AGENT_PORT: 6831
+      SERVER_PORT: 8080
+      RUST_LOG: "read_rpc_server=debug,is_data_consistency=debug"
+    restart: on-failure
+    ports:
+      - 8080:8080
+    depends_on:
+      - scylla
+      - jaeger
+
+  state-indexer:
+    build:
+      context: .
+      dockerfile: state-indexer/Dockerfile
+      args:
+        features: tracing-instrumentation
+    environment:
+      INDEXER_ID: state-indexer-local
+      SCYLLA_URL: scylla:9042
+      SCYLLA_USER: cassandra
+      SCYLLA_PASSWORD: cassandra
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
+      AWS_DEFAULT_REGION: ${AWS_DEFAULT_REGION}
+      OTEL_EXPORTER_JAEGER_AGENT_HOST: jaeger
+      OTEL_EXPORTER_JAEGER_AGENT_PORT: 6831
+    command: [ "mainnet", "from-interruption" ]
+    depends_on:
+      - scylla
+      - jaeger
+    restart: on-failure
+
+  tx-indexer:
+    build:
+      context: .
+      dockerfile: tx-indexer/Dockerfile
+      args:
+        features: tracing-instrumentation
+    environment:
+      INDEXER_ID: tx-indexer-local
+      SCYLLA_URL: scylla:9042
+      SCYLLA_USER: cassandra
+      SCYLLA_PASSWORD: cassandra
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
+      AWS_DEFAULT_REGION: ${AWS_DEFAULT_REGION}
+      OTEL_EXPORTER_JAEGER_AGENT_HOST: jaeger
+      OTEL_EXPORTER_JAEGER_AGENT_PORT: 6831
+    command: [ "mainnet", "from-interruption" ]
+    depends_on:
+      - scylla
+      - jaeger
+    restart: on-failure
+
+  jaeger:
+    image: jaegertracing/all-in-one:1.37
+    ports:
+      - 5775:5775/udp
+      - 6831:6831/udp
+      - 6832:6832/udp
+      - 5778:5778
+      - 16686:16686
+      - 14268:14268
+      - 9411:9411
+
+  scylla:
+    image: scylladb/scylla
+    expose:
+      - 9042:9042
+    command: [ "--smp", "1" ]

--- a/tx-indexer/Cargo.toml
+++ b/tx-indexer/Cargo.toml
@@ -23,17 +23,31 @@ prometheus = "0.13.1"
 scylla = "0.8.1"
 serde = { version = "1.0.145", features = ["derive"] }
 serde_json = "1.0.85"
-tokio = { version = "1.19.2", features = ["sync", "time", "macros", "rt-multi-thread"] }
+tokio = { version = "1.19.2", features = [
+    "sync",
+    "time",
+    "macros",
+    "rt-multi-thread",
+] }
 tokio-stream = { version = "0.1.12" }
 tracing = "0.1.34"
-tracing-subscriber = { version = "0.3.15", features = ["fmt", "env-filter", "std", "json"] }
+tracing-subscriber = { version = "0.3.15", features = [
+    "fmt",
+    "env-filter",
+    "std",
+    "json",
+] }
 opentelemetry = { version = "0.17", features = ["rt-tokio-current-thread"] }
-opentelemetry-jaeger = { version = "0.16", features = ["rt-tokio-current-thread"] }
+opentelemetry-jaeger = { version = "0.16", features = [
+    "rt-tokio-current-thread",
+    "collector_client",
+    "isahc_collector_client",
+] }
 tracing-opentelemetry = { version = "0.17" }
 tracing-stackdriver = "0.7.2" # GCP logs
 
-database = { path = "../database"}
-readnode-primitives = { path = "../readnode-primitives"}
+database = { path = "../database" }
+readnode-primitives = { path = "../readnode-primitives" }
 
 near-indexer-primitives = "0.17.0"
 near-jsonrpc-client = { git = "https://github.com/khorolets/near-jsonrpc-client-rs", rev = "0b6ad111307202a37028ef300a75a41f2a7947c3" }

--- a/tx-indexer/Dockerfile
+++ b/tx-indexer/Dockerfile
@@ -16,6 +16,6 @@ COPY tx-indexer/src ./tx-indexer/src
 RUN cargo build --release --features "$features"
 
 FROM ubuntu:20.04
-RUN apt update && apt install -yy openssl ca-certificates
+RUN apt update && apt install -yy openssl ca-certificates libcurl4
 COPY --from=builder /tmp/target/release/tx-indexer .
 ENTRYPOINT ["./tx-indexer"]

--- a/tx-indexer/src/config.rs
+++ b/tx-indexer/src/config.rs
@@ -175,7 +175,7 @@ pub fn init_tracing() -> anyhow::Result<()> {
         .with_service_name("tx_indexer")
         .with_max_packet_size(9_216)
         .with_auto_split_batch(true)
-        .install_simple()?;
+        .install_batch(opentelemetry::runtime::TokioCurrentThread)?;
     let telemetry = tracing_opentelemetry::layer().with_tracer(tracer);
 
     let subscriber = tracing_subscriber::Registry::default()


### PR DESCRIPTION
This is an initial version of the `docker-compose.yml` for running the project locally.

I've left a "TODO" section about the Docker compose in the README with the things I want us to improve in the future:

- Setup all the services to use volumes for the codebase and use `cargo watch` to recompile the code on the fly
- Come up with a way of changing the configuration for the indexers in a convenient way
- Robust documentation for the docker-compose setup