### PR TITLE
Improvement(rpc-server): Add retrying to fetch object from s3

### DIFF
--- a/rpc-server/src/config.rs
+++ b/rpc-server/src/config.rs
@@ -1,6 +1,8 @@
 use crate::modules::blocks::CacheBlock;
 use clap::Parser;
 
+pub const DEFAULT_RETRY_COUNT: u8 = 3;
+
 #[derive(Parser)]
 #[clap(author, version, about, long_about = None)]
 pub struct Opts {


### PR DESCRIPTION
In this pr we added retrying to fetch object from s3. We add new function fetch_object_from_s3_with_retry in which we try to get object from s3 three times if we have some problem with network, otherwise we return an error.