### PR TITLE
refactor(rpc-server): Refactor shadow_compare_results function to return ShadowDataConsistencyError

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3096,6 +3096,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "near-jsonrpc-client"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "118f44c02ad211db805c1370ad3ff26576af6ff554093c9fece1b835d29d233a"
+dependencies = [
+ "borsh 0.10.3",
+ "lazy_static",
+ "log",
+ "near-chain-configs",
+ "near-crypto",
+ "near-jsonrpc-primitives",
+ "near-primitives",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "near-jsonrpc-primitives"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4227,7 +4246,7 @@ dependencies = [
  "near-chain-configs",
  "near-crypto",
  "near-indexer-primitives",
- "near-jsonrpc-client",
+ "near-jsonrpc-client 0.6.0",
  "near-jsonrpc-primitives",
  "near-primitives",
  "near-primitives-core",
@@ -4242,6 +4261,7 @@ dependencies = [
  "scylla",
  "serde",
  "serde_json",
+ "thiserror",
  "tokio",
  "tracing",
  "tracing-actix-web",
@@ -5010,7 +5030,7 @@ dependencies = [
  "itertools",
  "lazy_static",
  "near-indexer-primitives",
- "near-jsonrpc-client",
+ "near-jsonrpc-client 0.0.0",
  "near-lake-framework",
  "near-primitives-core",
  "num-bigint",
@@ -5648,7 +5668,7 @@ dependencies = [
  "humantime",
  "lazy_static",
  "near-indexer-primitives",
- "near-jsonrpc-client",
+ "near-jsonrpc-client 0.0.0",
  "near-lake-framework",
  "num-bigint",
  "num-traits",

--- a/rpc-server/Cargo.toml
+++ b/rpc-server/Cargo.toml
@@ -19,7 +19,7 @@ erased-serde = "0.3.23"
 futures = "0.3.24"
 hex = "0.4.3"
 http = "0.2.8"
-jsonrpc-v2 = { git  = "https://github.com/kobayurii/jsonrpc-v2", rev = "95e7b1d2567ae841163af212a3f25abb6862becb" }
+jsonrpc-v2 = { git = "https://github.com/kobayurii/jsonrpc-v2", rev = "95e7b1d2567ae841163af212a3f25abb6862becb" }
 lazy_static = "1.4.0"
 lru = "0.8.1"
 num-bigint = "0.3"
@@ -28,21 +28,29 @@ prometheus = "0.13.1"
 scylla = "0.8.1"
 serde = { version = "1.0.145", features = ["derive"] }
 serde_json = "1.0.85"
+thiserror = "1.0.40"
 tokio = { version = "1.28.2", features = ["full", "tracing"] }
 tracing = { version = "0.1.36", features = ["std"] }
 tracing-actix-web = "0.6.1"
-tracing-subscriber = { version = "0.3.15", features = ["fmt", "env-filter", "std", "json"] }
+tracing-subscriber = { version = "0.3.15", features = [
+    "fmt",
+    "env-filter",
+    "std",
+    "json",
+] }
 opentelemetry = { version = "0.17", features = ["rt-tokio-current-thread"] }
-opentelemetry-jaeger = { version = "0.16", features = ["rt-tokio-current-thread"] }
+opentelemetry-jaeger = { version = "0.16", features = [
+    "rt-tokio-current-thread",
+] }
 tracing-opentelemetry = { version = "0.17" }
 tracing-stackdriver = "0.7.2" # GCP logs
 
-database = { path = "../database"}
-readnode-primitives = { path = "../readnode-primitives"}
+database = { path = "../database" }
+readnode-primitives = { path = "../readnode-primitives" }
 
 near-chain-configs = "0.17.0"
 near-crypto = "0.17.0"
-near-jsonrpc-client = { git = "https://github.com/khorolets/near-jsonrpc-client-rs", rev = "0b6ad111307202a37028ef300a75a41f2a7947c3" }
+near-jsonrpc-client = "0.6.0"
 near-jsonrpc-primitives = "0.17.0"
 near-indexer-primitives = "0.17.0"
 near-primitives = "0.17.0"
@@ -55,5 +63,5 @@ default = ["submit_tx_methods"]
 submit_tx_methods = []
 tracing-instrumentation = []
 scylla_db_tracing = ["database/scylla_db_tracing"]
-shadow_data_consistency = ["dep:assert-json-diff",]
+shadow_data_consistency = ["dep:assert-json-diff"]
 account_access_keys = []


### PR DESCRIPTION
Essentially, this PR does what the title says.

The goal was to refactor the `shadow_compare_results` function from the feature `shadow_data_consistency`. We wanted to change the way the function can be used as a result of this refactor.

Initially, the function `shadow_compare_results` were emitting log-messages. However, we find it inconvenient and wanted to be able to use this function a little bit differently.

That's why this PR introduces an error structure `ShadowDataConsistencyError` (hidden behind the same feature-flag)

```
/// Represents the error that can occur during the shadow data consistency check.
#[cfg(feature = "shadow_data_consistency")]
#[derive(thiserror::Error, Debug)]
pub enum ShadowDataConsistencyError {
    #[error("Failed to parse ReadRPC response: {0}")]
    ReadRpcResponseParseError(serde_json::Error),
    #[error("Failed to parse NEAR JSON RPC response: {0}")]
    NearRpcResponseParseError(serde_json::Error),
    #[error("NEAR RPC call error: {0}")]
    NearRpcCallError(String),
    #[error("Results don't match: {0}")]
    ResultsDontMatch(String),
}
```

This allows us to refactor the RPC methods. We are able to operate the comparison results and decide whether we need to proxy the call in case of an error on the Read RPC side, or we need to simply respond with the error crafted by Read RPC itself.

**Please note,** we are actively using the feature `shadow_data_consistency` to identify misalignments and bugs on the Read RPC side regarding the data consistency. After the bug-hunting cycle, this feature will not be used.