### PR TITLE
Improvement(rpc-server): Add additional logs for `shadow_data_consistency`

### DIFF
--- a/rpc-server/src/modules/blocks/methods.rs
+++ b/rpc-server/src/modules/blocks/methods.rs
@@ -62,12 +62,17 @@ pub async fn chunk(
     {
         let near_rpc_client = data.near_rpc_client.clone();
         let error_meta = format!("CHUNK: {:?}", params);
-        let read_rpc_response_json = match &result {
-            Ok(res) => serde_json::to_value(&res.chunk_view),
-            Err(err) => serde_json::to_value(err),
+        let (read_rpc_response_json, response_success) = match &result {
+            Ok(res) => (serde_json::to_value(&res.chunk_view), true),
+            Err(err) => (serde_json::to_value(err), false),
         };
-        let comparison_result =
-            shadow_compare_results(read_rpc_response_json, near_rpc_client, params).await;
+        let comparison_result = shadow_compare_results(
+            read_rpc_response_json,
+            near_rpc_client,
+            params,
+            response_success,
+        )
+        .await;
 
         match comparison_result {
             Ok(_) => {
@@ -172,7 +177,7 @@ async fn block_call(
     {
         let near_rpc_client = data.near_rpc_client.clone();
         let error_meta = format!("BLOCK: {:?}", params);
-        let read_rpc_response_json = match &result {
+        let (read_rpc_response_json, response_success) = match &result {
             Ok(res) => {
                 if let near_primitives::types::BlockReference::Finality(_) = params.block_reference
                 {
@@ -180,12 +185,17 @@ async fn block_call(
                         near_primitives::types::BlockId::Height(res.block_view.header.height),
                     )
                 };
-                serde_json::to_value(&res.block_view)
+                (serde_json::to_value(&res.block_view), true)
             }
-            Err(err) => serde_json::to_value(err),
+            Err(err) => (serde_json::to_value(err), false),
         };
-        let comparison_result =
-            shadow_compare_results(read_rpc_response_json, near_rpc_client, params).await;
+        let comparison_result = shadow_compare_results(
+            read_rpc_response_json,
+            near_rpc_client,
+            params,
+            response_success,
+        )
+        .await;
 
         match comparison_result {
             Ok(_) => {
@@ -225,12 +235,17 @@ async fn changes_in_block_call(
             )
         }
         let error_meta = format!("CHANGES_IN_BLOCK: {:?}", params);
-        let read_rpc_response_json = match &result {
-            Ok(res) => serde_json::to_value(res),
-            Err(err) => serde_json::to_value(err),
+        let (read_rpc_response_json, response_success) = match &result {
+            Ok(res) => (serde_json::to_value(res), true),
+            Err(err) => (serde_json::to_value(err), false),
         };
-        let comparison_result =
-            shadow_compare_results(read_rpc_response_json, near_rpc_client, params).await;
+        let comparison_result = shadow_compare_results(
+            read_rpc_response_json,
+            near_rpc_client,
+            params,
+            response_success,
+        )
+        .await;
 
         match comparison_result {
             Ok(_) => {
@@ -270,12 +285,17 @@ async fn changes_in_block_by_type_call(
             )
         }
         let error_meta = format!("CHANGES_IN_BLOCK_BY_TYPE: {:?}", params);
-        let read_rpc_response_json = match &result {
-            Ok(res) => serde_json::to_value(res),
-            Err(err) => serde_json::to_value(err),
+        let (read_rpc_response_json, response_success) = match &result {
+            Ok(res) => (serde_json::to_value(res), true),
+            Err(err) => (serde_json::to_value(err), false),
         };
-        let comparison_result =
-            shadow_compare_results(read_rpc_response_json, near_rpc_client, params).await;
+        let comparison_result = shadow_compare_results(
+            read_rpc_response_json,
+            near_rpc_client,
+            params,
+            response_success,
+        )
+        .await;
 
         match comparison_result {
             Ok(_) => {

--- a/rpc-server/src/modules/blocks/methods.rs
+++ b/rpc-server/src/modules/blocks/methods.rs
@@ -62,7 +62,7 @@ pub async fn chunk(
     {
         let near_rpc_client = data.near_rpc_client.clone();
         let error_meta = format!("CHUNK: {:?}", params);
-        let (read_rpc_response_json, response_success) = match &result {
+        let (read_rpc_response_json, is_response_ok) = match &result {
             Ok(res) => (serde_json::to_value(&res.chunk_view), true),
             Err(err) => (serde_json::to_value(err), false),
         };
@@ -70,7 +70,7 @@ pub async fn chunk(
             read_rpc_response_json,
             near_rpc_client,
             params,
-            response_success,
+            is_response_ok,
         )
         .await;
 
@@ -177,7 +177,7 @@ async fn block_call(
     {
         let near_rpc_client = data.near_rpc_client.clone();
         let error_meta = format!("BLOCK: {:?}", params);
-        let (read_rpc_response_json, response_success) = match &result {
+        let (read_rpc_response_json, is_response_ok) = match &result {
             Ok(res) => {
                 if let near_primitives::types::BlockReference::Finality(_) = params.block_reference
                 {
@@ -193,7 +193,7 @@ async fn block_call(
             read_rpc_response_json,
             near_rpc_client,
             params,
-            response_success,
+            is_response_ok,
         )
         .await;
 
@@ -235,7 +235,7 @@ async fn changes_in_block_call(
             )
         }
         let error_meta = format!("CHANGES_IN_BLOCK: {:?}", params);
-        let (read_rpc_response_json, response_success) = match &result {
+        let (read_rpc_response_json, is_response_ok) = match &result {
             Ok(res) => (serde_json::to_value(res), true),
             Err(err) => (serde_json::to_value(err), false),
         };
@@ -243,7 +243,7 @@ async fn changes_in_block_call(
             read_rpc_response_json,
             near_rpc_client,
             params,
-            response_success,
+            is_response_ok,
         )
         .await;
 
@@ -285,7 +285,7 @@ async fn changes_in_block_by_type_call(
             )
         }
         let error_meta = format!("CHANGES_IN_BLOCK_BY_TYPE: {:?}", params);
-        let (read_rpc_response_json, response_success) = match &result {
+        let (read_rpc_response_json, is_response_ok) = match &result {
             Ok(res) => (serde_json::to_value(res), true),
             Err(err) => (serde_json::to_value(err), false),
         };
@@ -293,7 +293,7 @@ async fn changes_in_block_by_type_call(
             read_rpc_response_json,
             near_rpc_client,
             params,
-            response_success,
+            is_response_ok,
         )
         .await;
 

--- a/rpc-server/src/modules/queries/methods.rs
+++ b/rpc-server/src/modules/queries/methods.rs
@@ -116,7 +116,7 @@ async fn query_call(
             )
         }
 
-        let (read_rpc_response_json, response_success) = match &result {
+        let (read_rpc_response_json, is_response_ok) = match &result {
             Ok(res) => (serde_json::to_value(res), true),
             Err(err) => (serde_json::to_value(err), false),
         };
@@ -125,7 +125,7 @@ async fn query_call(
             read_rpc_response_json,
             near_rpc_client,
             params,
-            response_success,
+            is_response_ok,
         )
         .await;
 

--- a/rpc-server/src/modules/queries/methods.rs
+++ b/rpc-server/src/modules/queries/methods.rs
@@ -116,13 +116,18 @@ async fn query_call(
             )
         }
 
-        let read_rpc_response_json = match &result {
-            Ok(res) => serde_json::to_value(res),
-            Err(err) => serde_json::to_value(err),
+        let (read_rpc_response_json, response_success) = match &result {
+            Ok(res) => (serde_json::to_value(res), true),
+            Err(err) => (serde_json::to_value(err), false),
         };
 
-        let comparison_result =
-            shadow_compare_results(read_rpc_response_json, near_rpc_client, params).await;
+        let comparison_result = shadow_compare_results(
+            read_rpc_response_json,
+            near_rpc_client,
+            params,
+            response_success,
+        )
+        .await;
 
         match comparison_result {
             Ok(_) => {

--- a/rpc-server/src/modules/receipts/methods.rs
+++ b/rpc-server/src/modules/receipts/methods.rs
@@ -20,7 +20,7 @@ pub async fn receipt(
     {
         let near_rpc_client = data.near_rpc_client.clone();
         let error_meta = format!("TX: {:?}", params);
-        let (read_rpc_response_json, response_success) = match &result {
+        let (read_rpc_response_json, is_response_ok) = match &result {
             Ok(res) => (serde_json::to_value(res), true),
             Err(err) => (serde_json::to_value(err), false),
         };
@@ -29,7 +29,7 @@ pub async fn receipt(
             read_rpc_response_json,
             near_rpc_client,
             params,
-            response_success,
+            is_response_ok,
         )
         .await;
 

--- a/rpc-server/src/modules/receipts/methods.rs
+++ b/rpc-server/src/modules/receipts/methods.rs
@@ -20,14 +20,18 @@ pub async fn receipt(
     {
         let near_rpc_client = data.near_rpc_client.clone();
         let error_meta = format!("TX: {:?}", params);
-
-        let read_rpc_response_json = match &result {
-            Ok(res) => serde_json::to_value(res),
-            Err(err) => serde_json::to_value(err),
+        let (read_rpc_response_json, response_success) = match &result {
+            Ok(res) => (serde_json::to_value(res), true),
+            Err(err) => (serde_json::to_value(err), false),
         };
 
-        let comparison_result =
-            shadow_compare_results(read_rpc_response_json, near_rpc_client, params).await;
+        let comparison_result = shadow_compare_results(
+            read_rpc_response_json,
+            near_rpc_client,
+            params,
+            response_success,
+        )
+        .await;
 
         match comparison_result {
             Ok(_) => {

--- a/rpc-server/src/modules/transactions/methods.rs
+++ b/rpc-server/src/modules/transactions/methods.rs
@@ -29,10 +29,9 @@ pub async fn tx(
     {
         let near_rpc_client = data.near_rpc_client.clone();
         let error_meta = format!("TX: {:?}", params);
-
-        let read_rpc_response_json = match &result {
-            Ok(res) => serde_json::to_value(res),
-            Err(err) => serde_json::to_value(err),
+        let (read_rpc_response_json, response_success) = match &result {
+            Ok(res) => (serde_json::to_value(res), true),
+            Err(err) => (serde_json::to_value(err), false),
         };
 
         let comparison_result = shadow_compare_results(
@@ -44,12 +43,13 @@ pub async fn tx(
             near_jsonrpc_client::methods::tx::RpcTransactionStatusRequest {
                 transaction_info: tx_status_request.transaction_info,
             },
+            response_success,
         )
         .await;
 
         match comparison_result {
             Ok(_) => {
-                tracing::info!(target: "shadow-data-consistency", "Shadow data check: CORRECT\n{}", error_meta);
+                tracing::info!(target: "shadow_data_consistency", "Shadow data check: CORRECT\n{}", error_meta);
             }
             Err(err) => {
                 tracing::warn!(target: "shadow_data_consistency", "Shadow data check: ERROR\n{}\n{:?}", error_meta, err);
@@ -79,9 +79,9 @@ pub async fn tx_status(
         let near_rpc_client = data.near_rpc_client.clone();
         let error_meta = format!("EXPERIMENTAL_TX_STATUS: {:?}", params);
 
-        let read_rpc_response_json = match &result {
-            Ok(res) => serde_json::to_value(res),
-            Err(err) => serde_json::to_value(err),
+        let (read_rpc_response_json, response_success) = match &result {
+            Ok(res) => (serde_json::to_value(res), true),
+            Err(err) => (serde_json::to_value(err), false),
         };
 
         let comparison_result = shadow_compare_results(
@@ -93,12 +93,13 @@ pub async fn tx_status(
             near_jsonrpc_client::methods::EXPERIMENTAL_tx_status::RpcTransactionStatusRequest {
                 transaction_info: tx_status_request.transaction_info,
             },
+            response_success,
         )
         .await;
 
         match comparison_result {
             Ok(_) => {
-                tracing::info!(target: "shadow-data-consistency", "Shadow data check: CORRECT\n{}", error_meta);
+                tracing::info!(target: "shadow_data_consistency", "Shadow data check: CORRECT\n{}", error_meta);
             }
             Err(err) => {
                 tracing::warn!(target: "shadow_data_consistency", "Shadow data check: ERROR\n{}\n{:?}", error_meta, err);

--- a/rpc-server/src/modules/transactions/methods.rs
+++ b/rpc-server/src/modules/transactions/methods.rs
@@ -29,7 +29,7 @@ pub async fn tx(
     {
         let near_rpc_client = data.near_rpc_client.clone();
         let error_meta = format!("TX: {:?}", params);
-        let (read_rpc_response_json, response_success) = match &result {
+        let (read_rpc_response_json, is_response_ok) = match &result {
             Ok(res) => (serde_json::to_value(res), true),
             Err(err) => (serde_json::to_value(err), false),
         };
@@ -43,7 +43,7 @@ pub async fn tx(
             near_jsonrpc_client::methods::tx::RpcTransactionStatusRequest {
                 transaction_info: tx_status_request.transaction_info,
             },
-            response_success,
+            is_response_ok,
         )
         .await;
 
@@ -79,7 +79,7 @@ pub async fn tx_status(
         let near_rpc_client = data.near_rpc_client.clone();
         let error_meta = format!("EXPERIMENTAL_TX_STATUS: {:?}", params);
 
-        let (read_rpc_response_json, response_success) = match &result {
+        let (read_rpc_response_json, is_response_ok) = match &result {
             Ok(res) => (serde_json::to_value(res), true),
             Err(err) => (serde_json::to_value(err), false),
         };
@@ -93,7 +93,7 @@ pub async fn tx_status(
             near_jsonrpc_client::methods::EXPERIMENTAL_tx_status::RpcTransactionStatusRequest {
                 transaction_info: tx_status_request.transaction_info,
             },
-            response_success,
+            is_response_ok,
         )
         .await;
 

--- a/rpc-server/src/utils.rs
+++ b/rpc-server/src/utils.rs
@@ -229,7 +229,7 @@ where
             )
         };
         return Err(ShadowDataConsistencyError::ResultsDontMatch(format!(
-            "{err}. Reason: {reason}. Description {description}"
+            "{err}.\n Reason: {reason}.\n Description: {description}"
         )));
     };
     Ok(())


### PR DESCRIPTION
https://github.com/near/read-rpc/issues/92
In this pr we improve shadow_data_consistency logs. 

Data may mismatch in 4 cases:
1. Both services(read_rpc and near_rpc) have a successful response 
if data mismatch we are logging into `shadow_data_consistency_successful_responses`both response objects for future investigation.
2. read_rpc - failure, near_rpc - successful
we are logging into `shadow_data_consistency_read_rpc_failure_response` just message about mismatch data without objects. In the future we should be investigate why we got error in the read_rpc.
3. read_rpc - successful , near_rpc - failure
we are logging into `shadow_data_consistency_near_failure_response` just message about mismatch data without objects. Expected that all error will be related with network issues.
4. Both services have a failure response
we are logging into `shadow_data_consistency_failure_responses` both response objects for future investigation.
Expected we will only have a difference in the error text.
