### PR TITLE
change consystensy level for scylla db

### DIFF
--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -320,10 +320,10 @@ pub trait ScyllaStorageManager {
     ) -> anyhow::Result<PreparedStatement> {
         let mut query = scylla::statement::query::Query::new(query_text);
 
-        // If `consistency` is not set use `LocalQuorum`
         if let Some(consistency) = consistency {
             query.set_consistency(consistency);
         } else {
+            // set `Consistency::LocalQuorum` as a default consistency
             query.set_consistency(scylla::frame::types::Consistency::LocalQuorum);
         }
 
@@ -342,7 +342,7 @@ pub trait ScyllaStorageManager {
     }
 
     /// Wrapper to prepare read queries
-    /// Just a simpler way to prepare a query with `Consistency::LocalQuorum`
+    /// Just a simpler way to prepare a query with `Consistency::LocalOne`
     /// we use it as a default consistency for read queries
     async fn prepare_read_query(
         scylla_db_session: &std::sync::Arc<scylla::Session>,
@@ -351,13 +351,13 @@ pub trait ScyllaStorageManager {
         Self::prepare_query(
             scylla_db_session,
             query_text,
-            Some(scylla::frame::types::Consistency::LocalQuorum),
+            Some(scylla::frame::types::Consistency::LocalOne),
         )
         .await
     }
 
     /// Wrapper to prepare write queries
-    /// Just a simpler way to prepare a query with `Consistency::Any`
+    /// Just a simpler way to prepare a query with `Consistency::LocalQuorum`
     /// we use it as a default consistency for write queries
     async fn prepare_write_query(
         scylla_db_session: &std::sync::Arc<scylla::Session>,
@@ -366,7 +366,7 @@ pub trait ScyllaStorageManager {
         Self::prepare_query(
             scylla_db_session,
             query_text,
-            Some(scylla::frame::types::Consistency::Any),
+            Some(scylla::frame::types::Consistency::LocalQuorum),
         )
         .await
     }


### PR DESCRIPTION
In this PR we change consistency to LOCAL_ONE for read queries and to LOCAL_QUORUM for writes.

- LOCAL_ONE (especially for reads) if you don't care about the consistency of your reads, as in possibly reading old/stale data.

- LOCAL_QUORUM (always for writes) to ensure you have at least QUORUM writes on the LOCAL datacenter before the app is satisfied. This will grant you at least 66% sure that the LOCAL_ONE query will reads the most up-to-date data all the time.