### PR TITLE
refactor(rpc-server): Adjust shadow-data-consistency check for QUERY method

### DIFF
--- a/rpc-server/src/modules/queries/methods.rs
+++ b/rpc-server/src/modules/queries/methods.rs
@@ -109,8 +109,19 @@ async fn query_call(
         let error_meta = format!("QUERY: {:?}", params);
         let near_rpc_client = data.near_rpc_client.clone();
         if let near_primitives::types::BlockReference::Finality(_) = params.block_reference {
+            // Final block is a bit tricky from the ReadRPC perspective.
+            // Since we do queries with the clause WHERE block_height <= X, we need to
+            // make sure that the block we are doing a shadow data consistency check for
+            // matches the one we got the result for.
+            // That's why we are using the block_height from the result.
+            let block_height = match &result {
+                Ok(res) => res.block_height,
+                // If the result is an error it does not contain the block_height, so we
+                // will use the block_height considered as final from the cache.
+                Err(err) => block.block_height,
+            };
             params.block_reference = near_primitives::types::BlockReference::from(
-                near_primitives::types::BlockId::Height(block.block_height),
+                near_primitives::types::BlockId::Height(block_height),
             )
         }
 

--- a/rpc-server/src/modules/queries/methods.rs
+++ b/rpc-server/src/modules/queries/methods.rs
@@ -118,7 +118,7 @@ async fn query_call(
                 Ok(res) => res.block_height,
                 // If the result is an error it does not contain the block_height, so we
                 // will use the block_height considered as final from the cache.
-                Err(err) => block.block_height,
+                Err(_err) => block.block_height,
             };
             params.block_reference = near_primitives::types::BlockReference::from(
                 near_primitives::types::BlockId::Height(block_height),


### PR DESCRIPTION
This is a follow-up for the #105 PR.

### Context

Shadow data consistency check for the methods accepting `block_reference` is being done for the specific block even if the original request was at `finality: final`. This is done because we want to compare the data at a given time (and compare block N with the real final block, where N is different from the final block height, which would lead to a mismatch guaranteed is not what we want). 

In this PR I adjust the block height propagating for the shadow call by taking the block height from the query-method response instead of a final block height from the cache. I left comments around it for future us.

