### PR TITLE
ND-541: Read RPC server dies with OOM from time to time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2348,9 +2348,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+checksum = "7dfda62a12f55daeae5015f81b0baea145391cb4520f86c248fc615d72640d12"
 dependencies = [
  "ahash 0.8.3",
  "allocator-api2",
@@ -2844,7 +2844,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a83fb7698b3643a0e34f9ae6f2e8f0178c0fd42f8b59d493aa271ff3a5bf21"
 dependencies = [
- "hashbrown 0.14.0",
+ "hashbrown 0.14.1",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,6 +301,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2341,6 +2347,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+dependencies = [
+ "ahash 0.8.3",
+ "allocator-api2",
+]
+
+[[package]]
 name = "heck"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2824,11 +2840,11 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.8.1"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6e8aaa3f231bb4bd57b84b2d5dc3ae7f350265df8aa96492e0bc394a1571909"
+checksum = "a4a83fb7698b3643a0e34f9ae6f2e8f0178c0fd42f8b59d493aa271ff3a5bf21"
 dependencies = [
- "hashbrown 0.12.3",
+ "hashbrown 0.14.0",
 ]
 
 [[package]]
@@ -3489,6 +3505,15 @@ dependencies = [
  "cfg-if 0.1.10",
  "libc",
  "void",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -4352,7 +4377,7 @@ dependencies = [
  "http",
  "jsonrpc-v2",
  "lazy_static",
- "lru 0.8.1",
+ "lru 0.11.1",
  "near-chain-configs",
  "near-crypto",
  "near-indexer-primitives",
@@ -4374,6 +4399,7 @@ dependencies = [
  "scylla",
  "serde",
  "serde_json",
+ "sysinfo",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -5254,6 +5280,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.29.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a18d114d420ada3a891e6bc8e96a2023402203296a47cdd65083377dad18ba5"
+dependencies = [
+ "cfg-if 1.0.0",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "rayon",
+ "winapi",
 ]
 
 [[package]]

--- a/rpc-server/Cargo.toml
+++ b/rpc-server/Cargo.toml
@@ -21,7 +21,7 @@ hex = "0.4.3"
 http = "0.2.8"
 jsonrpc-v2 = { git = "https://github.com/kobayurii/jsonrpc-v2", rev = "95e7b1d2567ae841163af212a3f25abb6862becb" }
 lazy_static = "1.4.0"
-lru = "0.8.1"
+lru = "0.11.1"
 num-bigint = "0.3"
 num-traits = "0.2.15"
 paste = "1.0.14"
@@ -44,6 +44,7 @@ opentelemetry = { version = "0.17", features = ["rt-tokio-current-thread"] }
 opentelemetry-jaeger = { version = "0.16", features = [
     "rt-tokio-current-thread",
 ] }
+sysinfo = "0.29.10"
 tracing-opentelemetry = { version = "0.17" }
 tracing-stackdriver = "0.7.2" # GCP logs
 

--- a/rpc-server/src/cache.rs
+++ b/rpc-server/src/cache.rs
@@ -1,0 +1,81 @@
+/// A memory-size based wrapper around the lru crate.
+
+const INITIAL_CAPACITY: Option<std::num::NonZeroUsize> = std::num::NonZeroUsize::new(10);
+
+/// An LRU-cache which operates on memory used.
+pub struct LruMemoryCache<K, V> {
+    inner: lru::LruCache<K, V>,
+    current_size: usize,
+    max_size: usize,
+}
+
+impl<K: std::hash::Hash + Eq, V> LruMemoryCache<K, V> {
+    /// Create a new cache with a maximum memory size of values.
+    pub fn new(max_size: usize) -> Self {
+        LruMemoryCache {
+            inner: lru::LruCache::new(INITIAL_CAPACITY.unwrap()),
+            current_size: 0,
+            max_size,
+        }
+    }
+
+    /// Remove elements until we are below the memory target.
+    fn decrease(&mut self) {
+        while self.current_size > self.max_size {
+            match self.inner.pop_lru() {
+                Some((_, v)) => self.current_size -= std::mem::size_of_val(&v),
+                _ => break,
+            }
+        }
+    }
+
+    /// Puts a key-value pair into cache.
+    /// If the key already exists in the cache, then it updates the key's value
+    pub fn put(&mut self, key: K, val: V) {
+        let cap = self.inner.cap().get();
+
+        // grow the cache as necessary,
+        // lru operates on amount of items,
+        // but we're working based on memory usage.
+        if self.inner.len() == cap {
+            let new_cap = std::num::NonZeroUsize::new(cap.saturating_mul(2))
+                .expect("only returns None if value is zero");
+            self.inner.resize(new_cap);
+        }
+
+        self.current_size += std::mem::size_of_val(&val);
+
+        // subtract any element displaced from the hash.
+        if let Some(lru) = self.inner.put(key, val) {
+            self.current_size -= std::mem::size_of_val(&lru);
+        }
+
+        self.decrease();
+    }
+
+    /// Returns a reference to the value of the key in the cache or None if it is not present in the cache.
+    pub fn get(&mut self, key: &K) -> Option<&V> {
+        self.inner.get(key)
+    }
+
+    /// Returns a bool indicating whether the given key is in the cache.
+    /// Does not update the LRU list.
+    pub fn contains(&self, key: &K) -> bool {
+        self.inner.contains(key)
+    }
+
+    /// Currently-used size of values in bytes.
+    pub fn current_size(&self) -> usize {
+        self.current_size
+    }
+
+    /// Max cache size of values in bytes.
+    pub fn max_size(&self) -> usize {
+        self.max_size
+    }
+
+    /// Returns the number of key-value pairs that are currently in the the cache.
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+}

--- a/rpc-server/src/config.rs
+++ b/rpc-server/src/config.rs
@@ -64,6 +64,29 @@ pub struct Opts {
     /// Default value is 300_000_000_000_000
     #[clap(long, env, default_value = "300000000000000")]
     pub max_gas_burnt: near_primitives_core::types::Gas,
+
+    /// Max contract size is limited 4MB
+    /// Configured in the near-core
+    #[clap(long, env, default_value = "4194304")]
+    pub max_contract_size: u64,
+
+    /// Max available memory for `block_cache` and `contract_code_cache` in bytes
+    /// By default we use all available memory
+    /// Example: 1GB = 1073741824 bytes
+    #[clap(long, env)]
+    pub limit_memory_cache: Option<u64>,
+
+    /// Reserved memory for running the application in bytes
+    /// By default we use 256MB (268_435_456 bytes
+    #[clap(long, env, default_value = "268435456")]
+    pub reserved_memory: u64,
+
+    /// Block cache size in bytes
+    /// By default we use 128MB (134_217_728 bytes)
+    /// One cache_block size is ≈ 96 bytes
+    /// In 128MB we can put 1_398_101 cache_blocks
+    #[clap(long, env, default_value = "134217728")]
+    pub block_cache_size: u64,
 }
 
 impl Opts {

--- a/rpc-server/src/config.rs
+++ b/rpc-server/src/config.rs
@@ -65,23 +65,22 @@ pub struct Opts {
     #[clap(long, env, default_value = "300000000000000")]
     pub max_gas_burnt: near_primitives_core::types::Gas,
 
-    /// Max available memory for `block_cache` and `contract_code_cache` in bytes
+    /// Max available memory for `block_cache` and `contract_code_cache` in gigabytes
     /// By default we use all available memory
-    /// Example: 1GB = 1073741824 bytes
     #[clap(long, env)]
-    pub limit_memory_cache: Option<usize>,
+    pub limit_memory_cache: Option<f64>,
 
-    /// Reserved memory for running the application in bytes
-    /// By default we use 256MB (268_435_456 bytes
-    #[clap(long, env, default_value = "268435456")]
-    pub reserved_memory: usize,
+    /// Reserved memory for running the application in gigabytes
+    /// By default we use 0.25 gigabyte (256MB or 268_435_456 bytes)
+    #[clap(long, env, default_value = "0.25")]
+    pub reserved_memory: f64,
 
-    /// Block cache size in bytes
-    /// By default we use 128MB (134_217_728 bytes)
+    /// Block cache size in gigabytes
+    /// By default we use 0.125 gigabyte (128MB or 134_217_728 bytes)
     /// One cache_block size is ≈ 96 bytes
     /// In 128MB we can put 1_398_101 cache_blocks
-    #[clap(long, env, default_value = "134217728")]
-    pub block_cache_size: usize,
+    #[clap(long, env, default_value = "0.125")]
+    pub block_cache_size: f64,
 }
 
 impl Opts {

--- a/rpc-server/src/modules/network/methods.rs
+++ b/rpc-server/src/modules/network/methods.rs
@@ -27,23 +27,22 @@ pub async fn status(
         used_memory: friendly_memory_size_format(used_memory as usize),
         available_memory: friendly_memory_size_format((total_memory - used_memory) as usize),
 
-        blocks_cache_size: blocks_cache.cap(),
         blocks_in_cache: blocks_cache.len(),
-        memory_blocks_cache_size: friendly_memory_size_format(
-            std::mem::size_of_val(&blocks_cache.peek_lru()) * blocks_cache.len(),
-        ),
+        max_blocks_cache_size: friendly_memory_size_format(blocks_cache.max_size()),
+        current_blocks_cache_size: friendly_memory_size_format(blocks_cache.current_size()),
 
-        contracts_codes_cache_size: contract_code_cache.cap(),
         contracts_codes_in_cache: contract_code_cache.len(),
-        memory_contracts_codes_cache_size: friendly_memory_size_format(
-            std::mem::size_of_val(&contract_code_cache.peek_lru()) * contract_code_cache.len(),
+        max_contracts_codes_cache_size: friendly_memory_size_format(contract_code_cache.max_size()),
+        current_contracts_codes_cache_size: friendly_memory_size_format(
+            contract_code_cache.current_size(),
         ),
 
-        compiled_contracts_codes_cache_size: compiled_contract_code_cache.cap(),
         compiled_contracts_codes_in_cache: compiled_contract_code_cache.len(),
-        memory_compiled_contracts_codes_cache_size: friendly_memory_size_format(
-            std::mem::size_of_val(&compiled_contract_code_cache.peek_lru())
-                * compiled_contract_code_cache.len(),
+        max_compiled_contracts_codes_cache_size: friendly_memory_size_format(
+            compiled_contract_code_cache.max_size(),
+        ),
+        current_compiled_contracts_codes_cache_size: friendly_memory_size_format(
+            compiled_contract_code_cache.current_size(),
         ),
 
         final_block_height: data

--- a/rpc-server/src/modules/network/mod.rs
+++ b/rpc-server/src/modules/network/mod.rs
@@ -19,17 +19,17 @@ pub struct StatusResponse {
     used_memory: String,
     available_memory: String,
 
-    blocks_cache_size: std::num::NonZeroUsize,
     blocks_in_cache: usize,
-    memory_blocks_cache_size: String,
+    max_blocks_cache_size: String,
+    current_blocks_cache_size: String,
 
-    contracts_codes_cache_size: std::num::NonZeroUsize,
     contracts_codes_in_cache: usize,
-    memory_contracts_codes_cache_size: String,
+    max_contracts_codes_cache_size: String,
+    current_contracts_codes_cache_size: String,
 
-    compiled_contracts_codes_cache_size: std::num::NonZeroUsize,
     compiled_contracts_codes_in_cache: usize,
-    memory_compiled_contracts_codes_cache_size: String,
+    max_compiled_contracts_codes_cache_size: String,
+    current_compiled_contracts_codes_cache_size: String,
 
     final_block_height: u64,
 }

--- a/rpc-server/src/modules/network/mod.rs
+++ b/rpc-server/src/modules/network/mod.rs
@@ -12,3 +12,39 @@ async fn parse_validator_request(
     };
     Ok(near_jsonrpc_primitives::types::validator::RpcValidatorRequest { epoch_reference })
 }
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub struct StatusResponse {
+    total_memory: String,
+    used_memory: String,
+    available_memory: String,
+
+    blocks_cache_size: std::num::NonZeroUsize,
+    blocks_in_cache: usize,
+    memory_blocks_cache_size: String,
+
+    contracts_codes_cache_size: std::num::NonZeroUsize,
+    contracts_codes_in_cache: usize,
+    memory_contracts_codes_cache_size: String,
+
+    compiled_contracts_codes_cache_size: std::num::NonZeroUsize,
+    compiled_contracts_codes_in_cache: usize,
+    memory_compiled_contracts_codes_cache_size: String,
+
+    final_block_height: u64,
+}
+
+pub fn friendly_memory_size_format(memory_size_bytes: usize) -> String {
+    if memory_size_bytes < 1024 {
+        format!("{:.2} B", memory_size_bytes)
+    } else if memory_size_bytes < 1024 * 1024 {
+        format!("{:.2} KB", memory_size_bytes as f64 / 1024.0)
+    } else if memory_size_bytes < 1024 * 1024 * 1024 {
+        format!("{:.2} MB", memory_size_bytes as f64 / 1024.0 / 1024.0)
+    } else {
+        format!(
+            "{:.2} GB",
+            memory_size_bytes as f64 / 1024.0 / 1024.0 / 1024.0
+        )
+    }
+}

--- a/rpc-server/src/modules/queries/utils.rs
+++ b/rpc-server/src/modules/queries/utils.rs
@@ -238,7 +238,11 @@ async fn run_code_in_vm_runner(
 #[allow(clippy::too_many_arguments)]
 #[cfg_attr(
     feature = "tracing-instrumentation",
-    tracing::instrument(skip(scylla_db_manager, compiled_contract_code_cache))
+    tracing::instrument(skip(
+        scylla_db_manager,
+        compiled_contract_code_cache,
+        contract_code_cache
+    ))
 )]
 pub async fn run_contract(
     account_id: near_primitives::types::AccountId,
@@ -247,7 +251,7 @@ pub async fn run_contract(
     scylla_db_manager: std::sync::Arc<ScyllaDBManager>,
     compiled_contract_code_cache: &std::sync::Arc<CompiledCodeCache>,
     contract_code_cache: &std::sync::Arc<
-        std::sync::RwLock<lru::LruCache<near_primitives::hash::CryptoHash, Vec<u8>>>,
+        std::sync::RwLock<crate::cache::LruMemoryCache<near_primitives::hash::CryptoHash, Vec<u8>>>,
     >,
     block: crate::modules::blocks::CacheBlock,
     max_gas_burnt: near_primitives_core::types::Gas,

--- a/rpc-server/src/utils.rs
+++ b/rpc-server/src/utils.rs
@@ -117,7 +117,11 @@ pub(crate) async fn calculate_contract_code_cache_sizes(
 
     let mem_cache_size = if let Some(limit) = limit_memory_cache {
         if limit >= available_memory {
-            panic!("Not enough memory to run the server. Available memory: {} bytes, required memory: {} bytes", available_memory, limit);
+            panic!(
+                "Not enough memory to run the server. Available memory: {}, required memory: {}",
+                crate::modules::network::friendly_memory_size_format(available_memory),
+                crate::modules::network::friendly_memory_size_format(limit),
+            );
         } else {
             limit
         }
@@ -126,6 +130,11 @@ pub(crate) async fn calculate_contract_code_cache_sizes(
     };
 
     (mem_cache_size - block_cache_size) / 2 // divide on 2 because we have 2 caches: compiled_contracts and contract_code
+}
+
+/// Convert gigabytes to bytes
+pub(crate) async fn gigabytes_to_bytes(gigabytes: f64) -> usize {
+    (gigabytes * 1024.0 * 1024.0 * 1024.0) as usize
 }
 
 /// The `shadow_compare_results` is a function that compares


### PR DESCRIPTION
We have a problem that the service crashes from time to time with an OOM error. This is most likely related to caching. I added a memory wrapper around the LRU сaсhe to avoid such situations. I also added the ability to set cache parameters via configuration. To make sense of the situation, I added information to the status method which returns the memory’s information on the server and how much memory cache takes up. 