### PR TITLE
refactor(rpc-server): Make shadow_data_consistency check handle `TIMEOUT_ERROR` as `NearRpcCallError`

### DIFF
--- a/rpc-server/src/utils.rs
+++ b/rpc-server/src/utils.rs
@@ -154,7 +154,15 @@ where
         Err(err) => {
             if let Some(e) = err.handler_error() {
                 match serde_json::to_value(&e) {
-                    Ok(near_rpc_response_json) => (near_rpc_response_json, false),
+                    Ok(near_rpc_response_json) => {
+                        if near_rpc_response_json["name"] == "TIMEOUT_ERROR" {
+                            return Err(ShadowDataConsistencyError::NearRpcCallError(format!(
+                                "{:?}",
+                                err
+                            )));
+                        }
+                        (near_rpc_response_json, false)
+                    }
                     Err(err) => {
                         return Err(ShadowDataConsistencyError::NearRpcResponseParseError(err));
                     }


### PR DESCRIPTION
The majority of mismatch errors for the `EXPERIMENTAL_tx_status` call contain the error from Archival RPC `TIMEOUT_ERROR`, which is handled as a `MismatchError` while it should be as `NearRpcCallError`.

I've made it in a hacky way. However, **I wasn't able to properly check it locally** since I've failed to reproduce the `TIMEOUT_ERROR`. This should work, but I must check it on the server after merging and fix/adjust it if necessary.