### PR TITLE
ND-604: query.function_call different results

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4360,6 +4360,7 @@ dependencies = [
  "near-jsonrpc-primitives",
  "near-primitives",
  "near-primitives-core",
+ "near-vm-errors",
  "near-vm-logic",
  "near-vm-runner",
  "num-bigint",

--- a/rpc-server/Cargo.toml
+++ b/rpc-server/Cargo.toml
@@ -58,6 +58,7 @@ near-primitives = "0.17.0"
 near-primitives-core = "0.17.0"
 near-vm-runner = "0.17.0"
 near-vm-logic = "0.17.0"
+near-vm-errors = "0.17.0"
 
 [features]
 default = ["submit_tx_methods"]

--- a/rpc-server/src/config.rs
+++ b/rpc-server/src/config.rs
@@ -61,6 +61,11 @@ pub struct Opts {
     /// before skipping giving up and moving to the next piece of data
     #[clap(long, default_value = "false", env)]
     pub strict_mode: bool,
+
+    /// Max gas burnt for contract function call
+    /// Default value is 300_000_000_000_000
+    #[clap(long, env, default_value = "300000000000000")]
+    pub max_gas_burnt: near_primitives_core::types::Gas,
 }
 
 pub struct ServerContext {
@@ -75,6 +80,7 @@ pub struct ServerContext {
     pub contract_code_cache: std::sync::Arc<
         std::sync::RwLock<lru::LruCache<near_primitives::hash::CryptoHash, Vec<u8>>>,
     >,
+    pub max_gas_burnt: near_primitives_core::types::Gas,
 }
 
 pub struct CompiledCodeCache {

--- a/rpc-server/src/errors.rs
+++ b/rpc-server/src/errors.rs
@@ -94,7 +94,7 @@ where
 }
 
 #[derive(thiserror::Error, Debug, Clone)]
-pub enum CallFunctionError {
+pub enum FunctionCallError {
     #[error("Account ID \"{requested_account_id}\" is invalid")]
     InvalidAccountId {
         requested_account_id: near_primitives::types::AccountId,
@@ -109,7 +109,7 @@ pub enum CallFunctionError {
     VMError { error_message: String },
 }
 
-impl CallFunctionError {
+impl FunctionCallError {
     pub fn to_rpc_query_error(
         &self,
         block_height: near_primitives::types::BlockHeight,

--- a/rpc-server/src/main.rs
+++ b/rpc-server/src/main.rs
@@ -134,6 +134,7 @@ async fn main() -> anyhow::Result<()> {
         final_block_height: std::sync::Arc::clone(&final_block_height),
         compiled_contract_code_cache,
         contract_code_cache,
+        max_gas_burnt: opts.max_gas_burnt,
     };
 
     let shutdown = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));

--- a/rpc-server/src/modules/blocks/mod.rs
+++ b/rpc-server/src/modules/blocks/mod.rs
@@ -8,4 +8,5 @@ pub struct CacheBlock {
     pub block_timestamp: u64,
     pub latest_protocol_version: near_primitives::types::ProtocolVersion,
     pub chunks_included: u64,
+    pub state_root: near_primitives::hash::CryptoHash,
 }

--- a/rpc-server/src/modules/blocks/utils.rs
+++ b/rpc-server/src/modules/blocks/utils.rs
@@ -279,6 +279,7 @@ pub async fn fetch_block_from_cache_or_get(
                 block_timestamp: block_from_s3.block_view.header.timestamp,
                 latest_protocol_version: block_from_s3.block_view.header.latest_protocol_version,
                 chunks_included: block_from_s3.block_view.header.chunks_included,
+                state_root: block_from_s3.block_view.header.prev_state_root,
             };
 
             data.blocks_cache

--- a/rpc-server/src/modules/queries/methods.rs
+++ b/rpc-server/src/modules/queries/methods.rs
@@ -318,28 +318,17 @@ async fn function_call(
         block.latest_protocol_version,
     )
     .await
-    .map_err(
-        |err| near_jsonrpc_primitives::types::query::RpcQueryError::InternalError {
-            error_message: format!("Function call failed: {:?}", err),
-        },
-    )?;
-    match call_results.result.return_data.as_value() {
-        Some(val) => Ok(near_jsonrpc_primitives::types::query::RpcQueryResponse {
-            kind: near_jsonrpc_primitives::types::query::QueryResponseKind::CallResult(
-                near_primitives::views::CallResult {
-                    result: val,
-                    logs: call_results.result.logs,
-                },
-            ),
-            block_height: call_results.block_height,
-            block_hash: call_results.block_hash,
-        }),
-        None => Err(
-            near_jsonrpc_primitives::types::query::RpcQueryError::InternalError {
-                error_message: "Failed function call: empty result".to_string(),
+    .map_err(|err| err.to_rpc_query_error(block.block_height, block.block_hash))?;
+    Ok(near_jsonrpc_primitives::types::query::RpcQueryResponse {
+        kind: near_jsonrpc_primitives::types::query::QueryResponseKind::CallResult(
+            near_primitives::views::CallResult {
+                result: call_results.result,
+                logs: call_results.logs,
             },
         ),
-    }
+        block_height: call_results.block_height,
+        block_hash: call_results.block_hash,
+    })
 }
 
 #[cfg_attr(feature = "tracing-instrumentation", tracing::instrument(skip(data)))]

--- a/rpc-server/src/modules/queries/methods.rs
+++ b/rpc-server/src/modules/queries/methods.rs
@@ -313,9 +313,8 @@ async fn function_call(
         data.scylla_db_manager.clone(),
         &data.compiled_contract_code_cache,
         &data.contract_code_cache,
-        block.block_height,
-        block.block_timestamp,
-        block.latest_protocol_version,
+        block,
+        data.max_gas_burnt,
     )
     .await
     .map_err(|err| err.to_rpc_query_error(block.block_height, block.block_hash))?;

--- a/rpc-server/src/modules/queries/utils.rs
+++ b/rpc-server/src/modules/queries/utils.rs
@@ -3,10 +3,13 @@ use std::ops::Deref;
 
 #[cfg(feature = "account_access_keys")]
 use borsh::BorshDeserialize;
+use borsh::BorshSerialize;
+use near_crypto::{KeyType, PublicKey};
+use near_primitives::utils::create_random_seed;
 use tokio::task;
 
 use crate::config::CompiledCodeCache;
-use crate::errors::CallFunctionError;
+use crate::errors::FunctionCallError;
 use crate::modules::queries::{CodeStorage, MAX_LIMIT};
 use crate::storage::ScyllaDBManager;
 
@@ -246,14 +249,13 @@ pub async fn run_contract(
     contract_code_cache: &std::sync::Arc<
         std::sync::RwLock<lru::LruCache<near_primitives::hash::CryptoHash, Vec<u8>>>,
     >,
-    block_height: near_primitives::types::BlockHeight,
-    timestamp: u64,
-    latest_protocol_version: near_primitives::types::ProtocolVersion,
-) -> Result<RunContractResponse, CallFunctionError> {
+    block: crate::modules::blocks::CacheBlock,
+    max_gas_burnt: near_primitives_core::types::Gas,
+) -> Result<RunContractResponse, FunctionCallError> {
     let contract = scylla_db_manager
-        .get_account(&account_id, block_height)
+        .get_account(&account_id, block.block_height)
         .await
-        .map_err(|_| CallFunctionError::AccountDoesNotExist {
+        .map_err(|_| FunctionCallError::AccountDoesNotExist {
             requested_account_id: account_id.clone(),
         })?;
 
@@ -269,9 +271,9 @@ pub async fn run_contract(
         }
         None => {
             let code = scylla_db_manager
-                .get_contract_code(&account_id, block_height)
+                .get_contract_code(&account_id, block.block_height)
                 .await
-                .map_err(|_| CallFunctionError::InvalidAccountId {
+                .map_err(|_| FunctionCallError::InvalidAccountId {
                     requested_account_id: account_id.clone(),
                 })?;
             contract_code_cache
@@ -281,24 +283,28 @@ pub async fn run_contract(
             near_primitives::contract::ContractCode::new(code.data, Some(contract.data.code_hash()))
         }
     };
+    let public_key = PublicKey::empty(KeyType::ED25519);
+    let random_seed = create_random_seed(
+        block.latest_protocol_version,
+        near_primitives_core::hash::CryptoHash::default(),
+        block.state_root,
+    );
     let context = near_vm_logic::VMContext {
         current_account_id: account_id.parse().unwrap(),
         signer_account_id: account_id.parse().unwrap(),
-        signer_account_pk: vec![],
+        signer_account_pk: public_key.try_to_vec().expect("Failed to serialize"),
         predecessor_account_id: account_id.parse().unwrap(),
         input: args.into(),
-        block_height,
-        block_timestamp: timestamp,
+        block_height: block.block_height,
+        block_timestamp: block.block_timestamp,
         epoch_height: 0, // TODO: implement indexing of epoch_height and pass it here
         account_balance: contract.data.amount(),
         account_locked_balance: contract.data.locked(),
         storage_usage: contract.data.storage_usage(),
         attached_deposit: 0,
-        prepaid_gas: 0,
-        random_seed: vec![], // TODO: test the contracts where random is used.
-        view_config: Some(near_primitives::config::ViewConfig {
-            max_gas_burnt: 300_000_000_000_000, // TODO: extract it into a configuration option
-        }),
+        prepaid_gas: max_gas_burnt,
+        random_seed,
+        view_config: Some(near_primitives::config::ViewConfig { max_gas_burnt }),
         output_data_receivers: vec![],
     };
 
@@ -307,19 +313,18 @@ pub async fn run_contract(
         method_name,
         context,
         account_id,
-        block_height,
+        block.block_height,
         scylla_db_manager.clone(),
-        latest_protocol_version,
+        block.latest_protocol_version,
         compiled_contract_code_cache,
     )
     .await
-    .map_err(|e| CallFunctionError::InternalError {
+    .map_err(|e| FunctionCallError::InternalError {
         error_message: e.to_string(),
     })?;
-
     if let Some(err) = result.aborted {
         let message = format!("wasm execution failed with error: {:?}", err);
-        Err(CallFunctionError::VMError {
+        Err(FunctionCallError::VMError {
             error_message: message,
         })
     } else {
@@ -331,8 +336,8 @@ pub async fn run_contract(
         Ok(RunContractResponse {
             result,
             logs,
-            block_height: contract.block_height,
-            block_hash: contract.block_hash,
+            block_height: block.block_height,
+            block_hash: block.block_hash,
         })
     }
 }

--- a/rpc-server/src/utils.rs
+++ b/rpc-server/src/utils.rs
@@ -57,6 +57,7 @@ pub async fn get_final_cache_block(
             block_timestamp: block_view.header.timestamp,
             latest_protocol_version: block_view.header.latest_protocol_version,
             chunks_included: block_view.header.chunks_included,
+            state_root: block_view.header.prev_state_root,
         }),
         Err(_) => None,
     }


### PR DESCRIPTION
This PR includes improvement for `query:function_call`
1. Added `random_seed` for function_call
2. Moved `max_gas_burnt` into the configuration options
3. Added an error handler to function_call the same as in NEAR RPC so that the error responses coincide. 