### PR TITLE
[status] Implement `status` method that is able to return `near_primitives::views::StatusResponse`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added support for `SyncCheckpoint` in the `block` method for better block handling and synchronization.
 - Added `ARCHIVAL_PROXY_QUERY_VIEW_STATE_WITH_INCLUDE_PROOFS` metric to track the number of archival proxy requests for view state with include proofs.
+- Added `GET /health` for the healthcheck of rpc-server.
+- Implemented the `status` method to accommodate `near_primitives::views::StatusResponse`.
+- Implemented the `health` method. Health includes the info about the syncing state of the node of `rpc-server`.
+
 ### Changed
 - Enhanced the tx method to show in-progress transaction status, avoiding `UNKNOWN_TRANSACTION` responses and providing more accurate feedback.
 - Reverted the logic behind the `block_height` and `block_hash` parameters in the `query` method to match the behavior of the `nearcore` JSON-RPC API.

--- a/docs/RPC_METHODS.md
+++ b/docs/RPC_METHODS.md
@@ -1,27 +1,28 @@
-| **Method**                      | **status** | **Note**                                                         |
-|---------------------------------|------------|------------------------------------------------------------------|
-| block                           | Included   |                                                                  |
-| chunk                           | Included   |                                                                  |
-| query.view_account              | Included   |                                                                  |
-| query.view_state                | Included   |                                                                  |
-| view_state_paginated            | Included   | Custom method. See details [here](../docs/CUSTOM_RPC_METHODS.md) |
-| query.view_code                 | Included   |                                                                  |
-| query.view_access_key           | Included   |                                                                  |
-| query.call_function             | Included   |                                                                  |
-| query.view_access_key_list      | Proxy      | Planned. It will be implemented in the future.                   |
-| gas_price                       | Included   |                                                                  |
-| tx                              | Included   |                                                                  |
-| EXPERIMENTAL_tx_status          | Included   |                                                                  |
-| broadcast_tx_commit             | Proxy      | PROXY_ONLY. Immediately proxy to a real RPC.                     |
-| broadcast_tx_async              | Proxy      | PROXY_ONLY. Immediately proxy to a real RPC.                     |
-| EXPETIMENTAL_receipt            | Included   |                                                                  |
-| EXPERIMENTAL_changes            | Included   |                                                                  |
-| EXPERIMENTAL_changes_in_block   | Included   |                                                                  |
-| network_info                    | Proxy      | PROXY_ONLY. Immediately proxy to a real RPC.                     |
-| status                          | Included   |                                                                  |
-| light_client_proof              | Proxy      |                                                                  |
-| next_light_client_block         | Proxy      |                                                                  |
-| validators                      | Included   |                                                                  |
-| EXPERIMENTAL_validators_ordered | Proxy      |                                                                  |
-| EXPERIMENTAL_genesis_config     | Included   | Cache it on the start.                                           |
-| EXPERIMENTAL_protocol_config    | Included   |                                                                  |
+| **Method**                      | **status** | **Note**                                                                    |
+|---------------------------------|------------|-----------------------------------------------------------------------------|
+| block                           | Included   |                                                                             |
+| chunk                           | Included   |                                                                             |
+| query.view_account              | Included   |                                                                             |
+| query.view_state                | Included   |                                                                             |
+| view_state_paginated            | Included   | Custom method. See details [here](../docs/CUSTOM_RPC_METHODS.md)            |
+| query.view_code                 | Included   |                                                                             |
+| query.view_access_key           | Included   |                                                                             |
+| query.call_function             | Included   |                                                                             |
+| query.view_access_key_list      | Proxy      | Planned. It will be implemented in the future.                              |
+| gas_price                       | Included   |                                                                             |
+| tx                              | Included   |                                                                             |
+| EXPERIMENTAL_tx_status          | Included   |                                                                             |
+| broadcast_tx_commit             | Proxy      | PROXY_ONLY. Immediately proxy to a real RPC.                                |
+| broadcast_tx_async              | Proxy      | PROXY_ONLY. Immediately proxy to a real RPC.                                |
+| EXPETIMENTAL_receipt            | Included   |                                                                             |
+| EXPERIMENTAL_changes            | Included   |                                                                             |
+| EXPERIMENTAL_changes_in_block   | Included   |                                                                             |
+| network_info                    | Proxy      | PROXY_ONLY. Immediately proxy to a real RPC.                                |
+| status                          | Included   |                                                                             |
+| health                          | Included   | Health includes the info about the syncing state of the node of rpc-server. |
+| light_client_proof              | Proxy      |                                                                             |
+| next_light_client_block         | Proxy      |                                                                             |
+| validators                      | Included   |                                                                             |
+| EXPERIMENTAL_validators_ordered | Proxy      |                                                                             |
+| EXPERIMENTAL_genesis_config     | Included   | Cache it on the start.                                                      |
+| EXPERIMENTAL_protocol_config    | Included   |                                                                             |

