### PR TITLE
Additional metrics to measure proxy calls (archival)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added support for `SyncCheckpoint` in the `block` method for better block handling and synchronization.
-
+- Added `ARCHIVAL_PROXY_QUERY_VIEW_STATE_WITH_INCLUDE_PROOFS` metric to track the number of archival proxy requests for view state with include proofs. 
 ### Changed
 - Enhanced the tx method to show in-progress transaction status, avoiding `UNKNOWN_TRANSACTION` responses and providing more accurate feedback.
 

--- a/rpc-server/src/metrics.rs
+++ b/rpc-server/src/metrics.rs
@@ -578,6 +578,14 @@ lazy_static! {
     // end RECEIPT
 }
 
+lazy_static! {
+    // ARCHIVAL PROXY CALL COUNTERS
+    pub(crate) static ref ARCHIVAL_PROXY_QUERY_VIEW_STATE_WITH_INCLUDE_PROOFS: IntCounter = try_create_int_counter(
+        "archive_proxy_query_view_state_with_include_proofs",
+        "Total number of the request to the archive nodes query_view_state with include_proofs"
+    ).unwrap();
+}
+
 /// Exposes prometheus metrics
 #[get("/metrics")]
 pub(crate) async fn get_metrics() -> impl Responder {


### PR DESCRIPTION
1. Rewrite the method to get genesis_block from `lake_framework` to avoid the call to archive nodes.
2. Added `archive_proxy_query_view_state_with_include_proofs` metric to calculate count of requests to the archive nodes
3. Added separation of calls in the `QUERY.VIEW_STATE` method with the `include_proof` flag into regular and archive nodes