### PR TITLE
refactor: Improve local receipt exclusion for tx-related methods. Revert the logic for chunks.

### DIFF
--- a/readnode-primitives/src/lib.rs
+++ b/readnode-primitives/src/lib.rs
@@ -82,7 +82,7 @@ impl TransactionDetails {
         }
     }
 
-    pub fn to_final_execution_outcome_with_receipt(
+    pub fn to_final_execution_outcome_with_receipts(
         &self,
     ) -> views::FinalExecutionOutcomeWithReceiptView {
         views::FinalExecutionOutcomeWithReceiptView {
@@ -90,7 +90,15 @@ impl TransactionDetails {
             receipts: self
                 .receipts
                 .iter()
-                .filter(|receipt| receipt.predecessor_id != receipt.receiver_id)
+                // We need to filter out the local receipts (which is the receipt transaction was converted into)
+                // because NEAR JSON RPC doesn't return them. We need to filter them out because they are not
+                // expected to be present in the final response from the JSON RPC.
+                .filter(|receipt| receipt.receipt_id != *self
+                    .transaction_outcome
+                    .outcome
+                    .receipt_ids
+                    .first()
+                    .expect("Transaction ExecutionOutcome must have exactly one receipt id in `receipt_ids`"))
                 .cloned()
                 .collect(),
         }

--- a/rpc-server/src/modules/blocks/utils.rs
+++ b/rpc-server/src/modules/blocks/utils.rs
@@ -94,11 +94,7 @@ pub async fn fetch_chunk_from_s3(
                     .into_iter()
                     .map(|indexer_transaction| indexer_transaction.transaction)
                     .collect(),
-                receipts: chunk
-                    .receipts
-                    .into_iter()
-                    .filter(|receipt| receipt.predecessor_id != receipt.receiver_id)
-                    .collect(),
+                receipts: chunk.receipts,
             }),
             None => Err(
                 near_jsonrpc_primitives::types::chunks::RpcChunkError::InternalError {

--- a/rpc-server/src/modules/transactions/methods.rs
+++ b/rpc-server/src/modules/transactions/methods.rs
@@ -203,7 +203,7 @@ async fn tx_status_common(
         Ok(
             near_jsonrpc_primitives::types::transactions::RpcTransactionResponse {
                 final_execution_outcome: FinalExecutionOutcomeWithReceipt(
-                    transaction_details.to_final_execution_outcome_with_receipt(),
+                    transaction_details.to_final_execution_outcome_with_receipts(),
                 ),
             },
         )


### PR DESCRIPTION
We had to filter out local receipts (ref: https://stackoverflow.com/questions/67678135/what-is-local-receipt-in-near-protocol) from the Read RPC responses. There are a couple of reasons for that:
1. `nearcore` doesn't store local receipts in the first place. Thus, NEAR JSON RPC doesn't include them in the responses. You won't get it even asking for them directly via the `EXPERIMENTAL_receipt` method. *RR does, however*.
2. NEAR Indexer Framework, on the other hand, exposes such receipts, which are stored in Lake S3. Since we're using S3 as a data source, Read RPC includes those receipts in the response, but we have to be consistent with the original NEAR JSON RPC.

Having the above statements, I've asked @kobayurii to filter out the local receipts from the responses. However, I misled him by saying `predecessor_id == receiver_id` means the receipt is local (my misunderstanding of the concept).

I raised the question about my confusion to the `nearcore` team and got the clarification that `predecessor_id` is not a `signer_id`. Long story short, a receipt can be local only if:
- Transaction `signer_id` equals the transaction `receiver_id`
- The receipt is a result of the conversion of the transaction into a receipt

This PR reverts the changes done by @kobayurii in #85 regarding the exclusion of the receipt for the `chunk` method (completely for now) and fixes the logic for `tx`-related methods.

~~Meanwhile, I continue to investigate whether the local receipts in the `chunk` is an issue and how to resolve it correctly.~~

Update: I've found a solution to exclude local receipts from the `chunk`. However, I suspect it won't help with local delayed receipts. Let's monitor a bit to identify that problem separately.