--- a/docs/RPC_METHODS.md
+++ b/docs/RPC_METHODS.md
@@ -1,27 +1,27 @@
-| **Method**                      | **status**    | **Note**                                                         |
-|---------------------------------|---------------|------------------------------------------------------------------|
-| block                           | Included      |                                                                  |
-| chunk                           | Included      |                                                                  |
-| query.view_account              | Included      |                                                                  |
-| query.view_state                | Included      |                                                                  |
-| view_state_paginated            | Included      | Custom method. See details [here](../docs/CUSTOM_RPC_METHODS.md) |
-| query.view_code                 | Included      |                                                                  |
-| query.view_access_key           | Included      |                                                                  |
-| query.call_function             | Included      |                                                                  |
-| query.view_access_key_list      | Proxy         | Planned. It will be implemented in the future.                   |
-| gas_price                       | Included      |                                                                  |
-| tx                              | Included      |                                                                  |
-| EXPERIMENTAL_tx_status          | Included      |                                                                  |
-| broadcast_tx_commit             | Proxy         | PROXY_ONLY. Immediately proxy to a real RPC.                     |
-| broadcast_tx_async              | Proxy         | PROXY_ONLY. Immediately proxy to a real RPC.                     |
-| EXPETIMENTAL_receipt            | Included      |                                                                  |
-| EXPERIMENTAL_changes            | Included      |                                                                  |
-| EXPERIMENTAL_changes_in_block   | Included      |                                                                  |
-| network_info                    | Proxy         | PROXY_ONLY. Immediately proxy to a real RPC.                     |
-| status                          | Unimplemented | Issue: https://github.com/near/read-rpc/issues/181               |
-| light_client_proof              | Proxy         |                                                                  |
-| next_light_client_block         | Proxy         |                                                                  |
-| validators                      | Included      |                                                                  |
-| EXPERIMENTAL_validators_ordered | Proxy         |                                                                  |
-| EXPERIMENTAL_genesis_config     | Included      | Cache it on the start.                                           |
-| EXPERIMENTAL_protocol_config    | Included      |                                                                  |
+| **Method**                      | **status** | **Note**                                                         |
+|---------------------------------|------------|------------------------------------------------------------------|
+| block                           | Included   |                                                                  |
+| chunk                           | Included   |                                                                  |
+| query.view_account              | Included   |                                                                  |
+| query.view_state                | Included   |                                                                  |
+| view_state_paginated            | Included   | Custom method. See details [here](../docs/CUSTOM_RPC_METHODS.md) |
+| query.view_code                 | Included   |                                                                  |
+| query.view_access_key           | Included   |                                                                  |
+| query.call_function             | Included   |                                                                  |
+| query.view_access_key_list      | Proxy      | Planned. It will be implemented in the future.                   |
+| gas_price                       | Included   |                                                                  |
+| tx                              | Included   |                                                                  |
+| EXPERIMENTAL_tx_status          | Included   |                                                                  |
+| broadcast_tx_commit             | Proxy      | PROXY_ONLY. Immediately proxy to a real RPC.                     |
+| broadcast_tx_async              | Proxy      | PROXY_ONLY. Immediately proxy to a real RPC.                     |
+| EXPETIMENTAL_receipt            | Included   |                                                                  |
+| EXPERIMENTAL_changes            | Included   |                                                                  |
+| EXPERIMENTAL_changes_in_block   | Included   |                                                                  |
+| network_info                    | Proxy      | PROXY_ONLY. Immediately proxy to a real RPC.                     |
+| status                          | Included   |                                                                  |
+| light_client_proof              | Proxy      |                                                                  |
+| next_light_client_block         | Proxy      |                                                                  |
+| validators                      | Included   |                                                                  |
+| EXPERIMENTAL_validators_ordered | Proxy      |                                                                  |
+| EXPERIMENTAL_genesis_config     | Included   | Cache it on the start.                                           |
+| EXPERIMENTAL_protocol_config    | Included   |                                                                  |

