### PR TITLE
remove `view_state` limit

### DIFF
--- a/database/src/base/rpc_server.rs
+++ b/database/src/base/rpc_server.rs
@@ -31,7 +31,10 @@ pub trait ReaderDbManager {
         account_id: &near_primitives::types::AccountId,
         block_height: near_primitives::types::BlockHeight,
         key_data: readnode_primitives::StateKey,
-    ) -> anyhow::Result<readnode_primitives::StateValue>;
+    ) -> (
+        readnode_primitives::StateKey,
+        readnode_primitives::StateValue,
+    );
 
     /// Returns the near_primitives::account::Account at the given block height
     async fn get_account(

--- a/rpc-server/src/modules/queries/mod.rs
+++ b/rpc-server/src/modules/queries/mod.rs
@@ -5,8 +5,6 @@ use std::collections::HashMap;
 pub mod methods;
 pub mod utils;
 
-const MAX_LIMIT: u8 = 100;
-
 pub type Result<T> = ::std::result::Result<T, near_vm_runner::logic::VMLogicError>;
 
 pub struct CodeStorage {
@@ -69,14 +67,12 @@ impl near_vm_runner::logic::External for CodeStorage {
         let get_db_data =
             self.db_manager
                 .get_state_key_value(&self.account_id, self.block_height, key.to_vec());
-        match block_on(get_db_data) {
-            Ok(data) => Ok(if !data.is_empty() {
-                Some(Box::new(StorageValuePtr { value: data }) as Box<_>)
-            } else {
-                None
-            }),
-            Err(_) => Ok(None),
-        }
+        let (_, data) = block_on(get_db_data);
+        Ok(if !data.is_empty() {
+            Some(Box::new(StorageValuePtr { value: data }) as Box<_>)
+        } else {
+            None
+        })
     }
 
     #[cfg_attr(feature = "tracing-instrumentation", tracing::instrument(skip(self)))]
@@ -109,10 +105,8 @@ impl near_vm_runner::logic::External for CodeStorage {
         let get_db_state_keys =
             self.db_manager
                 .get_state_key_value(&self.account_id, self.block_height, key.to_vec());
-        match block_on(get_db_state_keys) {
-            Ok(data) => Ok(!data.is_empty()),
-            Err(_) => Ok(false),
-        }
+        let (_, data) = block_on(get_db_state_keys);
+        Ok(!data.is_empty())
     }
 
     #[cfg_attr(feature = "tracing-instrumentation", tracing::instrument(skip(self)))]


### PR DESCRIPTION
**Changes Implemented**

**1. Removed Key Limit:** The previously imposed limitation on the number of keys in a state has been eliminated. This means our system can now handle a larger volume of keys without restrictions.
**2. Optimization of Queries:** We've implemented optimizations for both key and value queries. This enhancement ensures improved efficiency and performance when retrieving information related to keys and their corresponding values.

**Temporary Solution**
It's important to note that while these changes represent a substantial improvement, this solution is temporary. Although the system now allows for handling a greater number of keys, there's no absolute guarantee for handling exceptionally large datasets, such as those in the gigabyte range.

**Future Steps**

**1. Pagination Implementation:** The upcoming step will introduce new endpoints designed explicitly for pagination. These endpoints will facilitate the handling of large states by allowing the data to be retrieved in manageable chunks or pages.
**2. Guaranteed Retrieval for Large States**: These new endpoints will guarantee the retrieval of all keys, even for states with massive data volumes, ensuring that clients can reliably access and process extensive datasets without constraints.

This pull request lays the groundwork for future improvements, acknowledging the current enhancements while also outlining a clear path for addressing the handling of exceptionally large datasets in the upcoming iterations of the system.






