### PR TITLE
refactor(rpc-server): Split error metrics to disambiguate the error reasons

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3919,9 +3919,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.12"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
+checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "percent-encoding"
@@ -4348,6 +4348,7 @@ dependencies = [
  "num-traits",
  "opentelemetry 0.17.0",
  "opentelemetry-jaeger 0.16.0",
+ "paste",
  "prometheus",
  "readnode-primitives",
  "scylla",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       <<: *common-variables
       AWS_BUCKET_NAME: near-lake-data-mainnet
       SERVER_PORT: 8080
-      RUST_LOG: "read_rpc_server=debug,is_data_consistency=debug"
+      RUST_LOG: "read_rpc_server=debug,shadow_data_consistency=debug"
     restart: on-failure
     ports:
       - 8080:8080

--- a/rpc-server/Cargo.toml
+++ b/rpc-server/Cargo.toml
@@ -24,6 +24,7 @@ lazy_static = "1.4.0"
 lru = "0.8.1"
 num-bigint = "0.3"
 num-traits = "0.2.15"
+paste = "1.0.14"
 prometheus = "0.13.1"
 scylla = "0.9.0"
 serde = { version = "1.0.145", features = ["derive"] }

--- a/rpc-server/README.md
+++ b/rpc-server/README.md
@@ -91,8 +91,16 @@ All the metrics are defined in `src/metrics.rs` file. Two main categories of met
 
 The latter is split by the suffix code to differentiate the reason for the error when possible:
 
-- **0** - ReadRPC returns Success result and NEAR RPC returns Success result but results don't match
-- **1** - ReadRPC returns Success result and NEAR RPC returns Error result
-- **2** - ReadRPC returns Error result and NEAR RPC returns Success result
-- **3** - ReadRPC returns Error result and NEAR RPC returns Error result but results don't match
-- **4** - Could not perform consistency check because of the error (either network, or parsing the results)
+- **0** - ReadRPC returns a Success result, and NEAR RPC returns a Success result, but the results don't match
+- **1** - ReadRPC returns Success result, and NEAR RPC returns an Error result
+- **2** - ReadRPC returns an Error result, and NEAR RPC returns Success result
+- **3** - ReadRPC returns an Error result, and NEAR RPC returns an Error result, but the results don't match
+- **4** - Could not perform consistency check because of the error (either network or parsing the results)
+
+For example, method `block` will have these metrics:
+
+- `BLOCK_REQUESTS_TOTAL`
+- `BLOCK_ERROR_0`
+- `BLOCK_ERROR_1`
+- `BLOCK_ERROR_2`
+- `BLOCK_ERROR_3`

--- a/rpc-server/README.md
+++ b/rpc-server/README.md
@@ -104,3 +104,4 @@ For example, method `block` will have these metrics:
 - `BLOCK_ERROR_1`
 - `BLOCK_ERROR_2`
 - `BLOCK_ERROR_3`
+- `BLOCK_ERROR_4`

--- a/rpc-server/README.md
+++ b/rpc-server/README.md
@@ -79,3 +79,20 @@ This feature flag enables the shadow data consistency checks. With this feature 
 ### `account_access_keys` (default: `false`)
 
 We encountered a problem with the design of the table `account_access_keys` and overall design of the logic around it. We had to disable the table and proxy the calls of the `query.access_key_list` method to the real NEAR RPC. However, we still aren't ready to get rid of the code and that's why we hid it under the feature flag. We are planning to remove the code in the future and remove the feature flag.
+
+## Metrics (Prometheus)
+
+The read-rpc-server exposes Prometheus-compatible metrics at the `/metrics` endpoint.
+
+All the metrics are defined in `src/metrics.rs` file. Two main categories of metrics are:
+
+- Total number of requests for a specific method
+- Number of errors for a specific method (works only if the `shadow_data_consistency` feature flag is enabled)
+
+The latter is split by the suffix code to differentiate the reason for the error when possible:
+
+- **0** - ReadRPC returns Success result and NEAR RPC returns Success result but results don't match
+- **1** - ReadRPC returns Success result and NEAR RPC returns Error result
+- **2** - ReadRPC returns Error result and NEAR RPC returns Success result
+- **3** - ReadRPC returns Error result and NEAR RPC returns Error result but results don't match
+- **4** - Could not perform consistency check because of the error (either network, or parsing the results)

--- a/rpc-server/src/metrics.rs
+++ b/rpc-server/src/metrics.rs
@@ -34,7 +34,7 @@ lazy_static! {
     )
     .unwrap();
 
-    // requests total counters
+    // REQUESTS TOTAL COUNTERS
     // query requests counters
     pub(crate) static ref QUERY_VIEW_ACCOUNT_REQUESTS_TOTAL: IntCounter = try_create_int_counter(
         "query_view_account_requests_counter",
@@ -94,68 +94,388 @@ lazy_static! {
         "receipt_requests_counter",
         "Total number requests to the receipt endpoint"
     ).unwrap();
+}
 
-    // Error proxies counters
-    // query proxies counters
-    pub(crate) static ref QUERY_VIEW_ACCOUNT_PROXIES_TOTAL: IntCounter = try_create_int_counter(
-        "query_view_account_error_proxies_counter",
-        "Total number proxies requests to the query view account endpoint"
+// Error counters
+// QUERY counters
+lazy_static! {
+    // QUERY.view_account
+    pub(crate) static ref QUERY_VIEW_ACCOUNT_ERROR_0: IntCounter = try_create_int_counter(
+        "query_view_account_error_0",
+        "Query.view_account error 0: ReadRPC success, NEAR RPC success"
     )
     .unwrap();
-    pub(crate) static ref QUERY_VIEW_CODE_PROXIES_TOTAL: IntCounter = try_create_int_counter(
-        "query_view_code_error_proxies_counter",
-        "Total number proxies requests to the query view code endpoint"
+
+    pub(crate) static ref QUERY_VIEW_ACCOUNT_ERROR_1: IntCounter = try_create_int_counter(
+        "query_view_account_error_1",
+        "Query.view_account error 1: ReadRPC success, NEAR RPC error"
+    ).unwrap();
+
+    pub(crate) static ref QUERY_VIEW_ACCOUNT_ERROR_2: IntCounter = try_create_int_counter(
+        "query_view_account_error_2",
+        "Query.view_account error 2: ReadRPC error, NEAR RPC success"
+    ).unwrap();
+
+    pub(crate) static ref QUERY_VIEW_ACCOUNT_ERROR_3: IntCounter = try_create_int_counter(
+        "query_view_account_error_3",
+        "Query.view_account error 3: ReadRPC error, NEAR RPC error"
+    ).unwrap();
+
+    pub(crate) static ref QUERY_VIEW_ACCOUNT_ERROR_4: IntCounter = try_create_int_counter(
+        "query_view_account_error_4",
+        "Query.view_account error 4: Failed to compare. Network or parsing error"
+    ).unwrap();
+    // end QUERY.view_account
+}
+
+lazy_static! {
+    // QUERY.view_code
+    pub(crate) static ref QUERY_VIEW_CODE_ERROR_0: IntCounter = try_create_int_counter(
+        "query_view_code_error_0",
+        "Query.view_code error 0: ReadRPC success, NEAR RPC success"
     )
     .unwrap();
-    pub(crate) static ref QUERY_VIEW_ACCESS_KEY_PROXIES_TOTAL: IntCounter = try_create_int_counter(
-        "query_view_access_key_error_proxies_counter",
-        "Total number proxies requests to the query view access key endpoint"
-    ).unwrap();
-    pub(crate) static ref QUERY_VIEW_STATE_PROXIES_TOTAL: IntCounter = try_create_int_counter(
-        "query_view_state_error_proxies_counter",
-        "Total number proxies requests to the query view state endpoint"
-    ).unwrap();
-    pub(crate) static ref QUERY_FUNCTION_CALL_PROXIES_TOTAL: IntCounter = try_create_int_counter(
-        "query_function_call_error_proxies_counter",
-        "Total number proxies requests to the query function call endpoint"
-    ).unwrap();
-    pub(crate) static ref QUERY_VIEW_ACCESS_KEYS_LIST_PROXIES_TOTAL: IntCounter = try_create_int_counter(
-        "query_access_keys_list_error_proxies_counter",
-        "Total number proxies requests to the query access keys list endpoint"
+
+    pub(crate) static ref QUERY_VIEW_CODE_ERROR_1: IntCounter = try_create_int_counter(
+        "query_view_code_error_1",
+        "Query.view_code error 1: ReadRPC success, NEAR RPC error"
     ).unwrap();
 
-    // blocks proxies counters
-    pub(crate) static ref BLOCK_PROXIES_TOTAL: IntCounter = try_create_int_counter(
-        "block_error_proxies_counter",
-        "Total number proxies requests to the block endpoint"
-    ).unwrap();
-    pub(crate) static ref CHNGES_IN_BLOCK_BY_TYPE_PROXIES_TOTAL: IntCounter = try_create_int_counter(
-        "changes_in_block_by_type_error_proxies_counter",
-        "Total number proxies requests to the changes in block by type endpoint"
-    ).unwrap();
-    pub(crate) static ref CHNGES_IN_BLOCK_PROXIES_TOTAL: IntCounter = try_create_int_counter(
-        "changes_in_block_error_proxies_counter",
-        "Total number proxies requests to the changes in block endpoint"
-    ).unwrap();
-    pub(crate) static ref CHUNK_PROXIES_TOTAL: IntCounter = try_create_int_counter(
-        "chunk_error_proxies_counter",
-        "Total number proxies requests to the chunk endpoint"
+    pub(crate) static ref QUERY_VIEW_CODE_ERROR_2: IntCounter = try_create_int_counter(
+        "query_view_code_error_2",
+        "Query.view_code error 2: ReadRPC error, NEAR RPC success"
     ).unwrap();
 
-    // transactions proxies counters
-    pub(crate) static ref TX_PROXIES_TOTAL: IntCounter = try_create_int_counter(
-        "tx_error_proxies_counter",
-        "Total number proxies requests to the tx endpoint"
-    ).unwrap();
-    pub(crate) static ref TX_STATUS_PROXIES_TOTAL: IntCounter = try_create_int_counter(
-        "tx_status_error_proxies_counter",
-        "Total number proxies requests to the tx status endpoint"
-    ).unwrap();
-    pub(crate) static ref RECEIPT_PROXIES_TOTAL: IntCounter = try_create_int_counter(
-        "receipt_error_proxies_counter",
-        "Total number proxies requests to the receipt endpoint"
+    pub(crate) static ref QUERY_VIEW_CODE_ERROR_3: IntCounter = try_create_int_counter(
+        "query_view_code_error_3",
+        "Query.view_code error 3: ReadRPC error, NEAR RPC error"
     ).unwrap();
 
+    pub(crate) static ref QUERY_VIEW_CODE_ERROR_4: IntCounter = try_create_int_counter(
+        "query_view_code_error_4",
+        "Query.view_code error 4: Failed to compare. Network or parsing error"
+    ).unwrap();
+    // end QUERY.view_code
+}
+
+lazy_static! {
+    // QUERY.view_access_key
+    pub(crate) static ref QUERY_VIEW_ACCESS_KEY_ERROR_0: IntCounter = try_create_int_counter(
+        "query_view_access_key_error_0",
+        "Query.view_access_key error 0: ReadRPC success, NEAR RPC success"
+    ).unwrap();
+
+    pub(crate) static ref QUERY_VIEW_ACCESS_KEY_ERROR_1: IntCounter = try_create_int_counter(
+        "query_view_access_key_error_1",
+        "Query.view_access_key error 1: ReadRPC success, NEAR RPC error"
+    ).unwrap();
+
+    pub(crate) static ref QUERY_VIEW_ACCESS_KEY_ERROR_2: IntCounter = try_create_int_counter(
+        "query_view_access_key_error_2",
+        "Query.view_access_key error 2: ReadRPC error, NEAR RPC success"
+    ).unwrap();
+
+    pub(crate) static ref QUERY_VIEW_ACCESS_KEY_ERROR_3: IntCounter = try_create_int_counter(
+        "query_view_access_key_error_3",
+        "Query.view_access_key error 3: ReadRPC error, NEAR RPC error"
+    ).unwrap();
+
+    pub(crate) static ref QUERY_VIEW_ACCESS_KEY_ERROR_4: IntCounter = try_create_int_counter(
+        "query_view_access_key_error_4",
+        "Query.view_access_key error 4: Failed to compare. Network or parsing error"
+    ).unwrap();
+    // end QUERY.view_access_key
+}
+
+lazy_static! {
+    // QUERY.view_state
+    pub(crate) static ref QUERY_VIEW_STATE_ERROR_0: IntCounter = try_create_int_counter(
+        "query_view_state_error_0",
+        "Query.view_state error 0: ReadRPC success, NEAR RPC success"
+    ).unwrap();
+
+    pub(crate) static ref QUERY_VIEW_STATE_ERROR_1: IntCounter = try_create_int_counter(
+        "query_view_state_error_1",
+        "Query.view_state error 1: ReadRPC success, NEAR RPC error"
+    ).unwrap();
+
+    pub(crate) static ref QUERY_VIEW_STATE_ERROR_2: IntCounter = try_create_int_counter(
+        "query_view_state_error_2",
+        "Query.view_state error 2: ReadRPC error, NEAR RPC success"
+    ).unwrap();
+
+    pub(crate) static ref QUERY_VIEW_STATE_ERROR_3: IntCounter = try_create_int_counter(
+        "query_view_state_error_3",
+        "Query.view_state error 3: ReadRPC error, NEAR RPC error"
+    ).unwrap();
+
+    pub(crate) static ref QUERY_VIEW_STATE_ERROR_4: IntCounter = try_create_int_counter(
+        "query_view_state_error_4",
+        "Query.view_state error 4: Failed to compare. Network or parsing error"
+    ).unwrap();
+    // end QUERY.view_state
+}
+
+lazy_static! {
+    // QUERY.function_call
+    pub(crate) static ref QUERY_FUNCTION_CALL_ERROR_0: IntCounter = try_create_int_counter(
+        "query_function_call_error_0",
+        "Query.function_call error 0: ReadRPC success, NEAR RPC success"
+    ).unwrap();
+
+    pub(crate) static ref QUERY_FUNCTION_CALL_ERROR_1: IntCounter = try_create_int_counter(
+        "query_function_call_error_1",
+        "Query.function_call error 1: ReadRPC success, NEAR RPC error"
+    ).unwrap();
+
+    pub(crate) static ref QUERY_FUNCTION_CALL_ERROR_2: IntCounter = try_create_int_counter(
+        "query_function_call_error_2",
+        "Query.function_call error 2: ReadRPC error, NEAR RPC success"
+    ).unwrap();
+
+    pub(crate) static ref QUERY_FUNCTION_CALL_ERROR_3: IntCounter = try_create_int_counter(
+        "query_function_call_error_3",
+        "Query.function_call error 3: ReadRPC error, NEAR RPC error"
+    ).unwrap();
+
+    pub(crate) static ref QUERY_FUNCTION_CALL_ERROR_4: IntCounter = try_create_int_counter(
+        "query_function_call_error_4",
+        "Query.function_call error 4: Failed to compare. Network or parsing error"
+    ).unwrap();
+    // end QUERY.function_call
+}
+
+lazy_static! {
+    // QUERY.view_access_key_list
+    pub(crate) static ref QUERY_VIEW_ACCESS_KEY_LIST_ERROR_0: IntCounter = try_create_int_counter(
+        "query_view_access_key_list_error_0",
+        "Query.view_access_key_list error 0: ReadRPC success, NEAR RPC success"
+    ).unwrap();
+
+    pub(crate) static ref QUERY_VIEW_ACCESS_KEY_LIST_ERROR_1: IntCounter = try_create_int_counter(
+        "query_view_access_key_list_error_1",
+        "Query.view_access_key_list error 1: ReadRPC success, NEAR RPC error"
+    ).unwrap();
+
+    pub(crate) static ref QUERY_VIEW_ACCESS_KEY_LIST_ERROR_2: IntCounter = try_create_int_counter(
+        "query_view_access_key_list_error_2",
+        "Query.view_access_key_list error 2: ReadRPC error, NEAR RPC success"
+    ).unwrap();
+
+    pub(crate) static ref QUERY_VIEW_ACCESS_KEY_LIST_ERROR_3: IntCounter = try_create_int_counter(
+        "query_view_access_key_list_error_3",
+        "Query.view_access_key_list error 3: ReadRPC error, NEAR RPC error"
+    ).unwrap();
+
+    pub(crate) static ref QUERY_VIEW_ACCESS_KEY_LIST_ERROR_4: IntCounter = try_create_int_counter(
+        "query_view_access_key_list_error_4",
+        "Query.view_access_key_list error 4: Failed to compare. Network or parsing error"
+    ).unwrap();
+    // end QUERY.view_access_key_list
+}
+// end QUERY
+
+lazy_static! {
+    // BLOCK
+    pub(crate) static ref BLOCK_ERROR_0: IntCounter = try_create_int_counter(
+        "block_error_0",
+        "Block error 0: ReadRPC success, NEAR RPC success"
+    ).unwrap();
+
+    pub(crate) static ref BLOCK_ERROR_1: IntCounter = try_create_int_counter(
+        "block_error_1",
+        "Block error 1: ReadRPC success, NEAR RPC error"
+    ).unwrap();
+
+    pub(crate) static ref BLOCK_ERROR_2: IntCounter = try_create_int_counter(
+        "block_error_2",
+        "Block error 2: ReadRPC error, NEAR RPC success"
+    ).unwrap();
+
+    pub(crate) static ref BLOCK_ERROR_3: IntCounter = try_create_int_counter(
+        "block_error_3",
+        "Block error 3: ReadRPC error, NEAR RPC error"
+    ).unwrap();
+
+    pub(crate) static ref BLOCK_ERROR_4: IntCounter = try_create_int_counter(
+        "block_error_4",
+        "Block error 4: Failed to compare. Network or parsing error"
+    ).unwrap();
+    // end BLOCK
+}
+
+lazy_static! {
+    // CHUNK
+    pub(crate) static ref CHUNK_ERROR_0: IntCounter = try_create_int_counter(
+        "chunk_error_0",
+        "Chunk error 0: ReadRPC success, NEAR RPC success"
+    ).unwrap();
+
+    pub(crate) static ref CHUNK_ERROR_1: IntCounter = try_create_int_counter(
+        "chunk_error_1",
+        "Chunk error 1: ReadRPC success, NEAR RPC error"
+    ).unwrap();
+
+    pub(crate) static ref CHUNK_ERROR_2: IntCounter = try_create_int_counter(
+        "chunk_error_2",
+        "Chunk error 2: ReadRPC error, NEAR RPC success"
+    ).unwrap();
+
+    pub(crate) static ref CHUNK_ERROR_3: IntCounter = try_create_int_counter(
+        "chunk_error_3",
+        "Chunk error 3: ReadRPC error, NEAR RPC error"
+    ).unwrap();
+
+    pub(crate) static ref CHUNK_ERROR_4: IntCounter = try_create_int_counter(
+        "chunk_error_4",
+        "Chunk error 4: Failed to compare. Network or parsing error"
+    ).unwrap();
+    // end CHUNK
+}
+
+lazy_static! {
+    // TX
+    pub(crate) static ref TX_ERROR_0: IntCounter = try_create_int_counter(
+        "tx_error_0",
+        "Tx error 0: ReadRPC success, NEAR RPC success"
+    ).unwrap();
+
+    pub(crate) static ref TX_ERROR_1: IntCounter = try_create_int_counter(
+        "tx_error_1",
+        "Tx error 1: ReadRPC success, NEAR RPC error"
+    ).unwrap();
+
+    pub(crate) static ref TX_ERROR_2: IntCounter = try_create_int_counter(
+        "tx_error_2",
+        "Tx error 2: ReadRPC error, NEAR RPC success"
+    ).unwrap();
+
+    pub(crate) static ref TX_ERROR_3: IntCounter = try_create_int_counter(
+        "tx_error_3",
+        "Tx error 3: ReadRPC error, NEAR RPC error"
+    ).unwrap();
+
+    pub(crate) static ref TX_ERROR_4: IntCounter = try_create_int_counter(
+        "tx_error_4",
+        "Tx error 4: Failed to compare. Network or parsing error"
+    ).unwrap();
+    // end TX
+}
+
+lazy_static! {
+    // TX_STATUS
+    pub(crate) static ref EXPERIMENTAL_TX_STATUS_ERROR_0: IntCounter = try_create_int_counter(
+        "tx_status_error_0",
+        "TxStatus error 0: ReadRPC success, NEAR RPC success"
+    ).unwrap();
+
+    pub(crate) static ref EXPERIMENTAL_TX_STATUS_ERROR_1: IntCounter = try_create_int_counter(
+        "tx_status_error_1",
+        "TxStatus error 1: ReadRPC success, NEAR RPC error"
+    ).unwrap();
+
+    pub(crate) static ref EXPERIMENTAL_TX_STATUS_ERROR_2: IntCounter = try_create_int_counter(
+        "tx_status_error_2",
+        "TxStatus error 2: ReadRPC error, NEAR RPC success"
+    ).unwrap();
+
+    pub(crate) static ref EXPERIMENTAL_TX_STATUS_ERROR_3: IntCounter = try_create_int_counter(
+        "tx_status_error_3",
+        "TxStatus error 3: ReadRPC error, NEAR RPC error"
+    ).unwrap();
+
+    pub(crate) static ref EXPERIMENTAL_TX_STATUS_ERROR_4: IntCounter = try_create_int_counter(
+        "tx_status_error_4",
+        "TxStatus error 4: Failed to compare. Network or parsing error"
+    ).unwrap();
+    // end TX_STATUS
+}
+
+lazy_static! {
+    // CHANGES_IN_BLOCK_BY_TYPE
+    pub(crate) static ref CHANGES_IN_BLOCK_BY_TYPE_ERROR_0: IntCounter = try_create_int_counter(
+        "changes_in_block_by_type_error_0",
+        "ChangesInBlockByType error 0: ReadRPC success, NEAR RPC success"
+    ).unwrap();
+
+    pub(crate) static ref CHANGES_IN_BLOCK_BY_TYPE_ERROR_1: IntCounter = try_create_int_counter(
+        "changes_in_block_by_type_error_1",
+        "ChangesInBlockByType error 1: ReadRPC success, NEAR RPC error"
+    ).unwrap();
+
+    pub(crate) static ref CHANGES_IN_BLOCK_BY_TYPE_ERROR_2: IntCounter = try_create_int_counter(
+        "changes_in_block_by_type_error_2",
+        "ChangesInBlockByType error 2: ReadRPC error, NEAR RPC success"
+    ).unwrap();
+
+    pub(crate) static ref CHANGES_IN_BLOCK_BY_TYPE_ERROR_3: IntCounter = try_create_int_counter(
+        "changes_in_block_by_type_error_3",
+        "ChangesInBlockByType error 3: ReadRPC error, NEAR RPC error"
+    ).unwrap();
+
+    pub(crate) static ref CHANGES_IN_BLOCK_BY_TYPE_ERROR_4: IntCounter = try_create_int_counter(
+        "changes_in_block_by_type_error_4",
+        "ChangesInBlockByType error 4: Failed to compare. Network or parsing error"
+    ).unwrap();
+    // end CHANGES_IN_BLOCK_BY_TYPE
+}
+
+lazy_static! {
+    // CHANGES_IN_BLOCK
+    pub(crate) static ref CHANGES_IN_BLOCK_ERROR_0: IntCounter = try_create_int_counter(
+        "changes_in_block_error_0",
+        "ChangesInBlock error 0: ReadRPC success, NEAR RPC success"
+    ).unwrap();
+
+    pub(crate) static ref CHANGES_IN_BLOCK_ERROR_1: IntCounter = try_create_int_counter(
+        "changes_in_block_error_1",
+        "ChangesInBlock error 1: ReadRPC success, NEAR RPC error"
+    ).unwrap();
+
+    pub(crate) static ref CHANGES_IN_BLOCK_ERROR_2: IntCounter = try_create_int_counter(
+        "changes_in_block_error_2",
+        "ChangesInBlock error 2: ReadRPC error, NEAR RPC success"
+    ).unwrap();
+
+    pub(crate) static ref CHANGES_IN_BLOCK_ERROR_3: IntCounter = try_create_int_counter(
+        "changes_in_block_error_3",
+        "ChangesInBlock error 3: ReadRPC error, NEAR RPC error"
+    ).unwrap();
+
+    pub(crate) static ref CHANGES_IN_BLOCK_ERROR_4: IntCounter = try_create_int_counter(
+        "changes_in_block_error_4",
+        "ChangesInBlock error 4: Failed to compare. Network or parsing error"
+    ).unwrap();
+    // end CHANGES_IN_BLOCK
+}
+
+lazy_static! {
+    // RECEIPT
+    pub(crate) static ref RECEIPT_ERROR_0: IntCounter = try_create_int_counter(
+        "receipt_error_0",
+        "Receipt error 0: ReadRPC success, NEAR RPC success"
+    ).unwrap();
+
+    pub(crate) static ref RECEIPT_ERROR_1: IntCounter = try_create_int_counter(
+        "receipt_error_1",
+        "Receipt error 1: ReadRPC success, NEAR RPC error"
+    ).unwrap();
+
+    pub(crate) static ref RECEIPT_ERROR_2: IntCounter = try_create_int_counter(
+        "receipt_error_2",
+        "Receipt error 2: ReadRPC error, NEAR RPC success"
+    ).unwrap();
+
+    pub(crate) static ref RECEIPT_ERROR_3: IntCounter = try_create_int_counter(
+        "receipt_error_3",
+        "Receipt error 3: ReadRPC error, NEAR RPC error"
+    ).unwrap();
+
+    pub(crate) static ref RECEIPT_ERROR_4: IntCounter = try_create_int_counter(
+        "receipt_error_4",
+        "Receipt error 4: Failed to compare. Network or parsing error"
+    ).unwrap();
+    // end RECEIPT
 }
 
 /// Exposes prometheus metrics

--- a/rpc-server/src/modules/blocks/methods.rs
+++ b/rpc-server/src/modules/blocks/methods.rs
@@ -78,10 +78,7 @@ pub async fn chunk(
             Ok(_) => {
                 tracing::info!(target: "shadow_data_consistency", "Shadow data check: CORRECT\n{}", error_meta);
             }
-            Err(err) => {
-                tracing::warn!(target: "shadow_data_consistency", "Shadow data check: ERROR\n{}\n{:?}", error_meta, err);
-                crate::metrics::CHUNK_PROXIES_TOTAL.inc()
-            }
+            Err(err) => crate::utils::capture_shadow_consistency_error!(err, error_meta, "CHUNK"),
         }
     }
     Ok(result.map_err(near_jsonrpc_primitives::errors::RpcError::from)?)
@@ -201,10 +198,7 @@ async fn block_call(
             Ok(_) => {
                 tracing::info!(target: "shadow_data_consistency", "Shadow data check: CORRECT\n{}", error_meta);
             }
-            Err(err) => {
-                tracing::warn!(target: "shadow_data_consistency", "Shadow data check: ERROR\n{}\n{:?}", error_meta, err);
-                crate::metrics::BLOCK_PROXIES_TOTAL.inc()
-            }
+            Err(err) => crate::utils::capture_shadow_consistency_error!(err, error_meta, "BLOCK"),
         }
     };
 
@@ -252,8 +246,7 @@ async fn changes_in_block_call(
                 tracing::info!(target: "shadow_data_consistency", "Shadow data check: CORRECT\n{}", error_meta);
             }
             Err(err) => {
-                tracing::warn!(target: "shadow_data_consistency", "Shadow data check: ERROR\n{}\n{:?}", error_meta, err);
-                crate::metrics::CHNGES_IN_BLOCK_PROXIES_TOTAL.inc()
+                crate::utils::capture_shadow_consistency_error!(err, error_meta, "CHANGES_IN_BLOCK")
             }
         }
     }
@@ -302,8 +295,11 @@ async fn changes_in_block_by_type_call(
                 tracing::info!(target: "shadow_data_consistency", "Shadow data check: CORRECT\n{}", error_meta);
             }
             Err(err) => {
-                tracing::warn!(target: "shadow_data_consistency", "Shadow data check: ERROR\n{}\n{:?}", error_meta, err);
-                crate::metrics::CHNGES_IN_BLOCK_BY_TYPE_PROXIES_TOTAL.inc()
+                crate::utils::capture_shadow_consistency_error!(
+                    err,
+                    error_meta,
+                    "CHANGES_IN_BLOCK_BY_TYPE"
+                )
             }
         }
     }