--- a/rpc-server/src/health.rs
+++ b/rpc-server/src/health.rs
@@ -24,44 +24,55 @@ pub struct RPCHealthStatusResponse {
     final_block_height: u64,
 }
 
+impl RPCHealthStatusResponse {
+    pub async fn new(server_context: &ServerContext) -> Self {
+        let sys = System::new_all();
+        let total_memory = sys.total_memory();
+        let used_memory = sys.used_memory();
+        let blocks_cache = server_context.blocks_cache.read().await;
+        let contract_code_cache = server_context.contract_code_cache.read().await;
+        let compiled_contract_code_cache = server_context
+            .compiled_contract_code_cache
+            .local_cache
+            .read()
+            .await;
+        Self {
+            total_memory: friendly_memory_size_format(total_memory as usize),
+            used_memory: friendly_memory_size_format(used_memory as usize),
+            available_memory: friendly_memory_size_format((total_memory - used_memory) as usize),
+
+            blocks_in_cache: blocks_cache.len(),
+            max_blocks_cache_size: friendly_memory_size_format(blocks_cache.max_size()),
+            current_blocks_cache_size: friendly_memory_size_format(blocks_cache.current_size()),
+
+            contracts_codes_in_cache: contract_code_cache.len(),
+            max_contracts_codes_cache_size: friendly_memory_size_format(
+                contract_code_cache.max_size(),
+            ),
+            current_contracts_codes_cache_size: friendly_memory_size_format(
+                contract_code_cache.current_size(),
+            ),
+
+            compiled_contracts_codes_in_cache: compiled_contract_code_cache.len(),
+            max_compiled_contracts_codes_cache_size: friendly_memory_size_format(
+                compiled_contract_code_cache.max_size(),
+            ),
+            current_compiled_contracts_codes_cache_size: friendly_memory_size_format(
+                compiled_contract_code_cache.current_size(),
+            ),
+
+            final_block_height: server_context
+                .final_block_info
+                .read()
+                .await
+                .final_block_cache
+                .block_height,
+        }
+    }
+}
+
 /// Rpc server status
 #[actix_web::get("/health")]
 pub(crate) async fn get_health_status(data: actix_web::web::Data<ServerContext>) -> impl Responder {
-    let sys = System::new_all();
-    let total_memory = sys.total_memory();
-    let used_memory = sys.used_memory();
-    let blocks_cache = data.blocks_cache.read().await;
-    let contract_code_cache = data.contract_code_cache.read().await;
-    let compiled_contract_code_cache = data.compiled_contract_code_cache.local_cache.read().await;
-    let status = RPCHealthStatusResponse {
-        total_memory: friendly_memory_size_format(total_memory as usize),
-        used_memory: friendly_memory_size_format(used_memory as usize),
-        available_memory: friendly_memory_size_format((total_memory - used_memory) as usize),
-
-        blocks_in_cache: blocks_cache.len(),
-        max_blocks_cache_size: friendly_memory_size_format(blocks_cache.max_size()),
-        current_blocks_cache_size: friendly_memory_size_format(blocks_cache.current_size()),
-
-        contracts_codes_in_cache: contract_code_cache.len(),
-        max_contracts_codes_cache_size: friendly_memory_size_format(contract_code_cache.max_size()),
-        current_contracts_codes_cache_size: friendly_memory_size_format(
-            contract_code_cache.current_size(),
-        ),
-
-        compiled_contracts_codes_in_cache: compiled_contract_code_cache.len(),
-        max_compiled_contracts_codes_cache_size: friendly_memory_size_format(
-            compiled_contract_code_cache.max_size(),
-        ),
-        current_compiled_contracts_codes_cache_size: friendly_memory_size_format(
-            compiled_contract_code_cache.current_size(),
-        ),
-
-        final_block_height: data
-            .final_block_info
-            .read()
-            .await
-            .final_block_cache
-            .block_height,
-    };
-    actix_web::web::Json(status)
+    actix_web::web::Json(RPCHealthStatusResponse::new(&data).await)
 }

--- a/rpc-server/src/main.rs
+++ b/rpc-server/src/main.rs
@@ -80,6 +80,7 @@ async fn main() -> anyhow::Result<()> {
         )
         .with_method("gas_price", modules::gas::methods::gas_price)
         .with_method("status", modules::network::methods::status)
