### PR TITLE
Add reason code into the shadow consistency error log

### DIFF
--- a/rpc-server/src/modules/blocks/methods.rs
+++ b/rpc-server/src/modules/blocks/methods.rs
@@ -62,7 +62,7 @@ pub async fn chunk(
     #[cfg(feature = "shadow_data_consistency")]
     {
         let near_rpc_client = data.near_rpc_client.clone();
-        let error_meta = format!("CHUNK: {:?}", params);
+        let meta_data = format!("{:?}", params);
         let (read_rpc_response_json, is_response_ok) = match &result {
             Ok(res) => (serde_json::to_value(&res.chunk_view), true),
             Err(err) => (serde_json::to_value(err), false),
@@ -77,9 +77,9 @@ pub async fn chunk(
 
         match comparison_result {
             Ok(_) => {
-                tracing::info!(target: "shadow_data_consistency", "Shadow data check: CORRECT\n{}", error_meta);
+                tracing::info!(target: "shadow_data_consistency", "Shadow data check: CORRECT\n{}", meta_data);
             }
-            Err(err) => crate::utils::capture_shadow_consistency_error!(err, error_meta, "CHUNK"),
+            Err(err) => crate::utils::capture_shadow_consistency_error!(err, meta_data, "CHUNK"),
         }
     }
     Ok(result.map_err(near_jsonrpc_primitives::errors::RpcError::from)?)
@@ -174,7 +174,7 @@ async fn block_call(
     #[cfg(feature = "shadow_data_consistency")]
     {
         let near_rpc_client = data.near_rpc_client.clone();
-        let error_meta = format!("BLOCK: {:?}", params);
+        let meta_data = format!("{:?}", params);
         let (read_rpc_response_json, is_response_ok) = match &result {
             Ok(res) => {
                 if let near_primitives::types::BlockReference::Finality(_) = params.block_reference
@@ -197,9 +197,9 @@ async fn block_call(
 
         match comparison_result {
             Ok(_) => {
-                tracing::info!(target: "shadow_data_consistency", "Shadow data check: CORRECT\n{}", error_meta);
+                tracing::info!(target: "shadow_data_consistency", "Shadow data check: CORRECT\n{}", meta_data);
             }
-            Err(err) => crate::utils::capture_shadow_consistency_error!(err, error_meta, "BLOCK"),
+            Err(err) => crate::utils::capture_shadow_consistency_error!(err, meta_data, "BLOCK"),
         }
     };
 
@@ -229,7 +229,7 @@ async fn changes_in_block_call(
                 near_primitives::types::BlockId::Height(block.block_height),
             )
         }
-        let error_meta = format!("CHANGES_IN_BLOCK: {:?}", params);
+        let meta_data = format!("{:?}", params);
         let (read_rpc_response_json, is_response_ok) = match &result {
             Ok(res) => (serde_json::to_value(res), true),
             Err(err) => (serde_json::to_value(err), false),
@@ -244,10 +244,10 @@ async fn changes_in_block_call(
 
         match comparison_result {
             Ok(_) => {
-                tracing::info!(target: "shadow_data_consistency", "Shadow data check: CORRECT\n{}", error_meta);
+                tracing::info!(target: "shadow_data_consistency", "Shadow data check: CORRECT\n{}", meta_data);
             }
             Err(err) => {
-                crate::utils::capture_shadow_consistency_error!(err, error_meta, "CHANGES_IN_BLOCK")
+                crate::utils::capture_shadow_consistency_error!(err, meta_data, "CHANGES_IN_BLOCK")
             }
         }
     }
@@ -278,7 +278,7 @@ async fn changes_in_block_by_type_call(
                 near_primitives::types::BlockId::Height(block.block_height),
             )
         }
-        let error_meta = format!("CHANGES_IN_BLOCK_BY_TYPE: {:?}", params);
+        let meta_data = format!("{:?}", params);
         let (read_rpc_response_json, is_response_ok) = match &result {
             Ok(res) => (serde_json::to_value(res), true),
             Err(err) => (serde_json::to_value(err), false),
@@ -293,12 +293,12 @@ async fn changes_in_block_by_type_call(
 
         match comparison_result {
             Ok(_) => {
-                tracing::info!(target: "shadow_data_consistency", "Shadow data check: CORRECT\n{}", error_meta);
+                tracing::info!(target: "shadow_data_consistency", "Shadow data check: CORRECT\n{}", meta_data);
             }
             Err(err) => {
                 crate::utils::capture_shadow_consistency_error!(
                     err,
-                    error_meta,
+                    meta_data,
                     "CHANGES_IN_BLOCK_BY_TYPE"
                 )
             }

--- a/rpc-server/src/modules/queries/methods.rs
+++ b/rpc-server/src/modules/queries/methods.rs
@@ -152,50 +152,44 @@ async fn query_call(
                 // change them and reuse them for the observability of the shadow data consistency checks.
                 match request_copy {
                     near_primitives::views::QueryRequest::ViewAccount { .. } => {
-                        let error_meta = format!("QUERY:VIEW_ACCOUNT: {:?}", meta_data);
                         crate::utils::capture_shadow_consistency_error!(
                             err,
-                            error_meta,
+                            meta_data,
                             "QUERY_VIEW_ACCOUNT"
                         );
                     }
                     near_primitives::views::QueryRequest::ViewCode { .. } => {
-                        let error_meta = format!("QUERY:VIEW_CODE: {:?}", meta_data);
                         crate::utils::capture_shadow_consistency_error!(
                             err,
-                            error_meta,
+                            meta_data,
                             "QUERY_VIEW_CODE"
                         );
                     }
                     near_primitives::views::QueryRequest::ViewAccessKey { .. } => {
-                        let error_meta = format!("QUERY:VIEW_ACCESS_KEY: {:?}", meta_data);
                         crate::utils::capture_shadow_consistency_error!(
                             err,
-                            error_meta,
+                            meta_data,
                             "QUERY_VIEW_ACCESS_KEY"
                         );
                     }
                     near_primitives::views::QueryRequest::ViewState { .. } => {
-                        let error_meta = format!("QUERY:VIEW_STATE: {:?}", meta_data);
                         crate::utils::capture_shadow_consistency_error!(
                             err,
-                            error_meta,
+                            meta_data,
                             "QUERY_VIEW_STATE"
                         );
                     }
                     near_primitives::views::QueryRequest::CallFunction { .. } => {
-                        let error_meta = format!("QUERY:FUNCTION_CALL: {:?}", meta_data);
                         crate::utils::capture_shadow_consistency_error!(
                             err,
-                            error_meta,
+                            meta_data,
                             "QUERY_FUNCTION_CALL"
                         );
                     }
                     near_primitives::views::QueryRequest::ViewAccessKeyList { .. } => {
-                        let error_meta = format!("QUERY:VIEW_ACCESS_KEY_LIST: {:?}", meta_data);
                         crate::utils::capture_shadow_consistency_error!(
                             err,
-                            error_meta,
+                            meta_data,
                             "QUERY_VIEW_ACCESS_KEY_LIST"
                         );
                     }

--- a/rpc-server/src/modules/receipts/methods.rs
+++ b/rpc-server/src/modules/receipts/methods.rs
@@ -19,7 +19,7 @@ pub async fn receipt(
     #[cfg(feature = "shadow_data_consistency")]
     {
         let near_rpc_client = data.near_rpc_client.clone();
-        let error_meta = format!("RECEIPT: {:?}", params);
+        let meta_data = format!("{:?}", params);
         let (read_rpc_response_json, is_response_ok) = match &result {
             Ok(res) => (serde_json::to_value(res), true),
             Err(err) => (serde_json::to_value(err), false),
@@ -35,10 +35,10 @@ pub async fn receipt(
 
         match comparison_result {
             Ok(_) => {
-                tracing::info!(target: "shadow_data_consistency", "Shadow data check: CORRECT\n{}", error_meta);
+                tracing::info!(target: "shadow_data_consistency", "Shadow data check: CORRECT\n{}", meta_data);
             }
             Err(err) => {
-                crate::utils::capture_shadow_consistency_error!(err, error_meta, "RECEIPT");
+                crate::utils::capture_shadow_consistency_error!(err, meta_data, "RECEIPT");
             }
         }
     }

--- a/rpc-server/src/modules/transactions/methods.rs
+++ b/rpc-server/src/modules/transactions/methods.rs
@@ -28,7 +28,7 @@ pub async fn tx(
     #[cfg(feature = "shadow_data_consistency")]
     {
         let near_rpc_client = data.near_rpc_client.clone();
-        let error_meta = format!("TX: {:?}", params);
+        let meta_data = format!("{:?}", params);
         let (read_rpc_response_json, is_response_ok) = match &result {
             Ok(res) => (serde_json::to_value(res), true),
             Err(err) => (serde_json::to_value(err), false),
@@ -49,10 +49,10 @@ pub async fn tx(
 
         match comparison_result {
             Ok(_) => {
-                tracing::info!(target: "shadow_data_consistency", "Shadow data check: CORRECT\n{}", error_meta);
+                tracing::info!(target: "shadow_data_consistency", "Shadow data check: CORRECT\n{}", meta_data);
             }
             Err(err) => {
-                crate::utils::capture_shadow_consistency_error!(err, error_meta, "TX");
+                crate::utils::capture_shadow_consistency_error!(err, meta_data, "TX");
             }
         }
     }
@@ -76,7 +76,7 @@ pub async fn tx_status(
     #[cfg(feature = "shadow_data_consistency")]
     {
         let near_rpc_client = data.near_rpc_client.clone();
-        let error_meta = format!("EXPERIMENTAL_TX_STATUS: {:?}", params);
+        let meta_data = format!("{:?}", params);
 
         let (read_rpc_response_json, is_response_ok) = match &result {
             Ok(res) => (serde_json::to_value(res), true),
@@ -98,12 +98,12 @@ pub async fn tx_status(
 
         match comparison_result {
             Ok(_) => {
-                tracing::info!(target: "shadow_data_consistency", "Shadow data check: CORRECT\n{}", error_meta);
+                tracing::info!(target: "shadow_data_consistency", "Shadow data check: CORRECT\n{}", meta_data);
             }
             Err(err) => {
                 crate::utils::capture_shadow_consistency_error!(
                     err,
-                    error_meta,
+                    meta_data,
                     "EXPERIMENTAL_TX_STATUS"
                 );
             }

--- a/rpc-server/src/utils.rs
+++ b/rpc-server/src/utils.rs
@@ -362,7 +362,7 @@ fn generate_array_key(value: &serde_json::Value) -> String {
 
 #[cfg(feature = "shadow_data_consistency")]
 macro_rules! capture_shadow_consistency_error {
-    ($err:ident, $error_meta:ident, $method_metric_name:expr) => {
+    ($err:ident, $meta_data:ident, $method_metric_name:expr) => {
         match $err {
             crate::utils::ShadowDataConsistencyError::ResultsDontMatch {
                 reason,
@@ -372,8 +372,10 @@ macro_rules! capture_shadow_consistency_error {
             } => {
                 tracing::warn!(
                     target: "shadow_data_consistency",
-                    "Shadow data check: ERROR\n{}\n{}",
-                    $error_meta,
+                    "Shadow data check: ERROR\n{}:{}: {}\n{}",
+                    $method_metric_name,
+                    reason.code(),
+                    $meta_data,
                     format!("{}, ReadRPC: {:?}, NearRPC: {:?}", reason.reason(), read_rpc_response, near_rpc_response),
                 );
                 match reason.code() {
@@ -401,7 +403,7 @@ macro_rules! capture_shadow_consistency_error {
                 };
             },
             _ => {
-                tracing::warn!(target: "shadow_data_consistency", "Shadow data check: ERROR\n{}\n{:?}", $error_meta, $err);
+                tracing::warn!(target: "shadow_data_consistency", "Shadow data check: ERROR\n{}: {}\n{:?}", $method_metric_name, $meta_data, $err);
                 paste::paste!{
                     crate::metrics::[<$method_metric_name _ERROR_4>].inc();
                 }


### PR DESCRIPTION
In this PR we added `reason.code()` in to `shadow_consistency_error` logs. This will add the ability to filter logs entries by a specific `code`.