--- a/rpc-server/src/modules/queries/methods.rs
+++ b/rpc-server/src/modules/queries/methods.rs
@@ -139,25 +139,48 @@ async fn query_call(
                 // are not proxying the requests anymore and respond with the error to the client.
                 // Since we already have the dashboard using these metric names, we don't want to
                 // change them and reuse them for the observability of the shadow data consistency checks.
-                tracing::warn!(target: "shadow_data_consistency", "Shadow data check: ERROR\n{}\n{:?}", error_meta, err);
                 match request_copy {
                     near_primitives::views::QueryRequest::ViewAccount { .. } => {
-                        crate::metrics::QUERY_VIEW_ACCOUNT_PROXIES_TOTAL.inc()
+                        crate::utils::capture_shadow_consistency_error!(
+                            err,
+                            error_meta,
+                            "QUERY_VIEW_ACCOUNT"
+                        );
                     }
                     near_primitives::views::QueryRequest::ViewCode { .. } => {
-                        crate::metrics::QUERY_VIEW_CODE_PROXIES_TOTAL.inc()
+                        crate::utils::capture_shadow_consistency_error!(
+                            err,
+                            error_meta,
+                            "QUERY_VIEW_CODE"
+                        );
                     }
                     near_primitives::views::QueryRequest::ViewAccessKey { .. } => {
-                        crate::metrics::QUERY_VIEW_ACCESS_KEY_PROXIES_TOTAL.inc()
+                        crate::utils::capture_shadow_consistency_error!(
+                            err,
+                            error_meta,
+                            "QUERY_VIEW_ACCESS_KEY"
+                        );
                     }
                     near_primitives::views::QueryRequest::ViewState { .. } => {
-                        crate::metrics::QUERY_VIEW_STATE_PROXIES_TOTAL.inc()
+                        crate::utils::capture_shadow_consistency_error!(
+                            err,
+                            error_meta,
+                            "QUERY_VIEW_STATE"
+                        );
                     }
                     near_primitives::views::QueryRequest::CallFunction { .. } => {
-                        crate::metrics::QUERY_FUNCTION_CALL_PROXIES_TOTAL.inc()
+                        crate::utils::capture_shadow_consistency_error!(
+                            err,
+                            error_meta,
+                            "QUERY_FUNCTION_CALL"
+                        );
                     }
                     near_primitives::views::QueryRequest::ViewAccessKeyList { .. } => {
-                        crate::metrics::QUERY_VIEW_ACCESS_KEYS_LIST_PROXIES_TOTAL.inc()
+                        crate::utils::capture_shadow_consistency_error!(
+                            err,
+                            error_meta,
+                            "QUERY_VIEW_ACCESS_KEY_LIST"
+                        );
                     }
                 };
             }

