### PR TITLE
(state-indexer): Bug with indexing epoch validators info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4550,6 +4550,7 @@ dependencies = [
  "dotenv",
  "erased-serde",
  "futures",
+ "futures-locks",
  "hex",
  "http",
  "jsonrpc-v2",

--- a/database/src/base/rpc_server.rs
+++ b/database/src/base/rpc_server.rs
@@ -90,11 +90,20 @@ pub trait ReaderDbManager {
         block_height: near_primitives::types::BlockHeight,
         shard_id: near_primitives::types::ShardId,
     ) -> anyhow::Result<readnode_primitives::BlockHeightShardId>;
+
+    /// Returns epoch validators info by the given epoch id
     async fn get_validators_by_epoch_id(
         &self,
         epoch_id: near_primitives::hash::CryptoHash,
     ) -> anyhow::Result<readnode_primitives::EpochValidatorsInfo>;
 
+    /// Return epoch validators info by the given epoch end block height
+    async fn get_validators_by_end_block_height(
+        &self,
+        block_height: near_primitives::types::BlockHeight,
+    ) -> anyhow::Result<readnode_primitives::EpochValidatorsInfo>;
+
+    /// Return protocol config by the given epoch id
     async fn get_protocol_config_by_epoch_id(
         &self,
         epoch_id: near_primitives::hash::CryptoHash,

--- a/database/src/base/state_indexer.rs
+++ b/database/src/base/state_indexer.rs
@@ -104,6 +104,11 @@ pub trait StateIndexerDbManager {
         )>,
     ) -> anyhow::Result<()>;
 
+    async fn get_block_by_hash(
+        &self,
+        block_hash: near_primitives::hash::CryptoHash,
+    ) -> anyhow::Result<u64>;
+
     async fn update_meta(&self, indexer_id: &str, block_height: u64) -> anyhow::Result<()>;
     async fn get_last_processed_block_height(&self, indexer_id: &str) -> anyhow::Result<u64>;
     async fn add_validators(
@@ -120,5 +125,11 @@ pub trait StateIndexerDbManager {
         epoch_height: u64,
         epoch_start_height: u64,
         protocol_config: &near_chain_configs::ProtocolConfigView,
+    ) -> anyhow::Result<()>;
+
+    async fn update_epoch_end_height(
+        &self,
+        epoch_id: near_indexer_primitives::CryptoHash,
+        epoch_end_block_hash: near_indexer_primitives::CryptoHash,
     ) -> anyhow::Result<()>;
 }

--- a/database/src/postgres/migrations/2023-12-07-144820_epochs/up.sql
+++ b/database/src/postgres/migrations/2023-12-07-144820_epochs/up.sql
@@ -2,6 +2,7 @@ CREATE TABLE IF NOT EXISTS validators (
     epoch_id text NOT NULL,
     epoch_height numeric(20,0) NOT NULL,
     epoch_start_height numeric(20,0) NOT NULL,
+    epoch_end_height numeric(20,0) NULL,
     validators_info jsonb NOT NULL
 );
 
@@ -13,6 +14,7 @@ CREATE TABLE IF NOT EXISTS protocol_configs (
     epoch_id text NOT NULL,
     epoch_height numeric(20,0) NOT NULL,
     epoch_start_height numeric(20,0) NOT NULL,
+    epoch_end_height numeric(20,0) NULL,
     protocol_config jsonb NOT NULL
 );
 

--- a/database/src/postgres/models.rs
+++ b/database/src/postgres/models.rs
@@ -709,6 +709,18 @@ impl Validators {
 
         Ok(response)
     }
+    pub async fn get_validators_epoch_end_height(
+        mut conn: crate::postgres::PgAsyncConn,
+        epoch_end_height: bigdecimal::BigDecimal,
+    ) -> anyhow::Result<Self> {
+        let response = validators::table
+            .filter(validators::epoch_end_height.eq(epoch_end_height))
+            .select(Self::as_select())
+            .first(&mut conn)
+            .await?;
+
+        Ok(response)
+    }
 }
 
 #[derive(Insertable, Queryable, Selectable)]

--- a/database/src/postgres/models.rs
+++ b/database/src/postgres/models.rs
@@ -667,6 +667,7 @@ pub struct Validators {
     pub epoch_id: String,
     pub epoch_height: bigdecimal::BigDecimal,
     pub epoch_start_height: bigdecimal::BigDecimal,
+    pub epoch_end_height: Option<bigdecimal::BigDecimal>,
     pub validators_info: serde_json::Value,
 }
 