+        .with_method("health", modules::network::methods::health)
         .with_method(
             "light_client_proof",
             modules::clients::methods::light_client_proof,

--- a/rpc-server/src/modules/network/methods.rs
+++ b/rpc-server/src/modules/network/methods.rs
@@ -60,6 +60,15 @@ pub async fn status(
     })
 }
 
+pub async fn health(
+    data: Data<ServerContext>,
+    Params(_params): Params<serde_json::Value>,
+) -> Result<crate::health::RPCHealthStatusResponse, RPCError> {
+    // TODO: Improve to return error after implementing optimistic block
+    // see nearcore/chain/client/src/client_actor.rs:627 to get details
+    Ok(crate::health::RPCHealthStatusResponse::new(&data).await)
+}
+
 pub async fn network_info(
     Params(_params): Params<serde_json::Value>,
 ) -> Result<near_jsonrpc_primitives::types::network_info::RpcNetworkInfoResponse, RPCError> {

--- a/rpc-server/src/modules/network/methods.rs
+++ b/rpc-server/src/modules/network/methods.rs
@@ -1,17 +1,63 @@
+use jsonrpc_v2::{Data, Params};
+
+use near_primitives::utils::from_timestamp;
+
 use crate::config::ServerContext;
 use crate::errors::RPCError;
 use crate::modules::blocks::utils::fetch_block_from_cache_or_get;
 use crate::modules::network::{clone_protocol_config, parse_validator_request};
-use jsonrpc_v2::{Data, Params};
 
 pub async fn status(
-    _data: Data<ServerContext>,
+    data: Data<ServerContext>,
     Params(_params): Params<serde_json::Value>,
 ) -> Result<near_primitives::views::StatusResponse, RPCError> {
-    // TODO: Implement status. Issue: https://github.com/near/read-rpc/issues/181
-    Err(RPCError::unimplemented_error(
-        "Method is not implemented yet. Issue: https://github.com/near/read-rpc/issues/181",
-    ))
+    let final_block_info = data.final_block_info.read().await;
+    let validators = final_block_info
+        .current_validators
+        .current_validators
+        .iter()
+        .map(|validator| near_primitives::views::ValidatorInfo {
+            account_id: validator.account_id.clone(),
+            is_slashed: validator.is_slashed,
+        })
+        .collect();
+
+    Ok(near_primitives::views::StatusResponse {
+        version: data.version.clone(),
+        chain_id: data.genesis_info.genesis_config.chain_id.clone(),
+        protocol_version: near_primitives::version::PROTOCOL_VERSION,
+        latest_protocol_version: final_block_info.final_block_cache.latest_protocol_version,
+        // Address for current read_node RPC server.
+        rpc_addr: Some(format!("0.0.0.0:{}", data.server_port)),
+        validators,
+        sync_info: near_primitives::views::StatusSyncInfo {
+            latest_block_hash: final_block_info.final_block_cache.block_hash,
+            latest_block_height: final_block_info.final_block_cache.block_height,
+            latest_state_root: final_block_info.final_block_cache.state_root,
+            latest_block_time: from_timestamp(final_block_info.final_block_cache.block_timestamp),
+            // Always false because read_node is not need to sync
+            syncing: false,
+            earliest_block_hash: Some(data.genesis_info.genesis_block_cache.block_hash),
+            earliest_block_height: Some(data.genesis_info.genesis_block_cache.block_height),
+            earliest_block_time: Some(from_timestamp(
+                data.genesis_info.genesis_block_cache.block_timestamp,
+            )),
+            epoch_id: Some(near_primitives::types::EpochId(
+                final_block_info.final_block_cache.epoch_id,
+            )),
+            epoch_start_height: Some(final_block_info.current_validators.epoch_start_height),
+        },
+        validator_account_id: None,
+        validator_public_key: None,
+        // Generate empty public key because read_node is not regular archiver node
+        node_public_key: near_crypto::PublicKey::empty(near_crypto::KeyType::ED25519),
+        node_key: None,
+        // return uptime current read_node
+        uptime_sec: near_primitives::static_clock::StaticClock::utc().timestamp()
+            - data.boot_time_seconds,
+        // Not using for status method
+        detailed_debug_status: None,
+    })
 }
 
 pub async fn network_info(


### PR DESCRIPTION
This pull request addresses the issue #181 of implementing the status method, enhancing its functionality to enable the return of `near_primitives::views::StatusResponse`.

* Implemented the `status` method to accommodate `near_primitives::views::StatusResponse`.
* Implemented the `health` method. Health includes the info about the syncing state of the node of `rpc-server`.