--- a/rpc-server/src/modules/receipts/methods.rs
+++ b/rpc-server/src/modules/receipts/methods.rs
@@ -19,7 +19,7 @@ pub async fn receipt(
     #[cfg(feature = "shadow_data_consistency")]
     {
         let near_rpc_client = data.near_rpc_client.clone();
-        let error_meta = format!("TX: {:?}", params);
+        let error_meta = format!("RECEIPT: {:?}", params);
         let (read_rpc_response_json, is_response_ok) = match &result {
             Ok(res) => (serde_json::to_value(res), true),
             Err(err) => (serde_json::to_value(err), false),
@@ -38,8 +38,7 @@ pub async fn receipt(
                 tracing::info!(target: "shadow_data_consistency", "Shadow data check: CORRECT\n{}", error_meta);
             }
             Err(err) => {
-                tracing::warn!(target: "shadow_data_consistency", "Shadow data check: ERROR\n{}\n{:?}", error_meta, err);
-                crate::metrics::RECEIPT_PROXIES_TOTAL.inc();
+                crate::utils::capture_shadow_consistency_error!(err, error_meta, "RECEIPT");
             }
         }
     }

--- a/rpc-server/src/modules/transactions/methods.rs
+++ b/rpc-server/src/modules/transactions/methods.rs
@@ -52,8 +52,7 @@ pub async fn tx(
                 tracing::info!(target: "shadow_data_consistency", "Shadow data check: CORRECT\n{}", error_meta);
             }
             Err(err) => {
-                tracing::warn!(target: "shadow_data_consistency", "Shadow data check: ERROR\n{}\n{:?}", error_meta, err);
-                crate::metrics::TX_PROXIES_TOTAL.inc();
+                crate::utils::capture_shadow_consistency_error!(err, error_meta, "TX");
             }
         }
     }
