### PR TITLE
ND-605: query.view_account different results

### DIFF
--- a/rpc-server/src/modules/queries/methods.rs
+++ b/rpc-server/src/modules/queries/methods.rs
@@ -108,22 +108,20 @@ async fn query_call(
         let request_copy = params.request.clone();
         let meta_data = format!("{:?}", params);
         let near_rpc_client = data.near_rpc_client.clone();
-        if let near_primitives::types::BlockReference::Finality(_) = params.block_reference {
-            // Final block is a bit tricky from the ReadRPC perspective.
-            // Since we do queries with the clause WHERE block_height <= X, we need to
-            // make sure that the block we are doing a shadow data consistency check for
-            // matches the one we got the result for.
-            // That's why we are using the block_height from the result.
-            let block_height = match &result {
-                Ok(res) => res.block_height,
-                // If the result is an error it does not contain the block_height, so we
-                // will use the block_height considered as final from the cache.
-                Err(_err) => block.block_height,
-            };
-            params.block_reference = near_primitives::types::BlockReference::from(
-                near_primitives::types::BlockId::Height(block_height),
-            )
-        }
+
+        // Since we do queries with the clause WHERE block_height <= X, we need to
+        // make sure that the block we are doing a shadow data consistency check for
+        // matches the one we got the result for.
+        // That's why we are using the block_height from the result.
+        let block_height = match &result {
+            Ok(res) => res.block_height,
+            // If the result is an error it does not contain the block_height, so we
+            // will use the block_height considered as final from the cache.
+            Err(_err) => block.block_height,
+        };
+        params.block_reference = near_primitives::types::BlockReference::from(
+            near_primitives::types::BlockId::Height(block_height),
+        );
 
         let (read_rpc_response_json, is_response_ok) = match &result {
             Ok(res) => (serde_json::to_value(res), true),


### PR DESCRIPTION

1. Since we do queries with the clause WHERE block_height <= X, we need to make sure that the block we are doing a shadow data consistency check for matches the one we got the result for. That's why we are using the block_height from the result.
2. Performance improvement: delete additional query to get block_hash