### PR TITLE
change consistency level for read queries on LocalQuorum

### DIFF
--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -342,7 +342,7 @@ pub trait ScyllaStorageManager {
     }
 
     /// Wrapper to prepare read queries
-    /// Just a simpler way to prepare a query with `Consistency::LocalOne`
+    /// Just a simpler way to prepare a query with `Consistency::LocalQuorum`
     /// we use it as a default consistency for read queries
     async fn prepare_read_query(
         scylla_db_session: &std::sync::Arc<scylla::Session>,
@@ -351,7 +351,7 @@ pub trait ScyllaStorageManager {
         Self::prepare_query(
             scylla_db_session,
             query_text,
-            Some(scylla::frame::types::Consistency::LocalOne),
+            Some(scylla::frame::types::Consistency::LocalQuorum),
         )
         .await
     }


### PR DESCRIPTION
After repairing Scylla DC if we want to 100% guarantee data correctness and data consistency, Scylla Team recommended set to read + write with CL=LOCAL_QUORUM to accomplish CL=W + CL=R > RF --> 2/3 + 2/3 > RF=3 --> 4 > 3