@@ -102,8 +101,11 @@ pub async fn tx_status(
                 tracing::info!(target: "shadow_data_consistency", "Shadow data check: CORRECT\n{}", error_meta);
             }
             Err(err) => {
-                tracing::warn!(target: "shadow_data_consistency", "Shadow data check: ERROR\n{}\n{:?}", error_meta, err);
-                crate::metrics::TX_STATUS_PROXIES_TOTAL.inc();
+                crate::utils::capture_shadow_consistency_error!(
+                    err,
+                    error_meta,
+                    "EXPERIMENTAL_TX_STATUS"
+                );
             }
         }
     }


### PR DESCRIPTION
Resolves #97 

## What this PR is about?

In this PR my goal was to disambiguate the error counters to reflect different (known) reasons for the errors. I achieve this by renaming the existing metrics and adding the code as a suffix. 

Yeah, I am aware of the antipattern of "magic numbers", but I want to keep the metric names shorter. Here's the list of the available codes (also, I've added this info to the `rpc-server` README).

> - **0** - ReadRPC returns a Success result, and NEAR RPC returns a Success result, but the results don't match
> - **1** - ReadRPC returns Success result, and NEAR RPC returns an Error result
> - **2** - ReadRPC returns an Error result, and NEAR RPC returns Success result
> - **3** - ReadRPC returns an Error result, and NEAR RPC returns an Error result, but the results don't match
> - **4** - Could not perform consistency check because of the error (either network or parsing the results)

So for the `block` method, the metric with error code 0 will look like this `BLOCK_ERROR_0`.

## Things I want to draw your attention to

All the changes in this PR work only with the `shadow_data_consistency` feature flag and don't affect the other sides of the project.

FYI while renaming metrics, I've reached some limits of `lazy_static`, so I had to group the static refs of the metrics to a separate `lazy_static! {}` "containers".

To keep the code cleaner and follow the DRY principle, I introduced a macro `capture_shadow_consistency_error!` that handles the `ShadowConsistencyError`:
- Captures the error variant
- Emits a proper log message based on the variant and subvariants of the error

This PR also contains a small change to the `docker-compose.yml`, but that is just an improvement since we got rid of the ridiculous log target `is_data_consistency` in favor of the `shadow_data_consistency` similar to the feature name.

And yeah, merging this PR will break the existing ReadRPC dashboard, I am going to redo it afterward.