### PR TITLE
refactor(read-rpc): Add header referer: read-rpc to near-jsonrpc-client

### DIFF
--- a/rpc-server/src/main.rs
+++ b/rpc-server/src/main.rs
@@ -76,6 +76,8 @@ async fn main() -> anyhow::Result<()> {
     init_logging(false)?;
 
     let near_rpc_client = near_jsonrpc_client::JsonRpcClient::connect(opts.rpc_url.to_string());
+    // We want to set a custom referer to let NEAR JSON RPC nodes know that we are a read-rpc instance
+    let near_rpc_client = near_rpc_client.header(("referer", "read-rpc"))?; // TODO: make it configurable
     let blocks_cache = std::sync::Arc::new(std::sync::RwLock::new(lru::LruCache::new(
         std::num::NonZeroUsize::new(100000).unwrap(),
     )));

--- a/rpc-server/src/main.rs
+++ b/rpc-server/src/main.rs
@@ -77,7 +77,7 @@ async fn main() -> anyhow::Result<()> {
 
     let near_rpc_client = near_jsonrpc_client::JsonRpcClient::connect(opts.rpc_url.to_string());
     // We want to set a custom referer to let NEAR JSON RPC nodes know that we are a read-rpc instance
-    let near_rpc_client = near_rpc_client.header(("referer", "read-rpc"))?; // TODO: make it configurable
+    let near_rpc_client = near_rpc_client.header(("Referer", "read-rpc"))?; // TODO: make it configurable
     let blocks_cache = std::sync::Arc::new(std::sync::RwLock::new(lru::LruCache::new(
         std::num::NonZeroUsize::new(100000).unwrap(),
     )));


### PR DESCRIPTION
Currently, we run only one instance of the ReadRPC-server for traffic mirroring (with the`shadow_data_consistency` feature enabled). This instance receives a copy of the traffic from the Archival RPC nodes (some or all of the traffic doesn’t matter).

However, for the shadow calls, ReadRPC does the call to an Archival RPC. Recently internal and public archival RPC nodes were merged together, and the SRE team set up a feature that the request with the header `Referer: read-rpc` won’t be mirrored back to the ReadRPC.

We need to ensure ReadRPC includes this header in shadow calls.

I've added a `TODO` there to make it configurable in the future but hardcoded to handle the circulating requests issue for now.