### PR TITLE
refactor(read-rpc): Shadow compare results to handle ok and err respectively

### DIFF
--- a/rpc-server/src/errors.rs
+++ b/rpc-server/src/errors.rs
@@ -2,7 +2,8 @@ use near_jsonrpc_client::errors::{JsonRpcError, JsonRpcServerError};
 use std::ops::{Deref, DerefMut};
 type BoxedSerialize = Box<dyn erased_serde::Serialize + Send>;
 
-#[derive(Debug)]
+#[derive(Debug, serde::Serialize)]
+#[serde(transparent)]
 pub struct RPCError(pub(crate) near_jsonrpc_primitives::errors::RpcError);
 
 impl RPCError {

--- a/rpc-server/src/modules/queries/methods.rs
+++ b/rpc-server/src/modules/queries/methods.rs
@@ -86,8 +86,13 @@ pub async fn query(
             )
         }
 
+        let read_rpc_response_json = match &result {
+            Ok(res) => serde_json::to_value(res),
+            Err(err) => serde_json::to_value(err),
+        };
+
         let comparison_result =
-            shadow_compare_results(serde_json::to_value(&result), near_rpc_client, params).await;
+            shadow_compare_results(read_rpc_response_json, near_rpc_client, params).await;
 
         match comparison_result {
             Ok(_) => {


### PR DESCRIPTION
In this PR we're improving the `shadow_compare_results` to respect both `Ok` and `Err` to compare them properly.

**Note!** This is still working around the `query` method only, we're going to refactor other methods next.