### PR TITLE
add shadow data consistency rate

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -13,6 +13,7 @@ max_gas_burnt = "${MAX_GAS_BURNT}"
 limit_memory_cache = "${LIMIT_MEMORY_CACHE}"
 reserved_memory = "${RESERVED_MEMORY}"
 block_cache_size = "${BLOCK_CACHE_SIZE}"
+shadow_data_consistency_rate = "${SHADOW_DATA_CONSISTENCY_RATE}"
 
 [general.tx_indexer]
 indexer_id = "${TX_INDEXER_ID}"

--- a/configuration/example.config.toml
+++ b/configuration/example.config.toml
@@ -46,6 +46,12 @@ near_rpc_url = "https://beta.rpc.mainnet.near.org"
 ## In 128MB we can put 1_398_101 cache_blocks
 #block_cache_size = 0.125
 
+## How many requests we should check for data consistency
+## By default we use 100% of requests
+## If you want to check 1% of requests, you should set 1
+## thet means for every method calls will be checked every 100th request
+#shadow_data_consistency_rate = 100
+
 ### Tx indexer general configuration
 [general.tx_indexer]
 

--- a/configuration/src/configs/general.rs
+++ b/configuration/src/configs/general.rs
@@ -15,6 +15,7 @@ pub struct GeneralRpcServerConfig {
     pub limit_memory_cache: Option<f64>,
     pub reserved_memory: f64,
     pub block_cache_size: f64,
+    pub shadow_data_consistency_rate: f64,
 }
 
 #[derive(Debug, Clone)]
@@ -97,6 +98,8 @@ pub struct CommonGeneralRpcServerConfig {
     pub reserved_memory: Option<f64>,
     #[serde(deserialize_with = "deserialize_optional_data_or_env", default)]
     pub block_cache_size: Option<f64>,
+    #[serde(deserialize_with = "deserialize_optional_data_or_env", default)]
+    pub shadow_data_consistency_rate: Option<f64>,
 }
 
 impl CommonGeneralRpcServerConfig {
@@ -119,6 +122,10 @@ impl CommonGeneralRpcServerConfig {
     pub fn default_block_cache_size() -> f64 {
         0.125
     }
+
+    pub fn default_shadow_data_consistency_rate() -> f64 {
+        100.0
+    }
 }
 
 impl Default for CommonGeneralRpcServerConfig {
@@ -130,6 +137,7 @@ impl Default for CommonGeneralRpcServerConfig {
             limit_memory_cache: Default::default(),
             reserved_memory: Some(Self::default_reserved_memory()),
             block_cache_size: Some(Self::default_block_cache_size()),
+            shadow_data_consistency_rate: Some(Self::default_shadow_data_consistency_rate()),
         }
     }
 }
@@ -249,6 +257,10 @@ impl From<CommonGeneralConfig> for GeneralRpcServerConfig {
                 .rpc_server
                 .block_cache_size
                 .unwrap_or_else(CommonGeneralRpcServerConfig::default_block_cache_size),
+            shadow_data_consistency_rate: common_config
+                .rpc_server
+                .shadow_data_consistency_rate
+                .unwrap_or_else(CommonGeneralRpcServerConfig::default_shadow_data_consistency_rate),
         }
     }
 }

--- a/rpc-server/src/config.rs
+++ b/rpc-server/src/config.rs
@@ -17,6 +17,7 @@ pub struct ServerContext {
         >,
     >,
     pub max_gas_burnt: near_primitives::types::Gas,
+    pub shadow_data_consistency_rate: f64,
 }
 
 impl ServerContext {
@@ -38,6 +39,7 @@ impl ServerContext {
             >,
         >,
         max_gas_burnt: near_primitives::types::Gas,
+        shadow_data_consistency_rate: f64,
     ) -> Self {
         Self {
             s3_client,
@@ -50,6 +52,7 @@ impl ServerContext {
             compiled_contract_code_cache,
             contract_code_cache,
             max_gas_burnt,
+            shadow_data_consistency_rate,
         }
     }
 }

--- a/rpc-server/src/main.rs
+++ b/rpc-server/src/main.rs
@@ -106,6 +106,7 @@ async fn main() -> anyhow::Result<()> {
         compiled_contract_code_cache,
         contract_code_cache,
         rpc_server_config.general.max_gas_burnt,
+        rpc_server_config.general.shadow_data_consistency_rate,
     );
 
     tokio::spawn(async move {

--- a/rpc-server/src/modules/receipts/methods.rs
+++ b/rpc-server/src/modules/receipts/methods.rs
@@ -2,8 +2,6 @@ use jsonrpc_v2::{Data, Params};
 
 use crate::config::ServerContext;
 use crate::errors::RPCError;
-#[cfg(feature = "shadow_data_consistency")]
-use crate::utils::shadow_compare_results;
 
 /// Fetches a receipt by it's ID (as is, without a status or execution outcome)
 #[cfg_attr(feature = "tracing-instrumentation", tracing::instrument(skip(data)))]
@@ -18,29 +16,18 @@ pub async fn receipt(
 
     #[cfg(feature = "shadow_data_consistency")]
     {
-        let near_rpc_client = data.near_rpc_client.clone();
-        let meta_data = format!("{:?}", params);
-        let (read_rpc_response_json, is_response_ok) = match &result {
-            Ok(res) => (serde_json::to_value(res), true),
-            Err(err) => (serde_json::to_value(err), false),
-        };
-
-        let comparison_result = shadow_compare_results(
-            read_rpc_response_json,
-            near_rpc_client,
+        if let Some(err_code) = crate::utils::shadow_compare_results_handler(
+            crate::metrics::RECEIPT_REQUESTS_TOTAL.get(),
+            data.shadow_data_consistency_rate,
+            &result,
+            data.near_rpc_client.clone(),
             params,
-            is_response_ok,
+            "RECEIPT",
         )
-        .await;
-
-        match comparison_result {
-            Ok(_) => {
-                tracing::info!(target: "shadow_data_consistency", "Shadow data check: CORRECT\n{}", meta_data);
-            }
-            Err(err) => {
-                crate::utils::capture_shadow_consistency_error!(err, meta_data, "RECEIPT");
-            }
-        }
+        .await
+        {
+            crate::utils::capture_shadow_consistency_error!(err_code, "RECEIPT")
+        };
     }
 
     Ok(result.map_err(near_jsonrpc_primitives::errors::RpcError::from)?)


### PR DESCRIPTION
This pull request introduces a new parameter, shadow_data_consistency_rate, which offers the opportunity to compare a subset of results rather than the entirety of data. With this enhancement, users can specify a percentage of data to be compared for each request method, optimizing resource utilization and providing flexibility in data validation processes.

New Parameter: `shadow_data_consistency_rate`
1. This parameter allows users to define the percentage of data to be compared for each request method.
2. Default value: 100% (all data compared).
3. Range: 0% to 100%
4. Use-case: Users can set a lower percentage to perform partial data validation, reducing computational overhead.

Benefits:
1. Resource Optimization: Users can conserve resources by selectively validating a portion of data, especially in scenarios where full validation isn't necessary.
2. Flexibility: Provides users with granular control over data validation processes, accommodating diverse use-cases and performance requirements.
3. Improved Efficiency: Reduces computational burden by allowing for partial data comparison, enhancing overall system efficiency.

Impact:
1. Backward Compatibility: This enhancement maintains backward compatibility, ensuring existing functionality remains intact.
2. Ease of Adoption: The new parameter seamlessly integrates with existing methods, requiring minimal changes to existing codebases.