### PR TITLE
fix docker build

### DIFF
--- a/rpc-server/Dockerfile
+++ b/rpc-server/Dockerfile
@@ -3,7 +3,8 @@ ARG features="default"
 WORKDIR /tmp/
 
 COPY Cargo.lock ./
-RUN echo '[workspace]\nmembers = ["rpc-server", "database", "readnode-primitives"]' > Cargo.toml
+COPY Cargo.toml ./
+RUN sed '/perf-testing/d; /state-indexer/d; /tx-indexer/d' Cargo.toml > Cargo.toml.new && mv Cargo.toml.new Cargo.toml
 COPY rpc-server/Cargo.toml rpc-server/Cargo.toml
 COPY database database
 COPY readnode-primitives readnode-primitives

--- a/state-indexer/Dockerfile
+++ b/state-indexer/Dockerfile
@@ -3,7 +3,8 @@ ARG features="default"
 WORKDIR /tmp/
 
 COPY Cargo.lock ./
-RUN echo '[workspace]\nmembers = ["state-indexer", "database", "readnode-primitives"]' > Cargo.toml
+COPY Cargo.toml ./
+RUN sed '/perf-testing/d; /rpc-server/d; /tx-indexer/d' Cargo.toml > Cargo.toml.new && mv Cargo.toml.new Cargo.toml
 COPY state-indexer/Cargo.toml state-indexer/Cargo.toml
 COPY database database
 COPY readnode-primitives readnode-primitives

--- a/tx-indexer/Dockerfile
+++ b/tx-indexer/Dockerfile
@@ -3,7 +3,8 @@ ARG features="default"
 WORKDIR /tmp/
 
 COPY Cargo.lock ./
-RUN echo '[workspace]\nmembers = ["tx-indexer", "database", "readnode-primitives"]' > Cargo.toml
+COPY Cargo.toml ./
+RUN sed '/perf-testing/d; /rpc-server/d; /state-indexer/d' Cargo.toml > Cargo.toml.new && mv Cargo.toml.new Cargo.toml
 COPY tx-indexer/Cargo.toml tx-indexer/Cargo.toml
 COPY database database
 COPY readnode-primitives readnode-primitives


### PR DESCRIPTION
In the https://github.com/near/read-rpc/pull/139 we used `[patch.crates-io]` which should be grown at the top level.
During the build, we ignored this patch and therefore received a message about unavailable dependencies. 
Now we leave the Cargo.toml and remove the unnecessary modules when building. 