### PR TITLE
add archival proxy `light_client_proof` and `next_light_client_block`

### DIFF
--- a/rpc-server/src/metrics.rs
+++ b/rpc-server/src/metrics.rs
@@ -601,6 +601,14 @@ lazy_static! {
         "archive_proxy_query_view_state_with_include_proofs",
         "Total number of the request to the archive nodes query_view_state with include_proofs"
     ).unwrap();
+    pub(crate) static ref ARCHIVAL_PROXY_LIGHT_CLIENT_PROOF: IntCounter = try_create_int_counter(
+        "archive_proxy_light_client_proof",
+        "Total number of the request to the archive nodes light_client_proof"
+    ).unwrap();
+    pub(crate) static ref ARCHIVAL_PROXY_NEXT_LIGHT_CLIENT_BLOCK: IntCounter = try_create_int_counter(
+        "archive_proxy_next_light_client_block",
+        "Total number of the request to the archive nodes next_light_client_block"
+    ).unwrap();
 }
 
 /// Exposes prometheus metrics

--- a/rpc-server/src/modules/clients/methods.rs
+++ b/rpc-server/src/modules/clients/methods.rs
@@ -11,7 +11,8 @@ pub async fn light_client_proof(
     near_jsonrpc_primitives::types::light_client::RpcLightClientExecutionProofResponse,
     RPCError,
 > {
-    Ok(data.near_rpc_client.call(params).await?)
+    crate::metrics::ARCHIVAL_PROXY_LIGHT_CLIENT_PROOF.inc();
+    Ok(data.near_rpc_client.archival_call(params).await?)
 }
 
 pub async fn next_light_client_block(
@@ -21,7 +22,8 @@ pub async fn next_light_client_block(
     >,
 ) -> Result<near_jsonrpc_primitives::types::light_client::RpcLightClientNextBlockResponse, RPCError>
 {
-    match data.near_rpc_client.call(params).await? {
+    crate::metrics::ARCHIVAL_PROXY_NEXT_LIGHT_CLIENT_BLOCK.inc();
+    match data.near_rpc_client.archival_call(params).await? {
         Some(light_client_block) => Ok(
             near_jsonrpc_primitives::types::light_client::RpcLightClientNextBlockResponse {
                 light_client_block: Some(std::sync::Arc::new(light_client_block)),


### PR DESCRIPTION
This pr includes two changes:
1. Added  archival proxies for methods `light_client_proof` and `next_light_client_block`
2. Added metrics to count archival proxies: `archive_proxy_light_client_proof` and `archive_proxy_next_light_client_block`