### PR TITLE
fix(rpc-server): Fix the name of the feature in the `Cargo.toml` that enables write-methods proxy

### DIFF
--- a/rpc-server/Cargo.toml
+++ b/rpc-server/Cargo.toml
@@ -60,8 +60,8 @@ near-vm-errors = "0.17.0"
 
 
 [features]
-default = ["submit_tx_methods", "scylla_db"]
-submit_tx_methods = []
+default = ["send_tx_methods", "scylla_db"]
+send_tx_methods = []
 tracing-instrumentation = []
 postgres_db = ["database/postgres_db"]
 scylla_db = ["database/scylla_db"]

--- a/rpc-server/Dockerfile
+++ b/rpc-server/Dockerfile
@@ -1,5 +1,5 @@
 FROM rust:1.69 AS builder
-ARG features=""
+ARG features="default"
 WORKDIR /tmp/
 
 COPY Cargo.lock ./

--- a/state-indexer/Dockerfile
+++ b/state-indexer/Dockerfile
@@ -1,5 +1,5 @@
 FROM rust:1.69 AS builder
-ARG features=""
+ARG features="default"
 WORKDIR /tmp/
 
 COPY Cargo.lock ./

--- a/tx-indexer/Dockerfile
+++ b/tx-indexer/Dockerfile
@@ -1,5 +1,5 @@
 FROM rust:1.69 AS builder
-ARG features=""
+ARG features="default"
 WORKDIR /tmp/
 
 COPY Cargo.lock ./


### PR DESCRIPTION
Previously, I have messed up the feature of enabling/disabling proxying write methods (send-tx ones).

The feature name declared in the `Cargo.toml` of the project was not the same as in the code 😅.

This PR fixes it, and I confirm that sending transactions through ReadRPC via `near-cli-rs` works like a charm.

Also, `Dockerfile`s we have with the `ARGS feature="` declines the default feature on the build, so I had to add a `default` value there.

For future reference, if you want to build a project with default features and some additional one(s), you need to pass `--build-arg="features=default, another_feature"` (include the **default** word) in the `docker build` command.