### PR TITLE
DPLT-1045: Remove optimistic queries from error counters

### DIFF
--- a/rpc-server/src/metrics.rs
+++ b/rpc-server/src/metrics.rs
@@ -23,6 +23,11 @@ lazy_static! {
         "Total number of the request where finality was set to optimistic"
     )
     .unwrap();
+    pub(crate) static ref SYNC_CHECKPOINT_REQUESTS_TOTAL: IntCounter = try_create_int_counter(
+        "total_sync_checkpoint_requests",
+        "Total number of the request where set sync_checkpoint"
+    )
+    .unwrap();
     pub(crate) static ref FINAL_BLOCK_HEIGHT: IntGauge = try_create_int_gauge(
         "final_block_height",
         "The final block height from the perspective of the READ RPC server"

--- a/rpc-server/src/modules/network/methods.rs
+++ b/rpc-server/src/modules/network/methods.rs
@@ -52,13 +52,6 @@ pub async fn protocol_config(
     data: Data<ServerContext>,
     Params(params): Params<near_jsonrpc_primitives::types::config::RpcProtocolConfigRequest>,
 ) -> Result<near_jsonrpc_primitives::types::config::RpcProtocolConfigResponse, RPCError> {
-    // Increase the OPTIMISTIC_REQUESTS_TOTAL metric if the request has optimistic finality.
-    if let near_primitives::types::BlockReference::Finality(finality) = &params.block_reference {
-        // Finality::None stands for optimistic finality.
-        if finality == &near_primitives::types::Finality::None {
-            crate::metrics::OPTIMISTIC_REQUESTS_TOTAL.inc();
-        }
-    }
     let config_view = proxy_rpc_call(&data.near_rpc_client, params).await?;
     Ok(near_jsonrpc_primitives::types::config::RpcProtocolConfigResponse { config_view })
 }

--- a/rpc-server/src/modules/queries/methods.rs
+++ b/rpc-server/src/modules/queries/methods.rs
@@ -7,26 +7,55 @@ use crate::modules::queries::utils::fetch_list_access_keys_from_scylla_db;
 use crate::modules::queries::utils::{
     fetch_access_key_from_scylla_db, fetch_state_from_scylla_db, run_contract,
 };
+use crate::utils::proxy_rpc_call;
 #[cfg(feature = "shadow_data_consistency")]
 use crate::utils::shadow_compare_results;
 use borsh::BorshSerialize;
 use jsonrpc_v2::{Data, Params};
 
+/// `query` rpc method implementation
+/// calls proxy_rpc_call to get `query` from near-rpc if request parameters not supported by read-rpc
+/// as example: BlockReference for SyncCheckpoint is not supported by read-rpc
+/// another way to get `query` from read-rpc using `query_call`
 #[allow(unused_mut)]
 #[cfg_attr(feature = "tracing-instrumentation", tracing::instrument(skip(data)))]
 pub async fn query(
     data: Data<ServerContext>,
     Params(mut params): Params<near_jsonrpc_primitives::types::query::RpcQueryRequest>,
 ) -> Result<near_jsonrpc_primitives::types::query::RpcQueryResponse, RPCError> {
-    tracing::debug!("`query` call. Params: {:?}", params,);
-
-    // Increase the OPTIMISTIC_REQUESTS_TOTAL metric if the request has optimistic finality.
-    if let near_primitives::types::BlockReference::Finality(finality) = &params.block_reference {
-        // Finality::None stands for optimistic finality.
-        if finality == &near_primitives::types::Finality::None {
-            crate::metrics::OPTIMISTIC_REQUESTS_TOTAL.inc();
+    match &params.block_reference {
+        near_primitives::types::BlockReference::SyncCheckpoint(_) => {
+            // Increase the SYNC_CHECKPOINT_REQUESTS_TOTAL metric if the request has
+            // genesis sync_checkpoint or earliest_available sync_checkpoint
+            // and proxy to near-rpc
+            crate::metrics::SYNC_CHECKPOINT_REQUESTS_TOTAL.inc();
+            Ok(proxy_rpc_call(&data.near_rpc_client, params).await?)
+        }
+        near_primitives::types::BlockReference::Finality(finality) => {
+            if finality != &near_primitives::types::Finality::Final {
+                // Increase the OPTIMISTIC_REQUESTS_TOTAL metric if the request has
+                // optimistic finality or doom_slug finality
+                // and proxy to near-rpc
+                crate::metrics::OPTIMISTIC_REQUESTS_TOTAL.inc();
+                Ok(proxy_rpc_call(&data.near_rpc_client, params).await?)
+            } else {
+                query_call(data, Params(params)).await
+            }
+        }
+        near_primitives::types::BlockReference::BlockId(_) => {
+            query_call(data, Params(params)).await
         }
     }
+}
+
+/// fetch query result from read-rpc
+#[allow(unused_mut)]
+#[cfg_attr(feature = "tracing-instrumentation", tracing::instrument(skip(data)))]
+async fn query_call(
+    data: Data<ServerContext>,
+    Params(mut params): Params<near_jsonrpc_primitives::types::query::RpcQueryRequest>,
+) -> Result<near_jsonrpc_primitives::types::query::RpcQueryResponse, RPCError> {
+    tracing::debug!("`query` call. Params: {:?}", params,);
 
     let block = fetch_block_from_cache_or_get(&data, params.block_reference.clone())
         .await


### PR DESCRIPTION
There is an assumption that optimistic queries we don’t support in the Read RPC (yet) cause most errors. 
This PR remove optimistic requests from the error counters.
Added SYNC_CHECKPOINT_REQUESTS_TOTAL counter.