@@ -678,6 +679,19 @@ impl Validators {
         diesel::insert_into(validators::table)
             .values(self)
             .on_conflict_do_nothing()
+            .execute(&mut conn)
+            .await?;
+        Ok(())
+    }
+
+    pub async fn update_epoch_end_height(
+        mut conn: crate::postgres::PgAsyncConn,
+        epoch_id: near_indexer_primitives::CryptoHash,
+        epoch_end_height: bigdecimal::BigDecimal,
+    ) -> anyhow::Result<()> {
+        diesel::update(validators::table)
+            .filter(validators::epoch_id.eq(epoch_id.to_string()))
+            .set(validators::epoch_end_height.eq(epoch_end_height))
             .execute(&mut conn)
             .await?;
         Ok(())
@@ -703,6 +717,7 @@ pub struct ProtocolConfig {
     pub epoch_id: String,
     pub epoch_height: bigdecimal::BigDecimal,
     pub epoch_start_height: bigdecimal::BigDecimal,
+    pub epoch_end_height: Option<bigdecimal::BigDecimal>,
     pub protocol_config: serde_json::Value,
 }
 
@@ -714,6 +729,19 @@ impl ProtocolConfig {
         diesel::insert_into(protocol_configs::table)
             .values(self)
             .on_conflict_do_nothing()
+            .execute(&mut conn)
+            .await?;
+        Ok(())
+    }
+
+    pub async fn update_epoch_end_height(
+        mut conn: crate::postgres::PgAsyncConn,
+        epoch_id: near_indexer_primitives::CryptoHash,
+        epoch_end_height: bigdecimal::BigDecimal,
+    ) -> anyhow::Result<()> {
+        diesel::update(protocol_configs::table)
+            .filter(protocol_configs::epoch_id.eq(epoch_id.to_string()))
+            .set(protocol_configs::epoch_end_height.eq(epoch_end_height))
             .execute(&mut conn)
             .await?;
         Ok(())

--- a/database/src/postgres/rpc_server.rs
+++ b/database/src/postgres/rpc_server.rs
@@ -1,8 +1,10 @@
-use crate::postgres::PostgresStorageManager;
-use crate::AdditionalDatabaseOptions;
+use std::str::FromStr;
+
 use bigdecimal::ToPrimitive;
 use borsh::{BorshDeserialize, BorshSerialize};
-use std::str::FromStr;
+
+use crate::postgres::PostgresStorageManager;
+use crate::AdditionalDatabaseOptions;
 
 pub struct PostgresDBManager {
     pg_pool: crate::postgres::PgAsyncPool,

--- a/database/src/postgres/rpc_server.rs
+++ b/database/src/postgres/rpc_server.rs
@@ -2,6 +2,7 @@ use crate::postgres::PostgresStorageManager;
 use crate::AdditionalDatabaseOptions;
 use bigdecimal::ToPrimitive;
 use borsh::{BorshDeserialize, BorshSerialize};
+use std::str::FromStr;
 
 pub struct PostgresDBManager {
     pg_pool: crate::postgres::PgAsyncPool,
@@ -322,6 +323,36 @@ impl crate::ReaderDbManager for PostgresDBManager {
             epoch_id,
         )
         .await?;
+        let epoch_height = epoch
+            .epoch_height
+            .to_u64()
+            .ok_or_else(|| anyhow::anyhow!("Failed to parse `epoch_height` to u64"))?;
+        let epoch_start_height = epoch
+            .epoch_start_height
+            .to_u64()
+            .ok_or_else(|| anyhow::anyhow!("Failed to parse `epoch_start_height` to u64"))?;
+        let (validators_info,) = serde_json::from_value::<(
+            near_indexer_primitives::views::EpochValidatorInfo,
+        )>(epoch.validators_info)?;
+        Ok(readnode_primitives::EpochValidatorsInfo {
+            epoch_id,
+            epoch_height,
+            epoch_start_height,
+            validators_info,
+        })
+    }
+
+    async fn get_validators_by_end_block_height(
+        &self,
+        block_height: near_primitives::types::BlockHeight,
+    ) -> anyhow::Result<readnode_primitives::EpochValidatorsInfo> {
+        let epoch = crate::models::Validators::get_validators_epoch_end_height(
+            Self::get_connection(&self.pg_pool).await?,
+            bigdecimal::BigDecimal::from(block_height),
+        )
+        .await?;
+        let epoch_id = near_indexer_primitives::CryptoHash::from_str(&epoch.epoch_id)
+            .map_err(|err| anyhow::anyhow!("Failed to parse `epoch_id` to CryptoHash: {}", err))?;
         let epoch_height = epoch
             .epoch_height
             .to_u64()

--- a/database/src/postgres/schema.rs
+++ b/database/src/postgres/schema.rs
@@ -35,6 +35,7 @@ diesel::table! {
         epoch_id -> Text,
         epoch_height -> Numeric,
         epoch_start_height -> Numeric,
+        epoch_end_height -> Nullable<Numeric>,
         protocol_config -> Jsonb,
     }
 }
@@ -127,6 +128,7 @@ diesel::table! {
         epoch_id -> Text,
         epoch_height -> Numeric,
         epoch_start_height -> Numeric,
+        epoch_end_height -> Nullable<Numeric>,
         validators_info -> Jsonb,
     }
 }

--- a/database/src/postgres/state_indexer.rs
+++ b/database/src/postgres/state_indexer.rs
@@ -287,7 +287,7 @@ impl crate::StateIndexerDbManager for PostgresDBManager {
             Self::get_connection(&self.pg_pool).await?,
             block_hash,
         )
-            .await?;
+        .await?;
         block_height
             .to_u64()
             .ok_or_else(|| anyhow::anyhow!("Failed to parse `block_height` to u64"))

--- a/database/src/postgres/state_indexer.rs
+++ b/database/src/postgres/state_indexer.rs
@@ -279,6 +279,20 @@ impl crate::StateIndexerDbManager for PostgresDBManager {
             .await
     }
 
+    async fn get_block_by_hash(
+        &self,
+        block_hash: near_indexer_primitives::CryptoHash,
+    ) -> anyhow::Result<u64> {
+        let block_height = crate::models::Block::get_block_height_by_hash(
+            Self::get_connection(&self.pg_pool).await?,
+            block_hash,
+        )
+            .await?;
+        block_height
+            .to_u64()
+            .ok_or_else(|| anyhow::anyhow!("Failed to parse `block_height` to u64"))
+    }
+
     async fn update_meta(&self, indexer_id: &str, block_height: u64) -> anyhow::Result<()> {
         crate::models::Meta {
             indexer_id: indexer_id.to_string(),
@@ -309,6 +323,7 @@ impl crate::StateIndexerDbManager for PostgresDBManager {
             epoch_id: epoch_id.to_string(),
             epoch_height: bigdecimal::BigDecimal::from(epoch_height),
             epoch_start_height: bigdecimal::BigDecimal::from(epoch_start_height),
+            epoch_end_height: None,
             validators_info: serde_json::to_value(validators_info)?,
         }
         .insert_or_ignore(Self::get_connection(&self.pg_pool).await?)
@@ -327,10 +342,32 @@ impl crate::StateIndexerDbManager for PostgresDBManager {
             epoch_id: epoch_id.to_string(),
             epoch_height: bigdecimal::BigDecimal::from(epoch_height),
             epoch_start_height: bigdecimal::BigDecimal::from(epoch_start_height),
+            epoch_end_height: None,
             protocol_config: serde_json::to_value(protocol_config)?,
         }
         .insert_or_ignore(Self::get_connection(&self.pg_pool).await?)
         .await?;
+        Ok(())
+    }
+
+    async fn update_epoch_end_height(
+        &self,
+        epoch_id: near_indexer_primitives::CryptoHash,
+        epoch_end_block_hash: near_indexer_primitives::CryptoHash,
+    ) -> anyhow::Result<()> {
+        let epoch_end_height = self.get_block_by_hash(epoch_end_block_hash).await?;
+
+        let validators_future = crate::models::Validators::update_epoch_end_height(
+            Self::get_connection(&self.pg_pool).await?,
+            epoch_id,
+            bigdecimal::BigDecimal::from(epoch_end_height),
+        );
+        let protocol_config_future = crate::models::ProtocolConfig::update_epoch_end_height(
+            Self::get_connection(&self.pg_pool).await?,
+            epoch_id,
+            bigdecimal::BigDecimal::from(epoch_end_height),
+        );
+        futures::future::try_join(validators_future, protocol_config_future).await?;
         Ok(())
     }
 }

--- a/database/src/scylladb/rpc_server.rs
+++ b/database/src/scylladb/rpc_server.rs
@@ -1,11 +1,12 @@
-use crate::scylladb::ScyllaStorageManager;
-use borsh::{BorshDeserialize, BorshSerialize};
-use futures::StreamExt;
-use near_indexer_primitives::CryptoHash;
-use num_traits::ToPrimitive;
-use scylla::{prepared_statement::PreparedStatement, IntoTypedRows};
 use std::convert::TryFrom;
 use std::str::FromStr;
+
+use borsh::{BorshDeserialize, BorshSerialize};
+use futures::StreamExt;
+use num_traits::ToPrimitive;
+use scylla::{prepared_statement::PreparedStatement, IntoTypedRows};
+
+use crate::scylladb::ScyllaStorageManager;
 
 pub struct ScyllaDBManager {
     scylla_session: std::sync::Arc<scylla::Session>,
@@ -506,7 +507,7 @@ impl crate::ReaderDbManager for ScyllaDBManager {
         .single_row()?
         .into_typed::<(String, num_bigint::BigInt, String)>()?;
 
-        let epoch_id = CryptoHash::from_str(&epoch_id)
+        let epoch_id = near_indexer_primitives::CryptoHash::from_str(&epoch_id)
             .map_err(|err| anyhow::anyhow!("Failed to parse `epoch_id` to CryptoHash: {}", err))?;
 
         let validators_info: near_primitives::views::EpochValidatorInfo =

--- a/database/src/scylladb/rpc_server.rs
+++ b/database/src/scylladb/rpc_server.rs
@@ -1,9 +1,11 @@
 use crate::scylladb::ScyllaStorageManager;
 use borsh::{BorshDeserialize, BorshSerialize};
 use futures::StreamExt;
+use near_indexer_primitives::CryptoHash;
 use num_traits::ToPrimitive;
 use scylla::{prepared_statement::PreparedStatement, IntoTypedRows};
 use std::convert::TryFrom;
+use std::str::FromStr;
 
 pub struct ScyllaDBManager {
     scylla_session: std::sync::Arc<scylla::Session>,
@@ -21,6 +23,7 @@ pub struct ScyllaDBManager {
     get_transaction_by_hash: PreparedStatement,
     get_stored_at_block_height_and_shard_id_by_block_height: PreparedStatement,
     get_validators_by_epoch_id: PreparedStatement,
+    get_validators_by_end_block_height: PreparedStatement,
     get_protocol_config_by_epoch_id: PreparedStatement,
 }
 
@@ -120,6 +123,10 @@ impl ScyllaStorageManager for ScyllaDBManager {
             get_validators_by_epoch_id: Self::prepare_read_query(
                 &scylla_db_session,
                 "SELECT epoch_height, validators_info FROM state_indexer.validators WHERE epoch_id = ?",
+            ).await?,
+            get_validators_by_end_block_height: Self::prepare_read_query(
+                &scylla_db_session,
+                "SELECT epoch_id, epoch_height, validators_info FROM state_indexer.validators WHERE epoch_end_height = ?",
             ).await?,
             get_protocol_config_by_epoch_id: Self::prepare_read_query(
                 &scylla_db_session,
@@ -472,6 +479,35 @@ impl crate::ReaderDbManager for ScyllaDBManager {
         .await?
         .single_row()?
         .into_typed::<(num_bigint::BigInt, String)>()?;
+
+        let validators_info: near_primitives::views::EpochValidatorInfo =
+            serde_json::from_str(&validators_info)?;
+
+        Ok(readnode_primitives::EpochValidatorsInfo {
+            epoch_id,
+            epoch_height: epoch_height
+                .to_u64()
+                .ok_or_else(|| anyhow::anyhow!("Failed to parse `epoch_height` to u64"))?,
+            epoch_start_height: validators_info.epoch_start_height,
+            validators_info,
+        })
+    }
+
+    async fn get_validators_by_end_block_height(
+        &self,
+        block_height: near_primitives::types::BlockHeight,
+    ) -> anyhow::Result<readnode_primitives::EpochValidatorsInfo> {
+        let (epoch_id, epoch_height, validators_info) = Self::execute_prepared_query(
+            &self.scylla_session,
+            &self.get_validators_by_end_block_height,
+            (num_bigint::BigInt::from(block_height),),
+        )
+        .await?
+        .single_row()?
+        .into_typed::<(String, num_bigint::BigInt, String)>()?;
+
+        let epoch_id = CryptoHash::from_str(&epoch_id)
+            .map_err(|err| anyhow::anyhow!("Failed to parse `epoch_id` to CryptoHash: {}", err))?;
 
         let validators_info: near_primitives::views::EpochValidatorInfo =
             serde_json::from_str(&validators_info)?;

--- a/database/src/scylladb/state_indexer.rs
+++ b/database/src/scylladb/state_indexer.rs
@@ -355,7 +355,8 @@ impl ScyllaStorageManager for ScyllaDBManager {
             get_block_by_hash: Self::prepare_read_query(
                 &scylla_db_session,
                 "SELECT block_height FROM state_indexer.blocks WHERE block_hash = ?",
-            ).await?,
+            )
+            .await?,
             add_chunk: Self::prepare_write_query(
                 &scylla_db_session,
                 "INSERT INTO state_indexer.chunks
@@ -707,9 +708,9 @@ impl crate::StateIndexerDbManager for ScyllaDBManager {
             &self.get_block_by_hash,
             (block_hash.to_string(),),
         )
-            .await?
-            .single_row()?
-            .into_typed::<(num_bigint::BigInt,)>()?;
+        .await?
+        .single_row()?
+        .into_typed::<(num_bigint::BigInt,)>()?;
 
         result
             .to_u64()

--- a/database/src/scylladb/state_indexer.rs
+++ b/database/src/scylladb/state_indexer.rs
@@ -23,10 +23,16 @@ pub struct ScyllaDBManager {
     delete_account: PreparedStatement,
 
     add_block: PreparedStatement,
+    get_block_by_hash: PreparedStatement,
     add_chunk: PreparedStatement,
+
     add_validators: PreparedStatement,
     add_protocol_config: PreparedStatement,
+    update_validators_epoch_end_height: PreparedStatement,
+    update_protocol_config_epoch_end_height: PreparedStatement,
+
     add_account_state: PreparedStatement,
+
     update_meta: PreparedStatement,
     last_processed_block_height: PreparedStatement,
 }
@@ -158,6 +164,7 @@ impl ScyllaStorageManager for ScyllaDBManager {
                     epoch_id varchar,
                     epoch_height varint,
                     epoch_start_height varint,
+                    epoch_end_height varint,
                     validators_info text,
                     PRIMARY KEY (epoch_id)
                 )
@@ -173,6 +180,7 @@ impl ScyllaStorageManager for ScyllaDBManager {
                     epoch_id varchar,
                     epoch_height varint,
                     epoch_start_height varint,
+                    epoch_end_height varint,
                     protocol_config text,
                     PRIMARY KEY (epoch_id)
                 )
@@ -344,6 +352,10 @@ impl ScyllaStorageManager for ScyllaDBManager {
                     VALUES (?, ?)",
             )
             .await?,
+            get_block_by_hash: Self::prepare_read_query(
+                &scylla_db_session,
+                "SELECT block_height FROM state_indexer.blocks WHERE block_hash = ?",
+            ).await?,
             add_chunk: Self::prepare_write_query(
                 &scylla_db_session,
                 "INSERT INTO state_indexer.chunks
@@ -354,15 +366,25 @@ impl ScyllaStorageManager for ScyllaDBManager {
             add_validators: Self::prepare_write_query(
                 &scylla_db_session,
                 "INSERT INTO state_indexer.validators
-                    (epoch_id, epoch_height, epoch_start_height, validators_info)
-                    VALUES (?, ?, ?, ?)",
+                    (epoch_id, epoch_height, epoch_start_height, epoch_end_height, validators_info)
+                    VALUES (?, ?, ?, NULL, ?)",
             )
             .await?,
             add_protocol_config: Self::prepare_write_query(
                 &scylla_db_session,
                 "INSERT INTO state_indexer.protocol_configs
-                    (epoch_id, epoch_height, epoch_start_height, protocol_config)
-                    VALUES (?, ?, ?, ?)",
+                    (epoch_id, epoch_height, epoch_start_height, epoch_end_height, protocol_config)
+                    VALUES (?, ?, ?, NULL, ?)",
+            )
+            .await?,
+            update_validators_epoch_end_height: Self::prepare_write_query(
+                &scylla_db_session,
+                "UPDATE state_indexer.validators SET epoch_end_height = ? WHERE epoch_id = ?",
+            )
+            .await?,
+            update_protocol_config_epoch_end_height: Self::prepare_write_query(
+                &scylla_db_session,
+                "UPDATE state_indexer.protocol_configs SET epoch_end_height = ? WHERE epoch_id = ?",
             )
             .await?,
             add_account_state: Self::prepare_write_query(
@@ -514,10 +536,10 @@ impl crate::StateIndexerDbManager for ScyllaDBManager {
     ) -> anyhow::Result<()> {
         let public_key_hex = hex::encode(public_key).to_string();
 
-        let mut account_keys = match self.get_access_keys(account_id.clone(), block_height).await {
-            Ok(account_keys) => account_keys,
-            Err(_) => std::collections::HashMap::new(),
-        };
+        let mut account_keys = self
+            .get_access_keys(account_id.clone(), block_height)
+            .await
+            .unwrap_or_default();
 
         match access_key {
             Some(access_key) => {
@@ -676,6 +698,24 @@ impl crate::StateIndexerDbManager for ScyllaDBManager {
         Ok(())
     }
 
+    async fn get_block_by_hash(
+        &self,
+        block_hash: near_primitives::hash::CryptoHash,
+    ) -> anyhow::Result<u64> {
+        let (result,) = Self::execute_prepared_query(
+            &self.scylla_session,
+            &self.get_block_by_hash,
+            (block_hash.to_string(),),
+        )
+            .await?
+            .single_row()?
+            .into_typed::<(num_bigint::BigInt,)>()?;
+
+        result
+            .to_u64()
+            .ok_or_else(|| anyhow::anyhow!("Failed to parse `block_height` to u64"))
+    }
+
     async fn update_meta(&self, indexer_id: &str, block_height: u64) -> anyhow::Result<()> {
         Self::execute_prepared_query(
             &self.scylla_session,
@@ -739,6 +779,33 @@ impl crate::StateIndexerDbManager for ScyllaDBManager {
             ),
         )
         .await?;
+        Ok(())
+    }
+
+    async fn update_epoch_end_height(
+        &self,
+        epoch_id: near_indexer_primitives::CryptoHash,
+        epoch_end_block_hash: near_indexer_primitives::CryptoHash,
+    ) -> anyhow::Result<()> {
+        let epoch_end_height = self.get_block_by_hash(epoch_end_block_hash).await?;
+
+        let validators_future = Self::execute_prepared_query(
+            &self.scylla_session,
+            &self.update_validators_epoch_end_height,
+            (
+                num_bigint::BigInt::from(epoch_end_height),
+                epoch_id.to_string(),
+            ),
+        );
+        let protocol_config_future = Self::execute_prepared_query(
+            &self.scylla_session,
+            &self.update_protocol_config_epoch_end_height,
+            (
+                num_bigint::BigInt::from(epoch_end_height),
+                epoch_id.to_string(),
+            ),
+        );
+        futures::future::try_join(validators_future, protocol_config_future).await?;
         Ok(())
     }
 }

--- a/database/src/scylladb/state_indexer.rs
+++ b/database/src/scylladb/state_indexer.rs
@@ -176,6 +176,15 @@ impl ScyllaStorageManager for ScyllaDBManager {
         scylla_db_session
             .query(
                 "
+                CREATE INDEX IF NOT EXISTS validators_epoch_end_height ON validators (epoch_end_height);
+            ",
+                &[],
+            )
+            .await?;
+
+        scylla_db_session
+            .query(
+                "
                 CREATE TABLE IF NOT EXISTS protocol_configs (
                     epoch_id varchar,
                     epoch_height varint,

--- a/epoch-indexer/src/config.rs
+++ b/epoch-indexer/src/config.rs
@@ -103,8 +103,8 @@ impl Opts {
 
     pub fn rpc_url(&self) -> &str {
         match &self.chain_id {
-            ChainId::Mainnet(_) => "https://rpc.mainnet.near.org",
-            ChainId::Testnet(_) => "https://rpc.testnet.near.org",
+            ChainId::Mainnet(_) => "https://archival-rpc.mainnet.near.org",
+            ChainId::Testnet(_) => "https://archival-rpc.testnet.near.org",
         }
     }
     pub async fn to_s3_client(&self) -> near_lake_framework::s3_fetchers::LakeS3Client {

--- a/epoch-indexer/src/config.rs
+++ b/epoch-indexer/src/config.rs
@@ -103,8 +103,8 @@ impl Opts {
 
     pub fn rpc_url(&self) -> &str {
         match &self.chain_id {
-            ChainId::Mainnet(_) => "https://archival-rpc.mainnet.near.org",
-            ChainId::Testnet(_) => "https://archival-rpc.testnet.near.org",
+            ChainId::Mainnet(_) => "https://rpc.mainnet.near.org",
+            ChainId::Testnet(_) => "https://rpc.testnet.near.org",
         }
     }
     pub async fn to_s3_client(&self) -> near_lake_framework::s3_fetchers::LakeS3Client {

--- a/epoch-indexer/src/lib.rs
+++ b/epoch-indexer/src/lib.rs
@@ -92,6 +92,7 @@ pub async fn get_epoch_info_by_id(
         epoch_id,
         epoch_height: validators_info.epoch_height,
         epoch_start_height: validators_info.epoch_start_height,
+        epoch_end_height: None,
         validators_info,
         protocol_config,
     })
@@ -102,7 +103,7 @@ pub async fn get_epoch_info_by_block_height(
     s3_client: &near_lake_framework::s3_fetchers::LakeS3Client,
     s3_bucket_name: &str,
     rpc_client: &near_jsonrpc_client::JsonRpcClient,
-) -> anyhow::Result<readnode_primitives::IndexedEpochInfo> {
+) -> anyhow::Result<readnode_primitives::IndexedEpochInfoWithPreviousAndNextEpochId> {
     let block_heights = near_lake_framework::s3_fetchers::list_block_heights(
         s3_client,
         s3_bucket_name,
@@ -115,41 +116,82 @@ pub async fn get_epoch_info_by_block_height(
         block_heights[0],
     )
     .await?;
-    get_epoch_info_by_id(block.header.epoch_id, rpc_client).await
+    let epoch_info = get_epoch_info_by_id(block.header.epoch_id, rpc_client).await?;
+
+    Ok(
+        readnode_primitives::IndexedEpochInfoWithPreviousAndNextEpochId {
+            previous_epoch_id: None,
+            epoch_info,
+            next_epoch_id: block.header.next_epoch_id,
+        },
+    )
+
 }
 
 pub async fn first_epoch(
-    rpc_client: &near_jsonrpc_client::JsonRpcClient,
-) -> anyhow::Result<readnode_primitives::IndexedEpochInfo> {
-    get_epoch_info_by_id(CryptoHash::default(), rpc_client).await
-}
-
-pub async fn get_next_epoch(
-    current_epoch: &readnode_primitives::IndexedEpochInfo,
     s3_client: &near_lake_framework::s3_fetchers::LakeS3Client,
     s3_bucket_name: &str,
     rpc_client: &near_jsonrpc_client::JsonRpcClient,
-) -> anyhow::Result<readnode_primitives::IndexedEpochInfo> {
-    let block_heights = near_lake_framework::s3_fetchers::list_block_heights(
+) -> anyhow::Result<readnode_primitives::IndexedEpochInfoWithPreviousAndNextEpochId> {
+    let epoch_info = get_epoch_info_by_id(CryptoHash::default(), rpc_client).await?;
+    let first_epoch_block = near_lake_framework::s3_fetchers::fetch_block_or_retry(
         s3_client,
         s3_bucket_name,
-        current_epoch.epoch_start_height,
+        epoch_info.epoch_start_height,
     )
-    .await?;
-    let epoch_first_block = near_lake_framework::s3_fetchers::fetch_block_or_retry(
+        .await?;
+    Ok(readnode_primitives::IndexedEpochInfoWithPreviousAndNextEpochId {
+        previous_epoch_id: None,
+        epoch_info,
+        next_epoch_id: first_epoch_block.header.next_epoch_id,
+    })
+}
+
+pub async fn get_next_epoch(
+    current_epoch: &readnode_primitives::IndexedEpochInfoWithPreviousAndNextEpochId,
+    s3_client: &near_lake_framework::s3_fetchers::LakeS3Client,
+    s3_bucket_name: &str,
+    rpc_client: &near_jsonrpc_client::JsonRpcClient,
+) -> anyhow::Result<readnode_primitives::IndexedEpochInfoWithPreviousAndNextEpochId> {
+
+    let mut epoch_info = get_epoch_info_by_id(current_epoch.next_epoch_id, rpc_client).await?;
+
+    let epoch_info_first_block = near_lake_framework::s3_fetchers::fetch_block_or_retry(
         s3_client,
         s3_bucket_name,
-        block_heights[0],
+        epoch_info.epoch_start_height,
     )
-    .await?;
-    let next_epoch_id = epoch_first_block.header.next_epoch_id;
-    let mut epoch_info = get_epoch_info_by_id(next_epoch_id, rpc_client).await?;
-    if current_epoch.epoch_id == CryptoHash::default() {
+        .await?;
+    if current_epoch.epoch_info.epoch_id == CryptoHash::default() {
         epoch_info.epoch_height = 1;
     } else {
-        epoch_info.epoch_height = current_epoch.epoch_height + 1
+        epoch_info.epoch_height = current_epoch.epoch_info.epoch_height + 1
     };
-    Ok(epoch_info)
+    Ok(
+        readnode_primitives::IndexedEpochInfoWithPreviousAndNextEpochId {
+            previous_epoch_id: Some(current_epoch.epoch_info.epoch_id),
+            epoch_info,
+            next_epoch_id: epoch_info_first_block.header.next_epoch_id,
+        },
+    )
+}
+
+pub async fn update_epoch_end_height(
+    db_manager: &(impl database::StateIndexerDbManager + Sync + Send + 'static),
+    epoch_id: Option<CryptoHash>,
+    epoch_end_block_hash: CryptoHash,
+) -> anyhow::Result<()> {
+    if let Some(epoch_id) = epoch_id {
+        tracing::info!(
+            "Update epoch_end_height: epoch_id: {:?}, epoch_end_height: {}",
+            epoch_id,
+            epoch_end_block_hash
+        );
+        db_manager
+            .update_epoch_end_height(epoch_id, epoch_end_block_hash)
+            .await?;
+    }
+    Ok(())
 }
 
 pub async fn save_epoch_info(

--- a/epoch-indexer/src/lib.rs
+++ b/epoch-indexer/src/lib.rs
@@ -125,7 +125,6 @@ pub async fn get_epoch_info_by_block_height(
             next_epoch_id: block.header.next_epoch_id,
         },
     )
-
 }
 
 pub async fn first_epoch(
@@ -139,12 +138,14 @@ pub async fn first_epoch(
         s3_bucket_name,
         epoch_info.epoch_start_height,
     )
-        .await?;
-    Ok(readnode_primitives::IndexedEpochInfoWithPreviousAndNextEpochId {
-        previous_epoch_id: None,
-        epoch_info,
-        next_epoch_id: first_epoch_block.header.next_epoch_id,
-    })
+    .await?;
+    Ok(
+        readnode_primitives::IndexedEpochInfoWithPreviousAndNextEpochId {
+            previous_epoch_id: None,
+            epoch_info,
+            next_epoch_id: first_epoch_block.header.next_epoch_id,
+        },
+    )
 }
 
 pub async fn get_next_epoch(
@@ -153,7 +154,6 @@ pub async fn get_next_epoch(
     s3_bucket_name: &str,
     rpc_client: &near_jsonrpc_client::JsonRpcClient,
 ) -> anyhow::Result<readnode_primitives::IndexedEpochInfoWithPreviousAndNextEpochId> {
-
     let mut epoch_info = get_epoch_info_by_id(current_epoch.next_epoch_id, rpc_client).await?;
 
     let epoch_info_first_block = near_lake_framework::s3_fetchers::fetch_block_or_retry(
@@ -161,7 +161,7 @@ pub async fn get_next_epoch(
         s3_bucket_name,
         epoch_info.epoch_start_height,
     )
-        .await?;
+    .await?;
     if current_epoch.epoch_info.epoch_id == CryptoHash::default() {
         epoch_info.epoch_height = 1;
     } else {
@@ -183,7 +183,7 @@ pub async fn update_epoch_end_height(
 ) -> anyhow::Result<()> {
     if let Some(epoch_id) = epoch_id {
         tracing::info!(
-            "Update epoch_end_height: epoch_id: {:?}, epoch_end_height: {}",
+            "Update epoch_end_height: epoch_id: {:?}, epoch_end_height_hash: {}",
             epoch_id,
             epoch_end_block_hash
         );
@@ -223,7 +223,7 @@ pub async fn save_epoch_info(
     tracing::info!(
         "Save epoch info: epoch_id: {:?}, epoch_height: {:?}, epoch_start_height: {}",
         epoch.epoch_id,
-        epoch.epoch_height,
+        epoch_height,
         epoch.epoch_start_height,
     );
     Ok(())

--- a/epoch-indexer/src/main.rs
+++ b/epoch-indexer/src/main.rs
@@ -110,11 +110,9 @@ async fn main() -> anyhow::Result<()> {
     let rpc_client = near_jsonrpc_client::JsonRpcClient::connect(opts.rpc_url());
 
     let epoch = match opts.start_options() {
-        StartOptions::FromGenesis => epoch_indexer::first_epoch(
-            &s3_client,
-            &opts.s3_bucket_name,
-            &rpc_client,
-        ).await?,
+        StartOptions::FromGenesis => {
+            epoch_indexer::first_epoch(&s3_client, &opts.s3_bucket_name, &rpc_client).await?
+        }
         StartOptions::FromInterruption => {
             let block_height = db_manager
                 .get_last_processed_block_height(opts.indexer_id.as_str())

--- a/epoch-indexer/src/main.rs
+++ b/epoch-indexer/src/main.rs
@@ -12,25 +12,38 @@ async fn index_epochs(
     db_manager: impl StateIndexerDbManager + Sync + Send + 'static,
     rpc_client: near_jsonrpc_client::JsonRpcClient,
     indexer_id: &str,
-    start_epoch: readnode_primitives::IndexedEpochInfo,
+    start_epoch: readnode_primitives::IndexedEpochInfoWithPreviousAndNextEpochId,
 ) -> anyhow::Result<()> {
     let mut epoch = start_epoch;
     loop {
-        epoch = match epoch_indexer::get_next_epoch(&epoch, s3_client, s3_bucket_name, &rpc_client)
-            .await
-        {
-            Ok(epoch) => epoch,
-            Err(e) => {
-                anyhow::bail!("Error fetching next epoch: {:?}", e);
-            }
-        };
+        let epoch_info =
+            match epoch_indexer::get_next_epoch(&epoch, s3_client, s3_bucket_name, &rpc_client)
+                .await
+            {
+                Ok(next_epoch) => next_epoch,
+                Err(e) => {
+                    anyhow::bail!("Error fetching next epoch: {:?}", e);
+                }
+            };
 
-        if let Err(e) = epoch_indexer::save_epoch_info(&epoch, &db_manager, None).await {
+        if let Err(e) =
+            epoch_indexer::save_epoch_info(&epoch_info.epoch_info, &db_manager, None).await
+        {
             tracing::warn!("Error saving epoch info: {:?}", e);
         }
+        if let Err(e) = epoch_indexer::update_epoch_end_height(
+            &db_manager,
+            epoch_info.previous_epoch_id,
+            epoch_info.next_epoch_id,
+        )
+        .await
+        {
+            tracing::warn!("Error update epoch_end_height: {:?}", e);
+        }
         db_manager
-            .update_meta(indexer_id, epoch.epoch_start_height)
+            .update_meta(indexer_id, epoch.epoch_info.epoch_start_height)
             .await?;
+        epoch = epoch_info;
     }
 }
 
@@ -97,7 +110,11 @@ async fn main() -> anyhow::Result<()> {
     let rpc_client = near_jsonrpc_client::JsonRpcClient::connect(opts.rpc_url());
 
     let epoch = match opts.start_options() {
-        StartOptions::FromGenesis => epoch_indexer::first_epoch(&rpc_client).await?,
+        StartOptions::FromGenesis => epoch_indexer::first_epoch(
+            &s3_client,
+            &opts.s3_bucket_name,
+            &rpc_client,
+        ).await?,
         StartOptions::FromInterruption => {
             let block_height = db_manager
                 .get_last_processed_block_height(opts.indexer_id.as_str())
@@ -111,7 +128,7 @@ async fn main() -> anyhow::Result<()> {
             .await?
         }
     };
-    epoch_indexer::save_epoch_info(&epoch, &db_manager, None).await?;
+    epoch_indexer::save_epoch_info(&epoch.epoch_info, &db_manager, None).await?;
 
     index_epochs(
         &s3_client,

--- a/perf-testing/src/chunks.rs
+++ b/perf-testing/src/chunks.rs
@@ -1,9 +1,11 @@
-use crate::{TestResult, TxInfo};
+use std::time::{Duration, Instant};
+
 use futures::future::join_all;
 use near_jsonrpc_client::{methods, JsonRpcClient};
 use near_jsonrpc_primitives::types::chunks::ChunkReference;
 use near_primitives::types::{BlockHeight, BlockId};
-use std::time::{Duration, Instant};
+
+use crate::{TestResult, TxInfo};
 
 // While testing chunks, it's important to collect accounts and transactions for further tests
 async fn get_random_chunk(

--- a/readnode-primitives/src/lib.rs
+++ b/readnode-primitives/src/lib.rs
@@ -180,8 +180,16 @@ pub struct IndexedEpochInfo {
     pub epoch_id: CryptoHash,
     pub epoch_height: u64,
     pub epoch_start_height: u64,
+    pub epoch_end_height: Option<u64>,
     pub validators_info: views::EpochValidatorInfo,
     pub protocol_config: near_chain_configs::ProtocolConfigView,
+}
+
+#[derive(Debug)]
+pub struct IndexedEpochInfoWithPreviousAndNextEpochId {
+    pub previous_epoch_id: Option<CryptoHash>,
+    pub epoch_info: IndexedEpochInfo,
+    pub next_epoch_id: CryptoHash,
 }
 
 // TryFrom impls for defined types

--- a/readnode-primitives/src/lib.rs
+++ b/readnode-primitives/src/lib.rs
@@ -1,9 +1,10 @@
+use std::convert::TryFrom;
+use std::str::FromStr;
+
 use borsh::{BorshDeserialize, BorshSerialize};
 use near_indexer_primitives::{views, CryptoHash, IndexerTransactionWithOutcome};
 use num_traits::ToPrimitive;
 use serde::{Deserialize, Serialize};
-use std::convert::TryFrom;
-use std::str::FromStr;
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Debug)]
 pub struct TransactionKey {

--- a/rpc-server/Cargo.toml
+++ b/rpc-server/Cargo.toml
@@ -16,6 +16,7 @@ clap = { version = "3.2.22", features = ["color", "derive", "env"] }
 dotenv = "0.15.0"
 erased-serde = "0.3.23"
 futures = "0.3.24"
+futures-locks = "0.7.1"
 hex = "0.4.3"
 http = "0.2.8"
 jsonrpc-v2 = { git = "https://github.com/kobayurii/jsonrpc-v2", rev = "95e7b1d2567ae841163af212a3f25abb6862becb" }

--- a/rpc-server/src/config.rs
+++ b/rpc-server/src/config.rs
@@ -1,4 +1,4 @@
-use crate::modules::blocks::CacheBlock;
+use crate::modules::blocks::{CacheBlock, FinaleBlockInfo};
 use clap::Parser;
 
 #[derive(Parser)]
@@ -154,7 +154,7 @@ pub struct ServerContext {
     pub genesis_config: near_chain_configs::GenesisConfig,
     pub blocks_cache:
         std::sync::Arc<std::sync::RwLock<crate::cache::LruMemoryCache<u64, CacheBlock>>>,
-    pub final_block_height: std::sync::Arc<std::sync::atomic::AtomicU64>,
+    pub final_block_info: std::sync::Arc<std::sync::RwLock<FinaleBlockInfo>>,
     pub compiled_contract_code_cache: std::sync::Arc<CompiledCodeCache>,
     pub contract_code_cache: std::sync::Arc<
         std::sync::RwLock<crate::cache::LruMemoryCache<near_primitives::hash::CryptoHash, Vec<u8>>>,
@@ -173,7 +173,7 @@ impl ServerContext {
         blocks_cache: std::sync::Arc<
             std::sync::RwLock<crate::cache::LruMemoryCache<u64, CacheBlock>>,
         >,
-        final_block_height: std::sync::Arc<std::sync::atomic::AtomicU64>,
+        final_block_info: std::sync::Arc<std::sync::RwLock<FinaleBlockInfo>>,
         compiled_contract_code_cache: std::sync::Arc<CompiledCodeCache>,
         contract_code_cache: std::sync::Arc<
             std::sync::RwLock<
@@ -189,7 +189,7 @@ impl ServerContext {
             s3_bucket_name,
             genesis_config,
             blocks_cache,
-            final_block_height,
+            final_block_info,
             compiled_contract_code_cache,
             contract_code_cache,
             max_gas_burnt,

--- a/rpc-server/src/config.rs
+++ b/rpc-server/src/config.rs
@@ -1,5 +1,6 @@
-use crate::modules::blocks::{CacheBlock, FinaleBlockInfo};
+use crate::modules::blocks::{CacheBlock, FinalBlockInfo};
 use clap::Parser;
+use futures::executor::block_on;
 
 #[derive(Parser)]
 #[clap(author, version, about, long_about = None)]
@@ -153,11 +154,13 @@ pub struct ServerContext {
     pub s3_bucket_name: String,
     pub genesis_config: near_chain_configs::GenesisConfig,
     pub blocks_cache:
-        std::sync::Arc<std::sync::RwLock<crate::cache::LruMemoryCache<u64, CacheBlock>>>,
-    pub final_block_info: std::sync::Arc<std::sync::RwLock<FinaleBlockInfo>>,
+        std::sync::Arc<futures_locks::RwLock<crate::cache::LruMemoryCache<u64, CacheBlock>>>,
+    pub final_block_info: std::sync::Arc<futures_locks::RwLock<FinalBlockInfo>>,
     pub compiled_contract_code_cache: std::sync::Arc<CompiledCodeCache>,
     pub contract_code_cache: std::sync::Arc<
-        std::sync::RwLock<crate::cache::LruMemoryCache<near_primitives::hash::CryptoHash, Vec<u8>>>,
+        futures_locks::RwLock<
+            crate::cache::LruMemoryCache<near_primitives::hash::CryptoHash, Vec<u8>>,
+        >,
     >,
     pub max_gas_burnt: near_primitives::types::Gas,
 }
@@ -171,12 +174,12 @@ impl ServerContext {
         s3_bucket_name: String,
         genesis_config: near_chain_configs::GenesisConfig,
         blocks_cache: std::sync::Arc<
-            std::sync::RwLock<crate::cache::LruMemoryCache<u64, CacheBlock>>,
+            futures_locks::RwLock<crate::cache::LruMemoryCache<u64, CacheBlock>>,
         >,
-        final_block_info: std::sync::Arc<std::sync::RwLock<FinaleBlockInfo>>,
+        final_block_info: std::sync::Arc<futures_locks::RwLock<FinalBlockInfo>>,
         compiled_contract_code_cache: std::sync::Arc<CompiledCodeCache>,
         contract_code_cache: std::sync::Arc<
-            std::sync::RwLock<
+            futures_locks::RwLock<
                 crate::cache::LruMemoryCache<near_primitives::hash::CryptoHash, Vec<u8>>,
             >,
         >,
@@ -198,7 +201,7 @@ impl ServerContext {
 }
 pub struct CompiledCodeCache {
     pub local_cache: std::sync::Arc<
-        std::sync::RwLock<
+        futures_locks::RwLock<
             crate::cache::LruMemoryCache<
                 near_primitives::hash::CryptoHash,
                 near_vm_runner::logic::CompiledContract,
@@ -213,7 +216,7 @@ impl near_vm_runner::logic::CompiledContractCache for CompiledCodeCache {
         key: &near_primitives::hash::CryptoHash,
         value: near_vm_runner::logic::CompiledContract,
     ) -> std::io::Result<()> {
-        self.local_cache.write().unwrap().put(*key, value);
+        block_on(self.local_cache.write()).put(*key, value);
         Ok(())
     }
 
@@ -221,10 +224,10 @@ impl near_vm_runner::logic::CompiledContractCache for CompiledCodeCache {
         &self,
         key: &near_primitives::hash::CryptoHash,
     ) -> std::io::Result<Option<near_vm_runner::logic::CompiledContract>> {
-        Ok(self.local_cache.write().unwrap().get(key).cloned())
+        Ok(block_on(self.local_cache.write()).get(key).cloned())
     }
 
     fn has(&self, key: &near_primitives::hash::CryptoHash) -> std::io::Result<bool> {
-        Ok(self.local_cache.write().unwrap().contains(key))
+        Ok(block_on(self.local_cache.write()).contains(key))
     }
 }

--- a/rpc-server/src/errors.rs
+++ b/rpc-server/src/errors.rs
@@ -1,5 +1,7 @@
-use near_jsonrpc_client::errors::{JsonRpcError, JsonRpcServerError};
 use std::ops::{Deref, DerefMut};
+
+use near_jsonrpc_client::errors::{JsonRpcError, JsonRpcServerError};
+
 type BoxedSerialize = Box<dyn erased_serde::Serialize + Send>;
 
 #[derive(Debug, serde::Serialize)]

--- a/rpc-server/src/main.rs
+++ b/rpc-server/src/main.rs
@@ -1,4 +1,4 @@
-use crate::modules::blocks::FinaleBlockInfo;
+use crate::modules::blocks::FinalBlockInfo;
 use crate::utils::{
     get_final_cache_block, gigabytes_to_bytes, update_final_block_height_regularly,
 };
@@ -100,20 +100,20 @@ async fn main() -> anyhow::Result<()> {
     )
     .await;
 
-    let blocks_cache = std::sync::Arc::new(std::sync::RwLock::new(cache::LruMemoryCache::new(
+    let blocks_cache = std::sync::Arc::new(futures_locks::RwLock::new(cache::LruMemoryCache::new(
         block_cache_size_in_bytes,
     )));
 
-    let finale_block_info = std::sync::Arc::new(std::sync::RwLock::new(
-        FinaleBlockInfo::new(&near_rpc_client, &blocks_cache).await,
+    let finale_block_info = std::sync::Arc::new(futures_locks::RwLock::new(
+        FinalBlockInfo::new(&near_rpc_client, &blocks_cache).await,
     ));
 
     let compiled_contract_code_cache = std::sync::Arc::new(config::CompiledCodeCache {
-        local_cache: std::sync::Arc::new(std::sync::RwLock::new(cache::LruMemoryCache::new(
+        local_cache: std::sync::Arc::new(futures_locks::RwLock::new(cache::LruMemoryCache::new(
             contract_code_cache_size,
         ))),
     });
-    let contract_code_cache = std::sync::Arc::new(std::sync::RwLock::new(
+    let contract_code_cache = std::sync::Arc::new(futures_locks::RwLock::new(
         cache::LruMemoryCache::new(contract_code_cache_size),
     ));
 

--- a/rpc-server/src/modules/blocks/methods.rs
+++ b/rpc-server/src/modules/blocks/methods.rs
@@ -328,8 +328,11 @@ pub async fn fetch_block(
         },
         near_primitives::types::BlockReference::Finality(finality) => match finality {
             near_primitives::types::Finality::Final => Ok(data
-                .final_block_height
-                .load(std::sync::atomic::Ordering::SeqCst)),
+                .final_block_info
+                .read()
+                .unwrap()
+                .final_block_cache
+                .block_height),
             _ => Err(
                 near_jsonrpc_primitives::types::blocks::RpcBlockError::InternalError {
                     error_message: "Finality other than final is not supported".to_string(),

--- a/rpc-server/src/modules/blocks/methods.rs
+++ b/rpc-server/src/modules/blocks/methods.rs
@@ -330,7 +330,7 @@ pub async fn fetch_block(
             near_primitives::types::Finality::Final => Ok(data
                 .final_block_info
                 .read()
-                .unwrap()
+                .await
                 .final_block_cache
                 .block_height),
             _ => Err(

--- a/rpc-server/src/modules/blocks/mod.rs
+++ b/rpc-server/src/modules/blocks/mod.rs
@@ -14,16 +14,16 @@ pub struct CacheBlock {
 }
 
 #[derive(Debug)]
-pub struct FinaleBlockInfo {
+pub struct FinalBlockInfo {
     pub final_block_cache: CacheBlock,
     pub current_protocol_config: near_chain_configs::ProtocolConfigView,
 }
 
-impl FinaleBlockInfo {
+impl FinalBlockInfo {
     pub async fn new(
         near_rpc_client: &crate::utils::JsonRpcClient,
         blocks_cache: &std::sync::Arc<
-            std::sync::RwLock<crate::cache::LruMemoryCache<u64, CacheBlock>>,
+            futures_locks::RwLock<crate::cache::LruMemoryCache<u64, CacheBlock>>,
         >,
     ) -> Self {
         let final_block = crate::utils::get_final_cache_block(near_rpc_client)
@@ -35,7 +35,7 @@ impl FinaleBlockInfo {
 
         blocks_cache
             .write()
-            .unwrap()
+            .await
             .put(final_block.block_height, final_block);
 
         Self {

--- a/rpc-server/src/modules/blocks/utils.rs
+++ b/rpc-server/src/modules/blocks/utils.rs
@@ -97,8 +97,11 @@ pub async fn fetch_block_from_cache_or_get(
         near_primitives::types::BlockReference::Finality(_) => {
             // Returns the final_block_height for all the finalities.
             Ok(data
-                .final_block_height
-                .load(std::sync::atomic::Ordering::SeqCst))
+                .final_block_info
+                .read()
+                .unwrap()
+                .final_block_cache
+                .block_height)
         }
         // TODO: return the height of the first block height from S3 (cache it once on the start)
         near_primitives::types::BlockReference::SyncCheckpoint(_) => Err(

--- a/rpc-server/src/modules/blocks/utils.rs
+++ b/rpc-server/src/modules/blocks/utils.rs
@@ -99,7 +99,7 @@ pub async fn fetch_block_from_cache_or_get(
             Ok(data
                 .final_block_info
                 .read()
-                .unwrap()
+                .await
                 .final_block_cache
                 .block_height)
         }
@@ -110,12 +110,7 @@ pub async fn fetch_block_from_cache_or_get(
             },
         ),
     };
-    let block = data
-        .blocks_cache
-        .write()
-        .unwrap()
-        .get(&block_height?)
-        .cloned();
+    let block = data.blocks_cache.write().await.get(&block_height?).cloned();
     match block {
         Some(block) => Ok(block),
         None => {
@@ -133,7 +128,7 @@ pub async fn fetch_block_from_cache_or_get(
 
             data.blocks_cache
                 .write()
-                .unwrap()
+                .await
                 .put(block_from_s3.block_view.header.height, block);
             Ok(block)
         }

--- a/rpc-server/src/modules/network/methods.rs
+++ b/rpc-server/src/modules/network/methods.rs
@@ -16,13 +16,9 @@ pub async fn status(
     let sys = System::new_all();
     let total_memory = sys.total_memory();
     let used_memory = sys.used_memory();
-    let blocks_cache = data.blocks_cache.read().unwrap();
-    let contract_code_cache = data.contract_code_cache.read().unwrap();
-    let compiled_contract_code_cache = data
-        .compiled_contract_code_cache
-        .local_cache
-        .read()
-        .unwrap();
+    let blocks_cache = data.blocks_cache.read().await;
+    let contract_code_cache = data.contract_code_cache.read().await;
+    let compiled_contract_code_cache = data.compiled_contract_code_cache.local_cache.read().await;
     let status = StatusResponse {
         total_memory: friendly_memory_size_format(total_memory as usize),
         used_memory: friendly_memory_size_format(used_memory as usize),
@@ -49,7 +45,7 @@ pub async fn status(
         final_block_height: data
             .final_block_info
             .read()
-            .unwrap()
+            .await
             .final_block_cache
             .block_height,
     };
@@ -87,7 +83,7 @@ pub async fn validators(
         if data
             .final_block_info
             .read()
-            .unwrap()
+            .await
             .final_block_cache
             .epoch_id
             == epoch_id.0
@@ -254,16 +250,12 @@ async fn protocol_config_call(
     let protocol_config = if data
         .final_block_info
         .read()
-        .unwrap()
+        .await
         .final_block_cache
         .epoch_id
         == block.epoch_id
     {
-        let protocol_config = &data
-            .final_block_info
-            .read()
-            .unwrap()
-            .current_protocol_config;
+        let protocol_config = &data.final_block_info.read().await.current_protocol_config;
         clone_protocol_config(protocol_config)
     } else {
         data.db_manager

--- a/rpc-server/src/modules/network/mod.rs
+++ b/rpc-server/src/modules/network/mod.rs
@@ -56,3 +56,43 @@ pub fn friendly_memory_size_format(memory_size_bytes: usize) -> String {
         )
     }
 }
+
+/// cannot move out of dereference of `std::sync::RwLockReadGuard<FinaleBlockInfo>`
+/// move occurs because value `current_protocol_config` has type `ProtocolConfigView`,
+/// which does not implement the `Copy` trait
+pub fn clone_protocol_config(
+    protocol_config: &near_chain_configs::ProtocolConfigView,
+) -> near_chain_configs::ProtocolConfigView {
+    near_chain_configs::ProtocolConfigView {
+        protocol_version: protocol_config.protocol_version,
+        genesis_time: protocol_config.genesis_time,
+        chain_id: protocol_config.chain_id.clone(),
+        genesis_height: protocol_config.genesis_height,
+        num_block_producer_seats: protocol_config.num_block_producer_seats,
+        num_block_producer_seats_per_shard: protocol_config
+            .num_block_producer_seats_per_shard
+            .clone(),
+        avg_hidden_validator_seats_per_shard: protocol_config
+            .avg_hidden_validator_seats_per_shard
+            .clone(),
+        dynamic_resharding: protocol_config.dynamic_resharding,
+        protocol_upgrade_stake_threshold: protocol_config.protocol_upgrade_stake_threshold,
+        epoch_length: protocol_config.epoch_length,
+        gas_limit: protocol_config.gas_limit,
+        min_gas_price: protocol_config.min_gas_price,
+        max_gas_price: protocol_config.max_gas_price,
+        block_producer_kickout_threshold: protocol_config.block_producer_kickout_threshold,
+        chunk_producer_kickout_threshold: protocol_config.chunk_producer_kickout_threshold,
+        online_min_threshold: protocol_config.online_min_threshold,
+        online_max_threshold: protocol_config.online_max_threshold,
+        gas_price_adjustment_rate: protocol_config.gas_price_adjustment_rate,
+        runtime_config: protocol_config.runtime_config.clone(),
+        transaction_validity_period: protocol_config.transaction_validity_period,
+        protocol_reward_rate: protocol_config.protocol_reward_rate,
+        max_inflation_rate: protocol_config.max_inflation_rate,
+        num_blocks_per_year: protocol_config.num_blocks_per_year,
+        protocol_treasury_account: protocol_config.protocol_treasury_account.clone(),
+        fishermen_threshold: protocol_config.fishermen_threshold,
+        minimum_stake_divisor: protocol_config.minimum_stake_divisor,
+    }
+}

--- a/rpc-server/src/modules/network/mod.rs
+++ b/rpc-server/src/modules/network/mod.rs
@@ -57,7 +57,7 @@ pub fn friendly_memory_size_format(memory_size_bytes: usize) -> String {
     }
 }
 
-/// cannot move out of dereference of `std::sync::RwLockReadGuard<FinaleBlockInfo>`
+/// cannot move out of dereference of `futures_locks::RwLockReadGuard<FinalBlockInfo>`
 /// move occurs because value `current_protocol_config` has type `ProtocolConfigView`,
 /// which does not implement the `Copy` trait
 pub fn clone_protocol_config(

--- a/rpc-server/src/modules/queries/mod.rs
+++ b/rpc-server/src/modules/queries/mod.rs
@@ -1,6 +1,7 @@
+use std::collections::HashMap;
+
 use database::ReaderDbManager;
 use futures::executor::block_on;
-use std::collections::HashMap;
 
 pub mod methods;
 pub mod utils;

--- a/rpc-server/src/modules/queries/utils.rs
+++ b/rpc-server/src/modules/queries/utils.rs
@@ -224,7 +224,9 @@ pub async fn run_contract(
     db_manager: std::sync::Arc<Box<dyn database::ReaderDbManager + Sync + Send + 'static>>,
     compiled_contract_code_cache: &std::sync::Arc<CompiledCodeCache>,
     contract_code_cache: &std::sync::Arc<
-        std::sync::RwLock<crate::cache::LruMemoryCache<near_primitives::hash::CryptoHash, Vec<u8>>>,
+        futures_locks::RwLock<
+            crate::cache::LruMemoryCache<near_primitives::hash::CryptoHash, Vec<u8>>,
+        >,
     >,
     block: crate::modules::blocks::CacheBlock,
     max_gas_burnt: near_primitives::types::Gas,
@@ -238,7 +240,7 @@ pub async fn run_contract(
 
     let code: Option<Vec<u8>> = contract_code_cache
         .write()
-        .unwrap()
+        .await
         .get(&contract.data.code_hash())
         .cloned();
 
@@ -255,7 +257,7 @@ pub async fn run_contract(
                 })?;
             contract_code_cache
                 .write()
-                .unwrap()
+                .await
                 .put(contract.data.code_hash(), code.data.clone());
             near_primitives::contract::ContractCode::new(code.data, Some(contract.data.code_hash()))
         }

--- a/rpc-server/src/modules/state/utils.rs
+++ b/rpc-server/src/modules/state/utils.rs
@@ -1,5 +1,6 @@
-use futures::StreamExt;
 use std::collections::HashMap;
+
+use futures::StreamExt;
 
 #[cfg_attr(
     feature = "tracing-instrumentation",


### PR DESCRIPTION
The current implementation faces a challenge where information about validators during an epoch in Near operations may undergo changes. The StakeAction, acting as a trigger for these changes, is not properly considered by the indexer. As a result, the indexer neglects to update validator information when StakeAction occurs, leading to incomplete and inaccurate data about validators for that epoch.

In this PR:
1. Configured the system to save comprehensive information about validators at the conclusion of each epoch. This ensures that the indexer captures and indexes the most up-to-date data about validators, eliminating the issue of incomplete information.
2. Added functionality to include information about the last block of the epoch in the indexing process. This addition ensures that the server maintains a complete record of validator information, providing a comprehensive view of the epoch.

