### PR TITLE
refactor(rpc-server): Add CORS to allow any origin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-cors"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0346d8c1f762b41b458ed3145eea914966bb9ad20b9be0d6d463b20d45586370"
+dependencies = [
+ "actix-utils",
+ "actix-web",
+ "derive_more",
+ "futures-util",
+ "log",
+ "once_cell",
+ "smallvec",
+]
+
+[[package]]
 name = "actix-http"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4350,6 +4365,7 @@ dependencies = [
 name = "read-rpc-server"
 version = "0.1.0"
 dependencies = [
+ "actix-cors",
  "actix-web",
  "anyhow",
  "assert-json-diff",

--- a/rpc-server/Cargo.toml
+++ b/rpc-server/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 actix-web = "4.2.1"
+actix-cors = "0.6.5"
 anyhow = "1.0.70"
 assert-json-diff = { version = "2.0.2", optional = true }
 aws-credential-types = "0.53.0"

--- a/rpc-server/src/main.rs
+++ b/rpc-server/src/main.rs
@@ -221,7 +221,17 @@ async fn main() -> anyhow::Result<()> {
 
     actix_web::HttpServer::new(move || {
         let rpc = rpc.clone();
+
+        // Configure CORS
+        let cors = actix_cors::Cors::default()
+            .allow_any_origin()
+            .allowed_methods(vec!["GET", "POST", "OPTIONS"])
+            .allowed_headers(vec![http::header::ACCEPT])
+            .expose_any_header()
+            .max_age(3600);
+
         actix_web::App::new()
+            .wrap(cors)
             .wrap(tracing_actix_web::TracingLogger::default())
             .service(
                 actix_web::web::service("/")


### PR DESCRIPTION
This PR adds a setup for CORS to allow any origin to enable querying the server from the browser (required for NEAR BOS-component integrations)