### PR TITLE
refactor: Revert the logic behind the responding block_height and block_hash in query method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added support for `SyncCheckpoint` in the `block` method for better block handling and synchronization.
-- Added `ARCHIVAL_PROXY_QUERY_VIEW_STATE_WITH_INCLUDE_PROOFS` metric to track the number of archival proxy requests for view state with include proofs. 
+- Added `ARCHIVAL_PROXY_QUERY_VIEW_STATE_WITH_INCLUDE_PROOFS` metric to track the number of archival proxy requests for view state with include proofs.
 ### Changed
 - Enhanced the tx method to show in-progress transaction status, avoiding `UNKNOWN_TRANSACTION` responses and providing more accurate feedback.
+- Reverted the logic behind the `block_height` and `block_hash` parameters in the `query` method to match the behavior of the `nearcore` JSON-RPC API.
 
 ### Removed
 - Dropped the `SYNC_CHECKPOINT_REQUESTS_TOTAL` metric for redundancy.

--- a/readnode-primitives/src/lib.rs
+++ b/readnode-primitives/src/lib.rs
@@ -171,6 +171,10 @@ pub type StateValue = Vec<u8>;
 pub struct BlockHeightShardId(pub u64, pub u64);
 pub struct QueryData<T: BorshDeserialize> {
     pub data: T,
+    // block_height and block_hash we return here represents the moment
+    // when the data was last updated in the database
+    // We used to return it in the `QueryResponse` but it was replaced with
+    // the logic that corresponds the logic of the `nearcore` RPC API
     pub block_height: near_indexer_primitives::types::BlockHeight,
     pub block_hash: CryptoHash,
 }

--- a/rpc-server/src/modules/queries/methods.rs
+++ b/rpc-server/src/modules/queries/methods.rs
@@ -258,8 +258,8 @@ async fn view_account(
         kind: near_jsonrpc_primitives::types::query::QueryResponseKind::ViewAccount(
             near_primitives::views::AccountView::from(account.data),
         ),
-        block_height: account.block_height,
-        block_hash: account.block_hash,
+        block_height: block.block_height,
+        block_hash: block.block_hash,
     })
 }
 
@@ -308,8 +308,8 @@ async fn view_code(
                 ),
             ),
         ),
-        block_height: contract.block_height,
-        block_hash: contract.block_hash,
+        block_height: block.block_height,
+        block_hash: block.block_hash,
     })
 }
 
@@ -352,8 +352,8 @@ async fn function_call(
                 logs: call_results.logs,
             },
         ),
-        block_height: call_results.block_height,
-        block_hash: call_results.block_hash,
+        block_height: block.block_height,
+        block_hash: block.block_hash,
     })
 }
 
@@ -387,9 +387,6 @@ async fn view_state(
 
     Ok(near_jsonrpc_primitives::types::query::RpcQueryResponse {
         kind: near_jsonrpc_primitives::types::query::QueryResponseKind::ViewState(contract_state),
-        // We cannot return the block height and hash for the state, since different state keys
-        // can be from different blocks.
-        // We return the block height and hash for the requested block instead.
         block_height: block.block_height,
         block_hash: block.block_hash,
     })
@@ -428,8 +425,8 @@ async fn view_access_key(
         kind: near_jsonrpc_primitives::types::query::QueryResponseKind::AccessKey(
             near_primitives::views::AccessKeyView::from(access_key.data),
         ),
-        block_height: access_key.block_height,
-        block_hash: access_key.block_hash,
+        block_height: block.block_height,
+        block_hash: block.block_hash,
     })
 }
 


### PR DESCRIPTION
Some time ago, while we were actively developing and debugging the storage of the ReadRPC, we introduced a change in the logic different from the `nearcore` JSON-RPC API. Thus, we started to respond with the `block_height` and `block_hash` in the `query` method responses with the block data around the block **we observed the last change to the data** instead of the block we observed the data at. 

*Please feel free to ask in the comments if my explanation is confusing**

This PR reverts that logic to follow the `nearcore` one. Now, we will respond with the final block from the ReadRPC point of view when we ask. 

@kobayurii, we could have adjusted the `shadow_data_consistency` logic for this check. We don't need to match the blocks since it won't match anyway, but perhaps some additional polish would be required. 