### PR TITLE
refactor(rpc-server): storage refactoring

### DIFF
--- a/rpc-server/src/modules/queries/methods.rs
+++ b/rpc-server/src/modules/queries/methods.rs
@@ -4,9 +4,7 @@ use crate::modules::blocks::utils::fetch_block_from_cache_or_get;
 use crate::modules::blocks::CacheBlock;
 #[cfg(feature = "account_access_keys")]
 use crate::modules::queries::utils::fetch_list_access_keys_from_scylla_db;
-use crate::modules::queries::utils::{
-    fetch_access_key_from_scylla_db, fetch_state_from_scylla_db, run_contract,
-};
+use crate::modules::queries::utils::{fetch_state_from_scylla_db, run_contract};
 use crate::utils::proxy_rpc_call;
 #[cfg(feature = "shadow_data_consistency")]
 use crate::utils::shadow_compare_results;
@@ -219,9 +217,9 @@ async fn view_account(
 
     Ok(near_jsonrpc_primitives::types::query::RpcQueryResponse {
         kind: near_jsonrpc_primitives::types::query::QueryResponseKind::ViewAccount(
-            near_primitives::views::AccountView::from(account),
+            near_primitives::views::AccountView::from(account.data),
         ),
-        block_height: block.block_height,
+        block_height: account.block_height,
         block_hash: block.block_hash,
     })
 }
@@ -266,8 +264,8 @@ async fn view_code(
         kind: near_jsonrpc_primitives::types::query::QueryResponseKind::ViewCode(
             near_primitives::views::ContractCodeView::from(
                 near_primitives::contract::ContractCode::new(
-                    contract_code,
-                    Some(contract.code_hash()),
+                    contract_code.data,
+                    Some(contract.data.code_hash()),
                 ),
             ),
         ),
@@ -385,31 +383,28 @@ async fn view_access_key(
         key_data,
     );
 
-    let access_key = fetch_access_key_from_scylla_db(
-        &data.scylla_db_manager,
-        account_id,
-        block.block_height,
-        &key_data,
-    )
-    .await
-    .map_err(
-        |_err| match near_crypto::ED25519PublicKey::try_from(key_data.as_slice()) {
-            Ok(public_key) => {
-                near_jsonrpc_primitives::types::query::RpcQueryError::UnknownAccessKey {
-                    public_key: public_key.into(),
-                    block_height: block.block_height,
-                    block_hash: block.block_hash,
+    let access_key = data
+        .scylla_db_manager
+        .get_access_key(account_id, block.block_height, &key_data)
+        .await
+        .map_err(
+            |_err| match near_crypto::ED25519PublicKey::try_from(key_data.as_slice()) {
+                Ok(public_key) => {
+                    near_jsonrpc_primitives::types::query::RpcQueryError::UnknownAccessKey {
+                        public_key: public_key.into(),
+                        block_height: block.block_height,
+                        block_hash: block.block_hash,
+                    }
                 }
-            }
-            Err(_) => near_jsonrpc_primitives::types::query::RpcQueryError::InternalError {
-                error_message: "Failed to parse public key".to_string(),
+                Err(_) => near_jsonrpc_primitives::types::query::RpcQueryError::InternalError {
+                    error_message: "Failed to parse public key".to_string(),
+                },
             },
-        },
-    )?;
+        )?;
 
     Ok(near_jsonrpc_primitives::types::query::RpcQueryResponse {
         kind: near_jsonrpc_primitives::types::query::QueryResponseKind::AccessKey(
-            near_primitives::views::AccessKeyView::from(access_key),
+            near_primitives::views::AccessKeyView::from(access_key.data),
         ),
         block_height: block.block_height,
         block_hash: block.block_hash,

--- a/rpc-server/src/modules/queries/methods.rs
+++ b/rpc-server/src/modules/queries/methods.rs
@@ -220,7 +220,7 @@ async fn view_account(
             near_primitives::views::AccountView::from(account.data),
         ),
         block_height: account.block_height,
-        block_hash: block.block_hash,
+        block_hash: account.block_hash,
     })
 }
 
@@ -269,8 +269,8 @@ async fn view_code(
                 ),
             ),
         ),
-        block_height: block.block_height,
-        block_hash: block.block_hash,
+        block_height: contract.block_height,
+        block_hash: contract.block_hash,
     })
 }
 
@@ -292,6 +292,7 @@ async fn function_call(
         method_name,
         args,
     );
+    // TODO: receive a real block reference here
     let call_results = run_contract(
         account_id,
         method_name,
@@ -317,6 +318,7 @@ async fn function_call(
                     logs: call_results.logs,
                 },
             ),
+            // TODO: This is not honest block reference, but the request one
             block_height: block.block_height,
             block_hash: block.block_hash,
         }),
