### PR TITLE
add paginator into cache storage

### DIFF
--- a/tx-indexer/src/config.rs
+++ b/tx-indexer/src/config.rs
@@ -349,7 +349,7 @@ impl ScyllaStorageManager for ScyllaDBManager {
 
             cache_get_transactions: Self::prepare_read_query(
                 &scylla_db_session,
-                "SELECT transaction_details FROM tx_indexer_cache.transactions WHERE block_height <= ?",
+                "SELECT transaction_details FROM tx_indexer_cache.transactions WHERE block_height <= ? ALLOW FILTERING",
             ).await?,
 
             cache_get_receipts: Self::prepare_read_query(
@@ -514,10 +514,12 @@ impl ScyllaDBManager {
         >,
     > {
         let mut result = std::collections::HashMap::new();
+        let mut prepared_query = self.cache_get_transactions.clone();
+        prepared_query.set_page_size(10);
         let mut rows_stream = self
             .scylla_session
             .execute_iter(
-                self.cache_get_transactions.clone(),
+                prepared_query,
                 (num_bigint::BigInt::from(start_block_height),),
             )
             .await?

--- a/tx-indexer/src/config.rs
+++ b/tx-indexer/src/config.rs
@@ -98,24 +98,24 @@ impl Opts {
 impl Opts {
     pub async fn to_lake_config(
         &self,
-        scylladb_session: &std::sync::Arc<scylla::Session>,
+        start_block_height: u64,
     ) -> anyhow::Result<near_lake_framework::LakeConfig> {
         let config_builder = near_lake_framework::LakeConfigBuilder::default();
 
         Ok(match &self.chain_id {
             ChainId::Mainnet(_) => config_builder
                 .mainnet()
-                .start_block_height(get_start_block_height(self, scylladb_session).await?),
+                .start_block_height(start_block_height),
             ChainId::Testnet(_) => config_builder
                 .testnet()
-                .start_block_height(get_start_block_height(self, scylladb_session).await?),
+                .start_block_height(start_block_height),
         }
         .build()
         .expect("Failed to build LakeConfig"))
     }
 }
 
-async fn get_start_block_height(
+pub(crate) async fn get_start_block_height(
     opts: &Opts,
     scylladb_session: &std::sync::Arc<scylla::Session>,
 ) -> anyhow::Result<u64> {
@@ -349,7 +349,7 @@ impl ScyllaStorageManager for ScyllaDBManager {
 
             cache_get_transactions: Self::prepare_read_query(
                 &scylla_db_session,
-                "SELECT transaction_details FROM tx_indexer_cache.transactions",
+                "SELECT transaction_details FROM tx_indexer_cache.transactions WHERE block_height <= ?",
             ).await?,
 
             cache_get_receipts: Self::prepare_read_query(
@@ -506,6 +506,7 @@ impl ScyllaDBManager {
 
     pub(crate) async fn get_transactions_in_cache(
         &self,
+        start_block_height: u64,
     ) -> anyhow::Result<
         std::collections::HashMap<
             readnode_primitives::TransactionKey,
@@ -515,7 +516,10 @@ impl ScyllaDBManager {
         let mut result = std::collections::HashMap::new();
         let mut rows_stream = self
             .scylla_session
-            .execute_iter(self.cache_get_transactions.clone(), &[])
+            .execute_iter(
+                self.cache_get_transactions.clone(),
+                (num_bigint::BigInt::from(start_block_height),),
+            )
             .await?
             .into_typed::<(Vec<u8>,)>();
         while let Some(next_row_res) = rows_stream.next().await {

--- a/tx-indexer/src/main.rs
+++ b/tx-indexer/src/main.rs
@@ -35,12 +35,17 @@ async fn main() -> anyhow::Result<()> {
     );
     let scylla_session = scylla_db_client.scylla_session().await;
 
+    let start_block_height = config::get_start_block_height(&opts, &scylla_session).await?;
     tracing::info!(target: INDEXER, "Generating LakeConfig...");
-    let config: near_lake_framework::LakeConfig = opts.to_lake_config(&scylla_session).await?;
+    let config: near_lake_framework::LakeConfig = opts.to_lake_config(start_block_height).await?;
 
     tracing::info!(target: INDEXER, "Creating hash storage...");
     let tx_collecting_storage = std::sync::Arc::new(
-        storage::database::HashStorageWithDB::init_with_restore(scylla_db_client.clone()).await?,
+        storage::database::HashStorageWithDB::init_with_restore(
+            scylla_db_client.clone(),
+            start_block_height,
+        )
+        .await?,
     );
 
     tracing::info!(target: INDEXER, "Instantiating the stream...",);

--- a/tx-indexer/src/storage/database.rs
+++ b/tx-indexer/src/storage/database.rs
@@ -39,19 +39,23 @@ impl HashStorageWithDB {
     /// Init storage with restore transactions with receipts after interruption
     pub(crate) async fn init_with_restore(
         scylla_db_client: std::sync::Arc<crate::config::ScyllaDBManager>,
+        start_block_height: u64,
     ) -> anyhow::Result<Self> {
         let storage = Self::init_storage(scylla_db_client).await;
         storage
-            .restore_transactions_with_receipts_after_interruption()
+            .restore_transactions_with_receipts_after_interruption(start_block_height)
             .await?;
         Ok(storage)
     }
 
     /// Restore transactions with receipts after interruption
-    async fn restore_transactions_with_receipts_after_interruption(&self) -> anyhow::Result<()> {
+    async fn restore_transactions_with_receipts_after_interruption(
+        &self,
+        start_block_height: u64,
+    ) -> anyhow::Result<()> {
         for (transaction_key, transaction_details) in self
             .scylla_db_manager
-            .get_transactions_in_cache()
+            .get_transactions_in_cache(start_block_height)
             .await?
             .iter()
         {


### PR DESCRIPTION
In this PR we added a paginator in to query to read all transactions in the process. We did it because Scylla db failed when we tried to scan all rows in the table on start.