### PR TITLE
fix(rpc-server): Set permissive CORS

### DIFF
--- a/rpc-server/src/main.rs
+++ b/rpc-server/src/main.rs
@@ -223,12 +223,7 @@ async fn main() -> anyhow::Result<()> {
         let rpc = rpc.clone();
 
         // Configure CORS
-        let cors = actix_cors::Cors::default()
-            .allow_any_origin()
-            .allowed_methods(vec!["GET", "POST", "OPTIONS"])
-            .allowed_headers(vec![http::header::ACCEPT])
-            .expose_any_header()
-            .max_age(3600);
+        let cors = actix_cors::Cors::permissive();
 
         actix_web::App::new()
             .wrap(cors)


### PR DESCRIPTION
Previous PR #143 used to work during the local check but suddenly stopped. This one makes sure it's working.