@@ -344,6 +346,7 @@ async fn view_state(
         block.block_height,
         prefix,
     );
+    // TODO: receive block reference here
     let contract_state = fetch_state_from_scylla_db(
         &data.scylla_db_manager,
         account_id,
@@ -361,6 +364,7 @@ async fn view_state(
 
     Ok(near_jsonrpc_primitives::types::query::RpcQueryResponse {
         kind: near_jsonrpc_primitives::types::query::QueryResponseKind::ViewState(contract_state),
+        // TODO: this block reference is not related to the response but to the request
         block_height: block.block_height,
         block_hash: block.block_hash,
     })
@@ -406,8 +410,8 @@ async fn view_access_key(
         kind: near_jsonrpc_primitives::types::query::QueryResponseKind::AccessKey(
             near_primitives::views::AccessKeyView::from(access_key.data),
         ),
-        block_height: block.block_height,
-        block_hash: block.block_hash,
+        block_height: access_key.block_height,
+        block_hash: access_key.block_hash,
     })
 }
 

--- a/rpc-server/src/modules/queries/mod.rs
+++ b/rpc-server/src/modules/queries/mod.rs
@@ -108,12 +108,12 @@ impl near_vm_logic::External for CodeStorage {
         key: &[u8],
         _mode: near_vm_logic::StorageGetMode,
     ) -> Result<bool> {
-        let get_db_stata_keys = self.scylla_db_manager.get_state_key_value(
+        let get_db_state_keys = self.scylla_db_manager.get_state_key_value(
             &self.account_id,
             self.block_height,
             key.to_vec(),
         );
-        match block_on(get_db_stata_keys) {
+        match block_on(get_db_state_keys) {
             Ok(data) => Ok(!data.is_empty()),
             Err(_) => Ok(false),
         }

--- a/rpc-server/src/modules/queries/mod.rs
+++ b/rpc-server/src/modules/queries/mod.rs
@@ -72,12 +72,8 @@ impl near_vm_logic::External for CodeStorage {
             key.to_vec(),
         );
         match block_on(get_db_data) {
-            Ok(row) => Ok(if let Ok((data,)) = row.into_typed::<(Vec<u8>,)>() {
-                if !data.is_empty() {
-                    Some(Box::new(StorageValuePtr { value: data }) as Box<_>)
-                } else {
-                    None
-                }
+            Ok(data) => Ok(if !data.is_empty() {
+                Some(Box::new(StorageValuePtr { value: data }) as Box<_>)
             } else {
                 None
             }),
@@ -118,11 +114,7 @@ impl near_vm_logic::External for CodeStorage {
             key.to_vec(),
         );
         match block_on(get_db_stata_keys) {
-            Ok(row) => Ok(if let Ok((data,)) = row.into_typed::<(Vec<u8>,)>() {
-                !data.is_empty()
-            } else {
-                false
-            }),
+            Ok(data) => Ok(!data.is_empty()),
             Err(_) => Ok(false),
         }
     }

--- a/rpc-server/src/modules/queries/utils.rs
+++ b/rpc-server/src/modules/queries/utils.rs
@@ -125,7 +125,7 @@ pub async fn fetch_state_from_scylla_db(
         }
         Ok(near_primitives::views::ViewStateResult {
             values,
-            proof: vec![],
+            proof: vec![], // TODO: this is hardcoded empty value since we don't support proofs yet
         })
     }
 }


### PR DESCRIPTION
I initially intended to fix the `query` method to return an honest block reference in the response.

### Quick recap

All the responses of the `query` method with all its `request_type` contain `block_height` and `block_hash`. On the NEAR RPC side, those fields highlight the "time" the data is up-to-date. 
On the ReadRPC side, however, we put the block reference of the requested block there.

What does it mean? If you request the data for block 100 but indexers haven't collected the data for block 100, the ReadRPC will return the latest available data for block 99, for example. But in the response, block 100 will be included in those `block_height` and `block_hash` fields.

This unfair behavior can be misleading, making debugging a bit more complex.

### The goal of the refactoring

So I would ensure we include the `block_height` from the row we got from ScyllaDB. However, I encountered a couple of problems:
- We don't store `block_hash` in `state_*` tables in ScyllaDB
- We don't have an index on the `block_height` field in the `blocks` table in ScyllaDB
- Our `storage` code is clunky

So I ended up refactoring the `storage.rs`:

- [x] Stop returning a raw `Row` from the `ScyllaDbManager` methods in favour of the requested data (Introduce dedicated struct(s) and impl `TryFrom` to make the code cleaner)
- [x] Add index on the `block_height` column in the `blocks` table
- [x] Add extra query in `query`-related `ScyllaDbManager` methods to fetch the block hash
- [x] Ensure we include the real block reference in the `query` responses