### PR TITLE
fix function call mismatch error

### DIFF
--- a/rpc-server/src/modules/blocks/mod.rs
+++ b/rpc-server/src/modules/blocks/mod.rs
@@ -17,6 +17,7 @@ pub struct CacheBlock {
 pub struct FinalBlockInfo {
     pub final_block_cache: CacheBlock,
     pub current_protocol_config: near_chain_configs::ProtocolConfigView,
+    pub current_validators: near_primitives::views::EpochValidatorInfo,
 }
 
 impl FinalBlockInfo {
@@ -33,6 +34,10 @@ impl FinalBlockInfo {
             .await
             .expect("Error to get protocol_config");
 
+        let validators = crate::utils::get_current_validators(near_rpc_client)
+            .await
+            .expect("Error to get protocol_config");
+
         blocks_cache
             .write()
             .await
@@ -41,6 +46,7 @@ impl FinalBlockInfo {
         Self {
             final_block_cache: final_block,
             current_protocol_config: protocol_config,
+            current_validators: validators,
         }
     }
 }

--- a/rpc-server/src/modules/queries/methods.rs
+++ b/rpc-server/src/modules/queries/methods.rs
@@ -319,6 +319,7 @@ async fn function_call(
         data.db_manager.clone(),
         &data.compiled_contract_code_cache,
         &data.contract_code_cache,
+        &data.final_block_info,
         block,
         data.max_gas_burnt,
     )

--- a/rpc-server/src/utils.rs
+++ b/rpc-server/src/utils.rs
@@ -126,6 +126,15 @@ pub async fn get_current_protocol_config(
     Ok(near_rpc_client.call(params).await?)
 }
 
+pub async fn get_current_validators(
+    near_rpc_client: &JsonRpcClient,
+) -> anyhow::Result<near_primitives::views::EpochValidatorInfo> {
+    let params = near_jsonrpc_client::methods::validators::RpcValidatorRequest {
+        epoch_reference: near_primitives::types::EpochReference::Latest,
+    };
+    Ok(near_rpc_client.call(params).await?)
+}
+
 async fn handle_streamer_message(
     streamer_message: near_indexer_primitives::StreamerMessage,
     blocks_cache: std::sync::Arc<
@@ -154,6 +163,8 @@ async fn handle_streamer_message(
         );
         finale_block_info.write().await.current_protocol_config =
             get_current_protocol_config(near_rpc_client).await?;
+        finale_block_info.write().await.current_validators =
+            get_current_validators(near_rpc_client).await?;
     }
     finale_block_info.write().await.final_block_cache = block;
     blocks_cache.write().await.put(block.block_height, block);


### PR DESCRIPTION
add current_validators in cache.

For query_function_call we got a lot of errors:  `Failed to get epoch info` 
for cases when we request the latest block