### PR TITLE
fix: Local receipt handling (missed important indicator of the local receipt)

### DIFF
--- a/readnode-primitives/src/lib.rs
+++ b/readnode-primitives/src/lib.rs
@@ -90,15 +90,22 @@ impl TransactionDetails {
             receipts: self
                 .receipts
                 .iter()
-                // We need to filter out the local receipts (which is the receipt transaction was converted into)
+                // We need to filter out the local receipts
+                // (which is the receipt transaction was converted into if transaction's signer and receiver are the same)
                 // because NEAR JSON RPC doesn't return them. We need to filter them out because they are not
                 // expected to be present in the final response from the JSON RPC.
-                .filter(|receipt| receipt.receipt_id != *self
+                .filter(|receipt|
+                    if self.transaction.signer_id == self.transaction.receiver_id {
+                        receipt.receipt_id != *self
                     .transaction_outcome
                     .outcome
                     .receipt_ids
                     .first()
-                    .expect("Transaction ExecutionOutcome must have exactly one receipt id in `receipt_ids`"))
+                    .expect("Transaction ExecutionOutcome must have exactly one receipt id in `receipt_ids`")
+                    } else {
+                        true
+                    }
+                )
                 .cloned()
                 .collect(),
         }

--- a/rpc-server/src/modules/blocks/utils.rs
+++ b/rpc-server/src/modules/blocks/utils.rs
@@ -91,6 +91,9 @@ pub async fn fetch_chunk_from_s3(
                 let local_receipt_ids: Vec<near_indexer_primitives::CryptoHash> = chunk
                     .transactions
                     .iter()
+                    .filter(|indexer_tx| {
+                        indexer_tx.transaction.signer_id == indexer_tx.transaction.receiver_id
+                    })
                     .map(|indexer_tx| {
                         *indexer_tx
                             .outcome


### PR DESCRIPTION
In my previous PR #88, I missed the crucial indicator of the local receipts (the sender is 
 the receiver, to be precise). This PR fixes my mistake.