### PR TITLE
(rpc-server): add new endpoint view_state_paginated

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1700,6 +1700,7 @@ dependencies = [
  "async-trait",
  "bigdecimal 0.4.2",
  "borsh 0.10.3",
+ "bytes",
  "diesel",
  "diesel-async",
  "futures",

--- a/database/Cargo.toml
+++ b/database/Cargo.toml
@@ -8,6 +8,7 @@ anyhow = "1.0.70"
 async-trait = "0.1.66"
 bigdecimal = { version = "0.4.2", optional = true }
 borsh = "0.10.2"
+bytes = "1.0.1"
 diesel = { version = "2.1.3", features = ["postgres", "numeric", "serde_json"], optional = true }
 diesel-async = { version = "0.4.1", features = ["postgres", "deadpool"], optional = true }
 futures = "0.3.5"

--- a/database/src/base/mod.rs
+++ b/database/src/base/mod.rs
@@ -42,6 +42,8 @@ pub struct AdditionalDatabaseOptions {
     pub database_name: Option<String>,
 }
 
+pub type PageToken = Option<String>;
+
 #[async_trait::async_trait]
 pub trait BaseDbManager {
     async fn new(

--- a/database/src/base/rpc_server.rs
+++ b/database/src/base/rpc_server.rs
@@ -18,11 +18,12 @@ pub trait ReaderDbManager {
         account_id: &near_primitives::types::AccountId,
     ) -> anyhow::Result<Vec<readnode_primitives::StateKey>>;
 
+    /// Returns state keys for the given account id by page
     async fn get_state_keys_by_page(
         &self,
         account_id: &near_primitives::types::AccountId,
-        page_state: Option<String>,
-    ) -> anyhow::Result<(Vec<readnode_primitives::StateKey>, Option<String>)>;
+        page_token: crate::PageToken,
+    ) -> anyhow::Result<(Vec<readnode_primitives::StateKey>, crate::PageToken)>;
 
     /// Returns state keys for the given account id filtered by the given prefix
     async fn get_state_keys_by_prefix(

--- a/database/src/base/rpc_server.rs
+++ b/database/src/base/rpc_server.rs
@@ -18,6 +18,12 @@ pub trait ReaderDbManager {
         account_id: &near_primitives::types::AccountId,
     ) -> anyhow::Result<Vec<readnode_primitives::StateKey>>;
 
+    async fn get_state_keys_by_page(
+        &self,
+        account_id: &near_primitives::types::AccountId,
+        page_state: Option<String>,
+    ) -> anyhow::Result<(Vec<readnode_primitives::StateKey>, Option<String>)>;
+
     /// Returns state keys for the given account id filtered by the given prefix
     async fn get_state_keys_by_prefix(
         &self,

--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -1,10 +1,10 @@
 mod base;
 
-pub use crate::base::AdditionalDatabaseOptions;
 use crate::base::BaseDbManager;
 pub use crate::base::ReaderDbManager;
 pub use crate::base::StateIndexerDbManager;
 pub use crate::base::TxIndexerDbManager;
+pub use crate::base::{AdditionalDatabaseOptions, PageToken};
 
 #[cfg(feature = "scylla_db")]
 pub mod scylladb;

--- a/database/src/postgres/rpc_server.rs
+++ b/database/src/postgres/rpc_server.rs
@@ -98,10 +98,20 @@ impl crate::ReaderDbManager for PostgresDBManager {
 
     async fn get_state_keys_by_page(
         &self,
-        _account_id: &near_primitives::types::AccountId,
-        _page_state: Option<String>,
-    ) -> anyhow::Result<(Vec<readnode_primitives::StateKey>, Option<String>)> {
-        todo!()
+        account_id: &near_primitives::types::AccountId,
+        page_token: crate::PageToken,
+    ) -> anyhow::Result<(Vec<readnode_primitives::StateKey>, crate::PageToken)> {
+        let (state_keys, next_page_token) = crate::models::AccountState::get_state_keys_by_page(
+            Self::get_connection(&self.pg_pool).await?,
+            account_id,
+            page_token,
+        )
+        .await?;
+
+        let keys = state_keys
+            .into_iter()
+            .filter_map(|key| hex::decode(key).ok());
+        Ok((keys.collect(), next_page_token))
     }
 
     async fn get_state_key_value(

--- a/database/src/postgres/rpc_server.rs
+++ b/database/src/postgres/rpc_server.rs
@@ -96,6 +96,14 @@ impl crate::ReaderDbManager for PostgresDBManager {
         Ok(result.collect())
     }
 
+    async fn get_state_keys_by_page(
+        &self,
+        _account_id: &near_primitives::types::AccountId,
+        _page_state: Option<String>,
+    ) -> anyhow::Result<(Vec<readnode_primitives::StateKey>, Option<String>)> {
+        todo!()
+    }
+
     async fn get_state_key_value(
         &self,
         account_id: &near_primitives::types::AccountId,

--- a/database/src/scylladb/rpc_server.rs
+++ b/database/src/scylladb/rpc_server.rs
@@ -175,7 +175,11 @@ impl crate::ReaderDbManager for ScyllaDBManager {
             })
     }
 
-    /// Returns all state keys for the given account id
+    /// Returns 25000 state keys for the given account id
+    /// We limited the number of state keys returned because of the following reasons:
+    /// 1. The query is very slow and takes a lot of time to execute
+    /// 2. The contract state could be very large and we don't want to return all of it at once
+    /// To get all state keys use `get_state_keys_by_page` method
     async fn get_state_keys_all(
         &self,
         account_id: &near_primitives::types::AccountId,
@@ -187,25 +191,29 @@ impl crate::ReaderDbManager for ScyllaDBManager {
             .execute_iter(paged_query, (account_id.to_string(),))
             .await?
             .into_typed::<(String,)>();
-        let mut stata_keys = vec![];
+        let mut state_keys = vec![];
         while let Some(next_row_res) = rows_stream.next().await {
             let (value,): (String,) = next_row_res?;
-            stata_keys.push(hex::decode(value)?);
+            state_keys.push(hex::decode(value)?);
         }
-        Ok(stata_keys)
+        Ok(state_keys)
     }
 
+    /// Return contract state keys by page
+    /// The page size is 1000 keys
+    /// The page_token is a hex string of the scylla page_state
+    /// On the first call the page_token should be None
+    /// On the last page the page_token will be None
     async fn get_state_keys_by_page(
         &self,
         account_id: &near_primitives::types::AccountId,
-        page_state: Option<String>,
-    ) -> anyhow::Result<(Vec<readnode_primitives::StateKey>, Option<String>)> {
+        page_token: crate::PageToken,
+    ) -> anyhow::Result<(Vec<readnode_primitives::StateKey>, crate::PageToken)> {
         let mut paged_query = self.get_all_state_keys.clone();
         paged_query.set_page_size(1000);
 
-        let result = if let Some(page_state) = page_state {
-            let page_bytes = hex::decode(page_state)?;
-            let page_state = bytes::Bytes::from(page_bytes);
+        let result = if let Some(page_state) = page_token {
+            let page_state = bytes::Bytes::from(hex::decode(page_state)?);
             self.scylla_session
                 .execute_paged(&paged_query, (account_id.to_string(),), Some(page_state))
                 .await?
@@ -218,13 +226,13 @@ impl crate::ReaderDbManager for ScyllaDBManager {
             .await?
         };
 
-        let new_page_state = result.paging_state.as_ref().map(hex::encode);
+        let new_page_token = result.paging_state.as_ref().map(hex::encode);
 
-        let stata_keys = result
+        let state_keys = result
             .rows_typed::<(String,)>()?
             .filter_map(|row| row.ok().and_then(|(value,)| hex::decode(value).ok()));
 
-        Ok((stata_keys.collect(), new_page_state))
+        Ok((state_keys.collect(), new_page_token))
     }
 
     /// Returns state keys for the given account id filtered by the given prefix

--- a/rpc-server/src/main.rs
+++ b/rpc-server/src/main.rs
@@ -169,6 +169,10 @@ async fn main() -> anyhow::Result<()> {
     let rpc = Server::new()
         .with_data(Data::new(state))
         .with_method("query", modules::queries::methods::query)
+        .with_method(
+            "view_state_paginated",
+            modules::state::methods::view_state_paginated,
+        )
         .with_method("block", modules::blocks::methods::block)
         .with_method(
             "EXPERIMENTAL_changes",

--- a/rpc-server/src/modules/mod.rs
+++ b/rpc-server/src/modules/mod.rs
@@ -4,4 +4,5 @@ pub mod gas;
 pub mod network;
 pub mod queries;
 pub mod receipts;
+pub mod state;
 pub mod transactions;

--- a/rpc-server/src/modules/queries/utils.rs
+++ b/rpc-server/src/modules/queries/utils.rs
@@ -4,6 +4,7 @@ use std::ops::Deref;
 #[cfg(feature = "account_access_keys")]
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
+use futures::StreamExt;
 use near_crypto::{KeyType, PublicKey};
 use near_primitives::utils::create_random_seed;
 use tokio::task;
@@ -28,7 +29,7 @@ pub async fn get_state_keys_from_db(
     account_id: &near_primitives::types::AccountId,
     block_height: near_primitives::types::BlockHeight,
     prefix: &[u8],
-) -> HashMap<Vec<u8>, Vec<u8>> {
+) -> HashMap<readnode_primitives::StateKey, readnode_primitives::StateValue> {
     tracing::debug!(
         "`get_state_keys_from_db` call. AccountId {}, block {}, prefix {:?}",
         account_id,
@@ -48,16 +49,16 @@ pub async fn get_state_keys_from_db(
     };
     match result {
         Ok(state_keys) => {
-            for state_keys_chunk in state_keys.chunks(1000) {
-                // TODO: 1000 is hardcoded value. Make it configurable.
-                let mut tasks_futures = vec![];
+            for state_keys_chunk in state_keys.chunks(2400) {
+                // 3 nodes * 8 cpus * 100 = 2400
+                // TODO: 2400 is hardcoded value. Make it configurable.
+                let mut tasks = futures::stream::FuturesUnordered::new();
                 for state_key in state_keys_chunk {
                     let state_value_result_future =
                         db_manager.get_state_key_value(account_id, block_height, state_key.clone());
-                    tasks_futures.push(state_value_result_future);
+                    tasks.push(state_value_result_future);
                 }
-                let results = futures::future::join_all(tasks_futures).await;
-                for (state_key, state_value) in results.into_iter() {
+                while let Some((state_key, state_value)) = tasks.next().await {
                     if !state_value.is_empty() {
                         data.insert(state_key, state_value);
                     }
@@ -124,14 +125,13 @@ pub async fn fetch_state_from_db(
     if state_from_db.is_empty() {
         anyhow::bail!("Data not found in db")
     } else {
-        let mut values = Vec::new();
-        for (key, value) in state_from_db.iter() {
-            let state_item = near_primitives::views::StateItem {
-                key: key.to_vec().into(),
-                value: value.to_vec().into(),
-            };
-            values.push(state_item)
-        }
+        let values = state_from_db
+            .into_iter()
+            .map(|(key, value)| near_primitives::views::StateItem {
+                key: key.into(),
+                value: value.into(),
+            })
+            .collect();
         Ok(near_primitives::views::ViewStateResult {
             values,
             proof: vec![], // TODO: this is hardcoded empty value since we don't support proofs yet

--- a/rpc-server/src/modules/state/methods.rs
+++ b/rpc-server/src/modules/state/methods.rs
@@ -1,0 +1,30 @@
+use crate::config::ServerContext;
+use crate::errors::RPCError;
+use crate::modules::blocks::utils::fetch_block_from_cache_or_get;
+use crate::modules::state::utils::get_state_keys_from_db_paginated;
+use jsonrpc_v2::{Data, Params};
+
+pub async fn view_state_paginated(
+    data: Data<ServerContext>,
+    Params(params): Params<crate::modules::state::RpcViewStatePaginatedRequest>,
+) -> Result<crate::modules::state::RpcViewStatePaginatedResponse, RPCError> {
+    let block_reference = near_primitives::types::BlockReference::BlockId(params.block_id.clone());
+    let block = fetch_block_from_cache_or_get(&data, block_reference)
+        .await
+        .map_err(near_jsonrpc_primitives::errors::RpcError::from)?;
+
+    let state_value = get_state_keys_from_db_paginated(
+        &data.db_manager,
+        &params.account_id,
+        block.block_height,
+        params.next_page,
+    )
+    .await;
+
+    Ok(crate::modules::state::RpcViewStatePaginatedResponse {
+        values: state_value.values,
+        next_page: state_value.next_page,
+        block_height: block.block_height,
+        block_hash: block.block_hash,
+    })
+}

--- a/rpc-server/src/modules/state/methods.rs
+++ b/rpc-server/src/modules/state/methods.rs
@@ -13,17 +13,17 @@ pub async fn view_state_paginated(
         .await
         .map_err(near_jsonrpc_primitives::errors::RpcError::from)?;
 
-    let state_value = get_state_keys_from_db_paginated(
+    let state_values = get_state_keys_from_db_paginated(
         &data.db_manager,
         &params.account_id,
         block.block_height,
-        params.next_page,
+        params.next_page_token,
     )
     .await;
 
     Ok(crate::modules::state::RpcViewStatePaginatedResponse {
-        values: state_value.values,
-        next_page: state_value.next_page,
+        values: state_values.values,
+        next_page_token: state_values.next_page_token,
         block_height: block.block_height,
         block_hash: block.block_hash,
     })

--- a/rpc-server/src/modules/state/mod.rs
+++ b/rpc-server/src/modules/state/mod.rs
@@ -1,16 +1,17 @@
 pub mod methods;
 pub mod utils;
 
+#[derive(Default, Debug)]
 pub struct PageStateValues {
     pub values: Vec<near_primitives::views::StateItem>,
-    pub next_page: Option<String>,
+    pub next_page_token: database::PageToken,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Debug)]
 pub struct RpcViewStatePaginatedRequest {
     pub account_id: near_primitives::types::AccountId,
     pub block_id: near_primitives::types::BlockId,
-    pub next_page: Option<String>,
+    pub next_page_token: database::PageToken,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Debug)]
@@ -18,5 +19,5 @@ pub struct RpcViewStatePaginatedResponse {
     pub values: Vec<near_primitives::views::StateItem>,
     pub block_height: near_primitives::types::BlockHeight,
     pub block_hash: near_primitives::hash::CryptoHash,
-    pub next_page: Option<String>,
+    pub next_page_token: database::PageToken,
 }

--- a/rpc-server/src/modules/state/mod.rs
+++ b/rpc-server/src/modules/state/mod.rs
@@ -1,0 +1,22 @@
+pub mod methods;
+pub mod utils;
+
+pub struct PageStateValues {
+    pub values: Vec<near_primitives::views::StateItem>,
+    pub next_page: Option<String>,
+}
+
+#[derive(serde::Serialize, serde::Deserialize, Debug)]
+pub struct RpcViewStatePaginatedRequest {
+    pub account_id: near_primitives::types::AccountId,
+    pub block_id: near_primitives::types::BlockId,
+    pub next_page: Option<String>,
+}
+
+#[derive(serde::Serialize, serde::Deserialize, Debug)]
+pub struct RpcViewStatePaginatedResponse {
+    pub values: Vec<near_primitives::views::StateItem>,
+    pub block_height: near_primitives::types::BlockHeight,
+    pub block_hash: near_primitives::hash::CryptoHash,
+    pub next_page: Option<String>,
+}

--- a/rpc-server/src/modules/state/utils.rs
+++ b/rpc-server/src/modules/state/utils.rs
@@ -9,47 +9,41 @@ pub async fn get_state_keys_from_db_paginated(
     db_manager: &std::sync::Arc<Box<dyn database::ReaderDbManager + Sync + Send + 'static>>,
     account_id: &near_primitives::types::AccountId,
     block_height: near_primitives::types::BlockHeight,
-    page_state: Option<String>,
+    page_token: database::PageToken,
 ) -> crate::modules::state::PageStateValues {
     tracing::debug!(
-        "`get_state_keys_from_db_paginated` call. AccountId {}, block {}, page_state {:?}",
+        "`get_state_keys_from_db_paginated` call. AccountId {}, block {}, page_token {:?}",
         account_id,
         block_height,
-        page_state,
+        page_token,
     );
-    let mut data: HashMap<readnode_primitives::StateKey, readnode_primitives::StateValue> =
-        HashMap::new();
-    let mut new_page_state = None;
-    let result = db_manager
-        .get_state_keys_by_page(account_id, page_state)
-        .await;
-    if let Ok((state_keys, page_state)) = result {
-        new_page_state = page_state;
-        for state_keys_chunk in state_keys.chunks(1000) {
-            // 3 nodes * 8 cpus * 100 = 2400
-            // TODO: 2400 is hardcoded value. Make it configurable.
-            let mut tasks = futures::stream::FuturesUnordered::new();
-            for state_key in state_keys_chunk {
-                let state_value_result_future =
-                    db_manager.get_state_key_value(account_id, block_height, state_key.clone());
-                tasks.push(state_value_result_future);
-            }
-            while let Some((state_key, state_value)) = tasks.next().await {
-                if !state_value.is_empty() {
-                    data.insert(state_key, state_value);
-                }
+    if let Ok((state_keys, next_page_token)) = db_manager
+        .get_state_keys_by_page(account_id, page_token)
+        .await
+    {
+        let futures = state_keys.iter().map(|state_key| {
+            db_manager.get_state_key_value(account_id, block_height, state_key.clone())
+        });
+        let mut tasks = futures::stream::FuturesUnordered::from_iter(futures);
+        let mut data: HashMap<readnode_primitives::StateKey, readnode_primitives::StateValue> =
+            HashMap::new();
+        while let Some((state_key, state_value)) = tasks.next().await {
+            if !state_value.is_empty() {
+                data.insert(state_key, state_value);
             }
         }
-    }
-    let values = data
-        .into_iter()
-        .map(|(key, value)| near_primitives::views::StateItem {
-            key: key.into(),
-            value: value.into(),
-        })
-        .collect();
-    crate::modules::state::PageStateValues {
-        values,
-        next_page: new_page_state,
+        let values = data
+            .into_iter()
+            .map(|(key, value)| near_primitives::views::StateItem {
+                key: key.into(),
+                value: value.into(),
+            })
+            .collect();
+        crate::modules::state::PageStateValues {
+            values,
+            next_page_token,
+        }
+    } else {
+        crate::modules::state::PageStateValues::default()
     }
 }

--- a/rpc-server/src/modules/state/utils.rs
+++ b/rpc-server/src/modules/state/utils.rs
@@ -1,0 +1,55 @@
+use futures::StreamExt;
+use std::collections::HashMap;
+
+#[cfg_attr(
+    feature = "tracing-instrumentation",
+    tracing::instrument(skip(db_manager))
+)]
+pub async fn get_state_keys_from_db_paginated(
+    db_manager: &std::sync::Arc<Box<dyn database::ReaderDbManager + Sync + Send + 'static>>,
+    account_id: &near_primitives::types::AccountId,
+    block_height: near_primitives::types::BlockHeight,
+    page_state: Option<String>,
+) -> crate::modules::state::PageStateValues {
+    tracing::debug!(
+        "`get_state_keys_from_db_paginated` call. AccountId {}, block {}, page_state {:?}",
+        account_id,
+        block_height,
+        page_state,
+    );
+    let mut data: HashMap<readnode_primitives::StateKey, readnode_primitives::StateValue> =
+        HashMap::new();
+    let mut new_page_state = None;
+    let result = db_manager
+        .get_state_keys_by_page(account_id, page_state)
+        .await;
+    if let Ok((state_keys, page_state)) = result {
+        new_page_state = page_state;
+        for state_keys_chunk in state_keys.chunks(1000) {
+            // 3 nodes * 8 cpus * 100 = 2400
+            // TODO: 2400 is hardcoded value. Make it configurable.
+            let mut tasks = futures::stream::FuturesUnordered::new();
+            for state_key in state_keys_chunk {
+                let state_value_result_future =
+                    db_manager.get_state_key_value(account_id, block_height, state_key.clone());
+                tasks.push(state_value_result_future);
+            }
+            while let Some((state_key, state_value)) = tasks.next().await {
+                if !state_value.is_empty() {
+                    data.insert(state_key, state_value);
+                }
+            }
+        }
+    }
+    let values = data
+        .into_iter()
+        .map(|(key, value)| near_primitives::views::StateItem {
+            key: key.into(),
+            value: value.into(),
+        })
+        .collect();
+    crate::modules::state::PageStateValues {
+        values,
+        next_page: new_page_state,
+    }
+}


### PR DESCRIPTION
This pull request introduces a new API endpoint named `view_state_paginated` designed to facilitate paginated viewing of contract states.

New Endpoint: `view_state_paginated`
1. This endpoint is specifically crafted to facilitate paginated requests for retrieving contract states.
2. Implements the necessary logic to fetch contract states in paginated form based on specified parameters.

The primary objective of this addition is to enhance the contract management functionality by providing a more efficient and organized method to access contract states. The paginated view enables users to retrieve contract states in smaller, manageable segments, thereby improving system performance and simplifying navigation, especially when dealing with extensive contract data.
