### PR TITLE
Implement support for optimistic block finality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1233,9 +1233,9 @@ checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 
 [[package]]
 name = "bumpalo"
-version = "3.15.3"
+version = "3.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea184aa71bb362a1157c896979544cc23974e08fd265f29ea96b59f0b4a555b"
+checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
 
 [[package]]
 name = "bytecheck"
@@ -1328,9 +1328,9 @@ checksum = "a2698f953def977c68f935bb0dfa959375ad4638570e969e2f1e9f433cbf1af6"
 
 [[package]]
 name = "cc"
-version = "1.0.89"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0ba8f7aaa012f30d5b2861462f6708eccd49c3c39863fe083a308035f63d723"
+checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
 dependencies = [
  "jobserver",
  "libc",
@@ -1400,9 +1400,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.1"
+version = "4.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c918d541ef2913577a0f9566e9ce27cb35b6df072075769e0b26cb5a554520da"
+checksum = "b230ab84b0ffdf890d5a10abdbc8b83ae1c4918275daea1ab8801f71536b2651"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1410,9 +1410,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.1"
+version = "4.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f3e7391dad68afb0c2ede1bf619f579a3dc9c2ec67f089baa397123a2f3d1eb"
+checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2496,7 +2496,7 @@ dependencies = [
  "database",
  "near-chain-configs 0.0.0",
  "near-indexer-primitives",
- "near-jsonrpc-client 0.8.0 (git+https://github.com/kobayurii/near-jsonrpc-client-rs.git?branch=0.8.1)",
+ "near-jsonrpc-client 0.8.0 (git+https://github.com/kobayurii/near-jsonrpc-client-rs.git?branch=0.8.3)",
  "near-lake-framework",
  "readnode-primitives",
  "tokio",
@@ -2511,9 +2511,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "erased-serde"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388979d208a049ffdfb22fa33b9c81942215b940910bccfe258caeb25d125cb3"
+checksum = "2b73807008a3c7f171cc40312f37d95ef0396e048b5848d775f54b1a4dd4a0d3"
 dependencies = [
  "serde",
 ]
@@ -3792,7 +3792,7 @@ dependencies = [
 [[package]]
 name = "near-async"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=6216a118cc3833d916723b9724b9d747c3c4c563#6216a118cc3833d916723b9724b9d747c3c4c563"
+source = "git+https://github.com/near/nearcore.git?rev=4429cc8682eb3c00901af5d96233fef04768bf5a#4429cc8682eb3c00901af5d96233fef04768bf5a"
 dependencies = [
  "actix",
  "derive_more",
@@ -3810,7 +3810,7 @@ dependencies = [
 [[package]]
 name = "near-async-derive"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=6216a118cc3833d916723b9724b9d747c3c4c563#6216a118cc3833d916723b9724b9d747c3c4c563"
+source = "git+https://github.com/near/nearcore.git?rev=4429cc8682eb3c00901af5d96233fef04768bf5a#4429cc8682eb3c00901af5d96233fef04768bf5a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3820,7 +3820,7 @@ dependencies = [
 [[package]]
 name = "near-cache"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=6216a118cc3833d916723b9724b9d747c3c4c563#6216a118cc3833d916723b9724b9d747c3c4c563"
+source = "git+https://github.com/near/nearcore.git?rev=4429cc8682eb3c00901af5d96233fef04768bf5a#4429cc8682eb3c00901af5d96233fef04768bf5a"
 dependencies = [
  "lru 0.7.8",
 ]
@@ -3828,7 +3828,7 @@ dependencies = [
 [[package]]
 name = "near-chain"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=6216a118cc3833d916723b9724b9d747c3c4c563#6216a118cc3833d916723b9724b9d747c3c4c563"
+source = "git+https://github.com/near/nearcore.git?rev=4429cc8682eb3c00901af5d96233fef04768bf5a#4429cc8682eb3c00901af5d96233fef04768bf5a"
 dependencies = [
  "actix",
  "assert_matches",
@@ -3874,7 +3874,7 @@ dependencies = [
 [[package]]
 name = "near-chain-configs"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=6216a118cc3833d916723b9724b9d747c3c4c563#6216a118cc3833d916723b9724b9d747c3c4c563"
+source = "git+https://github.com/near/nearcore.git?rev=4429cc8682eb3c00901af5d96233fef04768bf5a#4429cc8682eb3c00901af5d96233fef04768bf5a"
 dependencies = [
  "anyhow",
  "bytesize",
@@ -3922,7 +3922,7 @@ dependencies = [
 [[package]]
 name = "near-chain-primitives"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=6216a118cc3833d916723b9724b9d747c3c4c563#6216a118cc3833d916723b9724b9d747c3c4c563"
+source = "git+https://github.com/near/nearcore.git?rev=4429cc8682eb3c00901af5d96233fef04768bf5a#4429cc8682eb3c00901af5d96233fef04768bf5a"
 dependencies = [
  "near-async",
  "near-crypto 0.0.0",
@@ -3935,7 +3935,7 @@ dependencies = [
 [[package]]
 name = "near-chunks"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=6216a118cc3833d916723b9724b9d747c3c4c563#6216a118cc3833d916723b9724b9d747c3c4c563"
+source = "git+https://github.com/near/nearcore.git?rev=4429cc8682eb3c00901af5d96233fef04768bf5a#4429cc8682eb3c00901af5d96233fef04768bf5a"
 dependencies = [
  "actix",
  "borsh 1.3.1",
@@ -3968,7 +3968,7 @@ dependencies = [
 [[package]]
 name = "near-chunks-primitives"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=6216a118cc3833d916723b9724b9d747c3c4c563#6216a118cc3833d916723b9724b9d747c3c4c563"
+source = "git+https://github.com/near/nearcore.git?rev=4429cc8682eb3c00901af5d96233fef04768bf5a#4429cc8682eb3c00901af5d96233fef04768bf5a"
 dependencies = [
  "near-chain-primitives",
  "near-primitives 0.0.0",
@@ -3977,7 +3977,7 @@ dependencies = [
 [[package]]
 name = "near-client"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=6216a118cc3833d916723b9724b9d747c3c4c563#6216a118cc3833d916723b9724b9d747c3c4c563"
+source = "git+https://github.com/near/nearcore.git?rev=4429cc8682eb3c00901af5d96233fef04768bf5a#4429cc8682eb3c00901af5d96233fef04768bf5a"
 dependencies = [
  "actix",
  "actix-rt",
@@ -4033,7 +4033,7 @@ dependencies = [
 [[package]]
 name = "near-client-primitives"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=6216a118cc3833d916723b9724b9d747c3c4c563#6216a118cc3833d916723b9724b9d747c3c4c563"
+source = "git+https://github.com/near/nearcore.git?rev=4429cc8682eb3c00901af5d96233fef04768bf5a#4429cc8682eb3c00901af5d96233fef04768bf5a"
 dependencies = [
  "actix",
  "chrono",
@@ -4055,7 +4055,7 @@ dependencies = [
 [[package]]
 name = "near-config-utils"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=6216a118cc3833d916723b9724b9d747c3c4c563#6216a118cc3833d916723b9724b9d747c3c4c563"
+source = "git+https://github.com/near/nearcore.git?rev=4429cc8682eb3c00901af5d96233fef04768bf5a#4429cc8682eb3c00901af5d96233fef04768bf5a"
 dependencies = [
  "anyhow",
  "json_comments",
@@ -4078,7 +4078,7 @@ dependencies = [
 [[package]]
 name = "near-crypto"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=6216a118cc3833d916723b9724b9d747c3c4c563#6216a118cc3833d916723b9724b9d747c3c4c563"
+source = "git+https://github.com/near/nearcore.git?rev=4429cc8682eb3c00901af5d96233fef04768bf5a#4429cc8682eb3c00901af5d96233fef04768bf5a"
 dependencies = [
  "blake2",
  "borsh 1.3.1",
@@ -4129,7 +4129,7 @@ dependencies = [
 [[package]]
 name = "near-dyn-configs"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=6216a118cc3833d916723b9724b9d747c3c4c563#6216a118cc3833d916723b9724b9d747c3c4c563"
+source = "git+https://github.com/near/nearcore.git?rev=4429cc8682eb3c00901af5d96233fef04768bf5a#4429cc8682eb3c00901af5d96233fef04768bf5a"
 dependencies = [
  "anyhow",
  "near-async",
@@ -4148,7 +4148,7 @@ dependencies = [
 [[package]]
 name = "near-epoch-manager"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=6216a118cc3833d916723b9724b9d747c3c4c563#6216a118cc3833d916723b9724b9d747c3c4c563"
+source = "git+https://github.com/near/nearcore.git?rev=4429cc8682eb3c00901af5d96233fef04768bf5a#4429cc8682eb3c00901af5d96233fef04768bf5a"
 dependencies = [
  "borsh 1.3.1",
  "itertools 0.10.5",
@@ -4171,7 +4171,7 @@ dependencies = [
 [[package]]
 name = "near-fmt"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=6216a118cc3833d916723b9724b9d747c3c4c563#6216a118cc3833d916723b9724b9d747c3c4c563"
+source = "git+https://github.com/near/nearcore.git?rev=4429cc8682eb3c00901af5d96233fef04768bf5a#4429cc8682eb3c00901af5d96233fef04768bf5a"
 dependencies = [
  "near-primitives-core 0.0.0",
 ]
@@ -4188,7 +4188,7 @@ dependencies = [
 [[package]]
 name = "near-indexer"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=6216a118cc3833d916723b9724b9d747c3c4c563#6216a118cc3833d916723b9724b9d747c3c4c563"
+source = "git+https://github.com/near/nearcore.git?rev=4429cc8682eb3c00901af5d96233fef04768bf5a#4429cc8682eb3c00901af5d96233fef04768bf5a"
 dependencies = [
  "actix",
  "anyhow",
@@ -4216,7 +4216,7 @@ dependencies = [
 [[package]]
 name = "near-indexer-primitives"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=6216a118cc3833d916723b9724b9d747c3c4c563#6216a118cc3833d916723b9724b9d747c3c4c563"
+source = "git+https://github.com/near/nearcore.git?rev=4429cc8682eb3c00901af5d96233fef04768bf5a#4429cc8682eb3c00901af5d96233fef04768bf5a"
 dependencies = [
  "near-primitives 0.0.0",
  "serde",
@@ -4226,7 +4226,7 @@ dependencies = [
 [[package]]
 name = "near-jsonrpc"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=6216a118cc3833d916723b9724b9d747c3c4c563#6216a118cc3833d916723b9724b9d747c3c4c563"
+source = "git+https://github.com/near/nearcore.git?rev=4429cc8682eb3c00901af5d96233fef04768bf5a#4429cc8682eb3c00901af5d96233fef04768bf5a"
 dependencies = [
  "actix",
  "actix-cors 0.6.5",
@@ -4258,7 +4258,7 @@ dependencies = [
 [[package]]
 name = "near-jsonrpc-client"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=6216a118cc3833d916723b9724b9d747c3c4c563#6216a118cc3833d916723b9724b9d747c3c4c563"
+source = "git+https://github.com/near/nearcore.git?rev=4429cc8682eb3c00901af5d96233fef04768bf5a#4429cc8682eb3c00901af5d96233fef04768bf5a"
 dependencies = [
  "actix-http",
  "awc",
@@ -4291,7 +4291,7 @@ dependencies = [
 [[package]]
 name = "near-jsonrpc-client"
 version = "0.8.0"
-source = "git+https://github.com/kobayurii/near-jsonrpc-client-rs.git?branch=0.8.1#f6c6c41b48c764508365a8de717fda4364ed539c"
+source = "git+https://github.com/kobayurii/near-jsonrpc-client-rs.git?branch=0.8.3#8f0c9ce3ad0f701a270a852cddccf016c78adfd4"
 dependencies = [
  "borsh 1.3.1",
  "lazy_static",
@@ -4309,7 +4309,7 @@ dependencies = [
 [[package]]
 name = "near-jsonrpc-primitives"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=6216a118cc3833d916723b9724b9d747c3c4c563#6216a118cc3833d916723b9724b9d747c3c4c563"
+source = "git+https://github.com/near/nearcore.git?rev=4429cc8682eb3c00901af5d96233fef04768bf5a#4429cc8682eb3c00901af5d96233fef04768bf5a"
 dependencies = [
  "arbitrary",
  "near-chain-configs 0.0.0",
@@ -4342,7 +4342,7 @@ dependencies = [
 [[package]]
 name = "near-lake-framework"
 version = "0.0.0"
-source = "git+https://github.com/kobayurii/near-lake-framework-rs.git?branch=0.7.8#433197168b2bcd73b83e053e26fd367008c6721b"
+source = "git+https://github.com/kobayurii/near-lake-framework-rs.git?branch=0.7.10#642f3021dcb9757827eef376b1680835efa7f8ce"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4366,7 +4366,7 @@ dependencies = [
 [[package]]
 name = "near-mainnet-res"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=6216a118cc3833d916723b9724b9d747c3c4c563#6216a118cc3833d916723b9724b9d747c3c4c563"
+source = "git+https://github.com/near/nearcore.git?rev=4429cc8682eb3c00901af5d96233fef04768bf5a#4429cc8682eb3c00901af5d96233fef04768bf5a"
 dependencies = [
  "near-account-id",
  "near-chain-configs 0.0.0",
@@ -4377,7 +4377,7 @@ dependencies = [
 [[package]]
 name = "near-network"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=6216a118cc3833d916723b9724b9d747c3c4c563#6216a118cc3833d916723b9724b9d747c3c4c563"
+source = "git+https://github.com/near/nearcore.git?rev=4429cc8682eb3c00901af5d96233fef04768bf5a#4429cc8682eb3c00901af5d96233fef04768bf5a"
 dependencies = [
  "actix",
  "anyhow",
@@ -4426,7 +4426,7 @@ dependencies = [
 [[package]]
 name = "near-o11y"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=6216a118cc3833d916723b9724b9d747c3c4c563#6216a118cc3833d916723b9724b9d747c3c4c563"
+source = "git+https://github.com/near/nearcore.git?rev=4429cc8682eb3c00901af5d96233fef04768bf5a#4429cc8682eb3c00901af5d96233fef04768bf5a"
 dependencies = [
  "actix",
  "base64 0.21.7",
@@ -4479,7 +4479,7 @@ dependencies = [
 [[package]]
 name = "near-parameters"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=6216a118cc3833d916723b9724b9d747c3c4c563#6216a118cc3833d916723b9724b9d747c3c4c563"
+source = "git+https://github.com/near/nearcore.git?rev=4429cc8682eb3c00901af5d96233fef04768bf5a#4429cc8682eb3c00901af5d96233fef04768bf5a"
 dependencies = [
  "borsh 1.3.1",
  "enum-map",
@@ -4515,7 +4515,7 @@ dependencies = [
 [[package]]
 name = "near-performance-metrics"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=6216a118cc3833d916723b9724b9d747c3c4c563#6216a118cc3833d916723b9724b9d747c3c4c563"
+source = "git+https://github.com/near/nearcore.git?rev=4429cc8682eb3c00901af5d96233fef04768bf5a#4429cc8682eb3c00901af5d96233fef04768bf5a"
 dependencies = [
  "actix",
  "bitflags 1.3.2",
@@ -4531,7 +4531,7 @@ dependencies = [
 [[package]]
 name = "near-performance-metrics-macros"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=6216a118cc3833d916723b9724b9d747c3c4c563#6216a118cc3833d916723b9724b9d747c3c4c563"
+source = "git+https://github.com/near/nearcore.git?rev=4429cc8682eb3c00901af5d96233fef04768bf5a#4429cc8682eb3c00901af5d96233fef04768bf5a"
 dependencies = [
  "quote",
  "syn 2.0.52",
@@ -4540,7 +4540,7 @@ dependencies = [
 [[package]]
 name = "near-pool"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=6216a118cc3833d916723b9724b9d747c3c4c563#6216a118cc3833d916723b9724b9d747c3c4c563"
+source = "git+https://github.com/near/nearcore.git?rev=4429cc8682eb3c00901af5d96233fef04768bf5a#4429cc8682eb3c00901af5d96233fef04768bf5a"
 dependencies = [
  "borsh 1.3.1",
  "near-crypto 0.0.0",
@@ -4553,7 +4553,7 @@ dependencies = [
 [[package]]
 name = "near-primitives"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=6216a118cc3833d916723b9724b9d747c3c4c563#6216a118cc3833d916723b9724b9d747c3c4c563"
+source = "git+https://github.com/near/nearcore.git?rev=4429cc8682eb3c00901af5d96233fef04768bf5a#4429cc8682eb3c00901af5d96233fef04768bf5a"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -4636,7 +4636,7 @@ dependencies = [
 [[package]]
 name = "near-primitives-core"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=6216a118cc3833d916723b9724b9d747c3c4c563#6216a118cc3833d916723b9724b9d747c3c4c563"
+source = "git+https://github.com/near/nearcore.git?rev=4429cc8682eb3c00901af5d96233fef04768bf5a#4429cc8682eb3c00901af5d96233fef04768bf5a"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -4677,7 +4677,7 @@ dependencies = [
 [[package]]
 name = "near-rosetta-rpc"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=6216a118cc3833d916723b9724b9d747c3c4c563#6216a118cc3833d916723b9724b9d747c3c4c563"
+source = "git+https://github.com/near/nearcore.git?rev=4429cc8682eb3c00901af5d96233fef04768bf5a#4429cc8682eb3c00901af5d96233fef04768bf5a"
 dependencies = [
  "actix",
  "actix-cors 0.6.5",
@@ -4708,7 +4708,7 @@ dependencies = [
 [[package]]
 name = "near-rpc-error-core"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=6216a118cc3833d916723b9724b9d747c3c4c563#6216a118cc3833d916723b9724b9d747c3c4c563"
+source = "git+https://github.com/near/nearcore.git?rev=4429cc8682eb3c00901af5d96233fef04768bf5a#4429cc8682eb3c00901af5d96233fef04768bf5a"
 dependencies = [
  "quote",
  "serde",
@@ -4729,7 +4729,7 @@ dependencies = [
 [[package]]
 name = "near-rpc-error-macro"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=6216a118cc3833d916723b9724b9d747c3c4c563#6216a118cc3833d916723b9724b9d747c3c4c563"
+source = "git+https://github.com/near/nearcore.git?rev=4429cc8682eb3c00901af5d96233fef04768bf5a#4429cc8682eb3c00901af5d96233fef04768bf5a"
 dependencies = [
  "near-rpc-error-core 0.0.0",
  "serde",
@@ -4778,7 +4778,7 @@ dependencies = [
 [[package]]
 name = "near-stdx"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=6216a118cc3833d916723b9724b9d747c3c4c563#6216a118cc3833d916723b9724b9d747c3c4c563"
+source = "git+https://github.com/near/nearcore.git?rev=4429cc8682eb3c00901af5d96233fef04768bf5a#4429cc8682eb3c00901af5d96233fef04768bf5a"
 
 [[package]]
 name = "near-stdx"
@@ -4789,7 +4789,7 @@ checksum = "855fd5540e3b4ff6fedf12aba2db1ee4b371b36f465da1363a6d022b27cb43b8"
 [[package]]
 name = "near-store"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=6216a118cc3833d916723b9724b9d747c3c4c563#6216a118cc3833d916723b9724b9d747c3c4c563"
+source = "git+https://github.com/near/nearcore.git?rev=4429cc8682eb3c00901af5d96233fef04768bf5a#4429cc8682eb3c00901af5d96233fef04768bf5a"
 dependencies = [
  "actix",
  "actix-rt",
@@ -4831,7 +4831,7 @@ dependencies = [
 [[package]]
 name = "near-telemetry"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=6216a118cc3833d916723b9724b9d747c3c4c563#6216a118cc3833d916723b9724b9d747c3c4c563"
+source = "git+https://github.com/near/nearcore.git?rev=4429cc8682eb3c00901af5d96233fef04768bf5a#4429cc8682eb3c00901af5d96233fef04768bf5a"
 dependencies = [
  "actix",
  "awc",
@@ -4850,7 +4850,7 @@ dependencies = [
 [[package]]
 name = "near-vm-compiler"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=6216a118cc3833d916723b9724b9d747c3c4c563#6216a118cc3833d916723b9724b9d747c3c4c563"
+source = "git+https://github.com/near/nearcore.git?rev=4429cc8682eb3c00901af5d96233fef04768bf5a#4429cc8682eb3c00901af5d96233fef04768bf5a"
 dependencies = [
  "enumset",
  "finite-wasm",
@@ -4866,7 +4866,7 @@ dependencies = [
 [[package]]
 name = "near-vm-compiler-singlepass"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=6216a118cc3833d916723b9724b9d747c3c4c563#6216a118cc3833d916723b9724b9d747c3c4c563"
+source = "git+https://github.com/near/nearcore.git?rev=4429cc8682eb3c00901af5d96233fef04768bf5a#4429cc8682eb3c00901af5d96233fef04768bf5a"
 dependencies = [
  "dynasm 2.0.0",
  "dynasmrt 2.0.0",
@@ -4887,11 +4887,10 @@ dependencies = [
 [[package]]
 name = "near-vm-engine"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=6216a118cc3833d916723b9724b9d747c3c4c563#6216a118cc3833d916723b9724b9d747c3c4c563"
+source = "git+https://github.com/near/nearcore.git?rev=4429cc8682eb3c00901af5d96233fef04768bf5a#4429cc8682eb3c00901af5d96233fef04768bf5a"
 dependencies = [
  "backtrace",
  "cfg-if 1.0.0",
- "crossbeam-queue",
  "enumset",
  "finite-wasm",
  "lazy_static",
@@ -4911,7 +4910,7 @@ dependencies = [
 [[package]]
 name = "near-vm-runner"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=6216a118cc3833d916723b9724b9d747c3c4c563#6216a118cc3833d916723b9724b9d747c3c4c563"
+source = "git+https://github.com/near/nearcore.git?rev=4429cc8682eb3c00901af5d96233fef04768bf5a#4429cc8682eb3c00901af5d96233fef04768bf5a"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -4990,7 +4989,7 @@ dependencies = [
 [[package]]
 name = "near-vm-types"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=6216a118cc3833d916723b9724b9d747c3c4c563#6216a118cc3833d916723b9724b9d747c3c4c563"
+source = "git+https://github.com/near/nearcore.git?rev=4429cc8682eb3c00901af5d96233fef04768bf5a#4429cc8682eb3c00901af5d96233fef04768bf5a"
 dependencies = [
  "indexmap 1.9.3",
  "num-traits",
@@ -5001,7 +5000,7 @@ dependencies = [
 [[package]]
 name = "near-vm-vm"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=6216a118cc3833d916723b9724b9d747c3c4c563#6216a118cc3833d916723b9724b9d747c3c4c563"
+source = "git+https://github.com/near/nearcore.git?rev=4429cc8682eb3c00901af5d96233fef04768bf5a#4429cc8682eb3c00901af5d96233fef04768bf5a"
 dependencies = [
  "backtrace",
  "cc",
@@ -5022,7 +5021,7 @@ dependencies = [
 [[package]]
 name = "near-wallet-contract"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=6216a118cc3833d916723b9724b9d747c3c4c563#6216a118cc3833d916723b9724b9d747c3c4c563"
+source = "git+https://github.com/near/nearcore.git?rev=4429cc8682eb3c00901af5d96233fef04768bf5a#4429cc8682eb3c00901af5d96233fef04768bf5a"
 dependencies = [
  "anyhow",
  "near-vm-runner 0.0.0",
@@ -5031,7 +5030,7 @@ dependencies = [
 [[package]]
 name = "nearcore"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=6216a118cc3833d916723b9724b9d747c3c4c563#6216a118cc3833d916723b9724b9d747c3c4c563"
+source = "git+https://github.com/near/nearcore.git?rev=4429cc8682eb3c00901af5d96233fef04768bf5a#4429cc8682eb3c00901af5d96233fef04768bf5a"
 dependencies = [
  "actix",
  "actix-rt",
@@ -5120,7 +5119,7 @@ dependencies = [
 [[package]]
 name = "node-runtime"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=6216a118cc3833d916723b9724b9d747c3c4c563#6216a118cc3833d916723b9724b9d747c3c4c563"
+source = "git+https://github.com/near/nearcore.git?rev=4429cc8682eb3c00901af5d96233fef04768bf5a#4429cc8682eb3c00901af5d96233fef04768bf5a"
 dependencies = [
  "borsh 1.3.1",
  "hex",
@@ -6314,7 +6313,7 @@ dependencies = [
  "near-chain-configs 0.0.0",
  "near-crypto 0.0.0",
  "near-indexer-primitives",
- "near-jsonrpc-client 0.8.0 (git+https://github.com/kobayurii/near-jsonrpc-client-rs.git?branch=0.8.1)",
+ "near-jsonrpc-client 0.8.0 (git+https://github.com/kobayurii/near-jsonrpc-client-rs.git?branch=0.8.3)",
  "near-jsonrpc-primitives 0.0.0",
  "near-lake-framework",
  "near-parameters 0.0.0",
@@ -6326,7 +6325,7 @@ dependencies = [
  "redis",
  "serde",
  "serde_json",
- "sysinfo 0.30.6",
+ "sysinfo 0.30.7",
  "thiserror",
  "time",
  "tokio",
@@ -6493,9 +6492,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.24"
+version = "0.11.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6920094eb85afde5e4a138be3f2de8bbdf28000f0029e72c45025a56b042251"
+checksum = "0eea5a9eb898d3783f17c6407670e3592fd174cb81a10e51d4c37f49450b9946"
 dependencies = [
  "base64 0.21.7",
  "bytes",
@@ -7382,7 +7381,7 @@ dependencies = [
  "humantime",
  "lazy_static",
  "near-indexer-primitives",
- "near-jsonrpc-client 0.8.0 (git+https://github.com/kobayurii/near-jsonrpc-client-rs.git?branch=0.8.1)",
+ "near-jsonrpc-client 0.8.0 (git+https://github.com/kobayurii/near-jsonrpc-client-rs.git?branch=0.8.3)",
  "near-lake-framework",
  "near-primitives 0.0.0",
  "openssl-probe",
@@ -7544,9 +7543,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.30.6"
+version = "0.30.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6746919caf9f2a85bff759535664c060109f21975c5ac2e8652e60102bd4d196"
+checksum = "0c385888ef380a852a16209afc8cfad22795dd8873d69c9a14d2e2088f118d18"
 dependencies = [
  "cfg-if 1.0.0",
  "core-foundation-sys",
@@ -7559,20 +7558,20 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+checksum = "658bc6ee10a9b4fcf576e9b0819d95ec16f4d2c02d39fd83ac1c8789785c4a42"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.2",
  "core-foundation",
  "system-configuration-sys",
 ]
 
 [[package]]
 name = "system-configuration-sys"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -8044,9 +8043,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-actix-web"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fe0d5feac3f4ca21ba33496bcb1ccab58cca6412b1405ae80f0581541e0ca78"
+checksum = "fa069bd1503dd526ee793bb3fce408895136c95fc86d2edb2acf1c646d7f0684"
 dependencies = [
  "actix-web",
  "mutually_exclusive_features",
@@ -8224,7 +8223,7 @@ dependencies = [
  "humantime",
  "lazy_static",
  "near-indexer-primitives",
- "near-jsonrpc-client 0.8.0 (git+https://github.com/kobayurii/near-jsonrpc-client-rs.git?branch=0.8.1)",
+ "near-jsonrpc-client 0.8.0 (git+https://github.com/kobayurii/near-jsonrpc-client-rs.git?branch=0.8.3)",
  "near-lake-framework",
  "prometheus",
  "readnode-primitives",
@@ -8973,9 +8972,9 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fec781d48b41f8163426ed18e8fc2864c12937df9ce54c88ede7bd47270893e"
+checksum = "a44ab49fad634e88f55bf8f9bb3abd2f27d7204172a112c7c9987e01c1c94ea9"
 dependencies = [
  "redox_syscall 0.4.1",
  "wasite",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,7 +169,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "mio",
- "socket2",
+ "socket2 0.5.6",
  "tokio",
  "tracing",
 ]
@@ -251,7 +251,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "smallvec",
- "socket2",
+ "socket2 0.5.6",
  "time",
  "url",
 ]
@@ -1477,6 +1477,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "combine"
+version = "4.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35ed6e9d84f0b51a7f52daf1c7d71dd136fd7a3f41a8462b8cdb8c78d920fad4"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util 0.7.10",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1863,7 +1877,7 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "socket2",
+ "socket2 0.5.6",
  "windows-sys 0.52.0",
 ]
 
@@ -3079,7 +3093,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.6",
  "tokio",
  "tower-service",
  "tracing",
@@ -4754,6 +4768,8 @@ dependencies = [
  "near-o11y 0.0.0",
  "openssl-probe",
  "prometheus",
+ "redis",
+ "serde_json",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -6307,6 +6323,7 @@ dependencies = [
  "paste",
  "prometheus",
  "readnode-primitives",
+ "redis",
  "serde",
  "serde_json",
  "sysinfo 0.30.6",
@@ -6329,6 +6346,30 @@ dependencies = [
  "num-traits",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "redis"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c580d9cbbe1d1b479e8d67cf9daf6a62c957e6846048408b80b43ac3f6af84cd"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "bytes",
+ "combine",
+ "futures",
+ "futures-util",
+ "itoa",
+ "percent-encoding",
+ "pin-project-lite",
+ "ryu",
+ "sha1_smol",
+ "socket2 0.4.10",
+ "tokio",
+ "tokio-retry",
+ "tokio-util 0.7.10",
+ "url",
 ]
 
 [[package]]
@@ -6817,7 +6858,7 @@ dependencies = [
  "scylla-macros",
  "smallvec",
  "snap",
- "socket2",
+ "socket2 0.5.6",
  "strum 0.23.0",
  "strum_macros 0.23.1",
  "thiserror",
@@ -7112,6 +7153,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
+
+[[package]]
 name = "sha2"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7264,6 +7311,16 @@ name = "snap"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
+
+[[package]]
+name = "socket2"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "socket2"
@@ -7684,7 +7741,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.5.6",
  "tokio-macros",
  "tracing",
  "windows-sys 0.48.0",
@@ -7753,10 +7810,21 @@ dependencies = [
  "postgres-protocol",
  "postgres-types",
  "rand 0.8.5",
- "socket2",
+ "socket2 0.5.6",
  "tokio",
  "tokio-util 0.7.10",
  "whoami",
+]
+
+[[package]]
+name = "tokio-retry"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
+dependencies = [
+ "pin-project",
+ "rand 0.8.5",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,16 +27,16 @@ database = { path = "database" }
 readnode-primitives = { path = "readnode-primitives" }
 epoch-indexer = { path = "epoch-indexer" }
 
-near-indexer = { git = 'https://github.com/near/nearcore.git', rev = '6216a118cc3833d916723b9724b9d747c3c4c563' }
-near-client = { git = 'https://github.com/near/nearcore.git', rev = '6216a118cc3833d916723b9724b9d747c3c4c563' }
-near-o11y = { git = 'https://github.com/near/nearcore.git', rev = '6216a118cc3833d916723b9724b9d747c3c4c563' }
-near-indexer-primitives = { git = 'https://github.com/near/nearcore.git', rev = '6216a118cc3833d916723b9724b9d747c3c4c563' }
-near-primitives = { git = 'https://github.com/near/nearcore.git', rev = '6216a118cc3833d916723b9724b9d747c3c4c563' }
-near-chain-configs = { git = 'https://github.com/near/nearcore.git', rev = '6216a118cc3833d916723b9724b9d747c3c4c563' }
-near-crypto = { git = 'https://github.com/near/nearcore.git', rev = '6216a118cc3833d916723b9724b9d747c3c4c563' }
-near-jsonrpc-primitives = { git = 'https://github.com/near/nearcore.git', rev = '6216a118cc3833d916723b9724b9d747c3c4c563' }
-near-parameters = { git = 'https://github.com/near/nearcore.git', rev = '6216a118cc3833d916723b9724b9d747c3c4c563' }
-near-vm-runner = { git = 'https://github.com/near/nearcore.git', rev = '6216a118cc3833d916723b9724b9d747c3c4c563' }
+near-indexer = { git = 'https://github.com/near/nearcore.git', rev = '4429cc8682eb3c00901af5d96233fef04768bf5a' }
+near-client = { git = 'https://github.com/near/nearcore.git', rev = '4429cc8682eb3c00901af5d96233fef04768bf5a' }
+near-o11y = { git = 'https://github.com/near/nearcore.git', rev = '4429cc8682eb3c00901af5d96233fef04768bf5a' }
+near-indexer-primitives = { git = 'https://github.com/near/nearcore.git', rev = '4429cc8682eb3c00901af5d96233fef04768bf5a' }
+near-primitives = { git = 'https://github.com/near/nearcore.git', rev = '4429cc8682eb3c00901af5d96233fef04768bf5a' }
+near-chain-configs = { git = 'https://github.com/near/nearcore.git', rev = '4429cc8682eb3c00901af5d96233fef04768bf5a' }
+near-crypto = { git = 'https://github.com/near/nearcore.git', rev = '4429cc8682eb3c00901af5d96233fef04768bf5a' }
+near-jsonrpc-primitives = { git = 'https://github.com/near/nearcore.git', rev = '4429cc8682eb3c00901af5d96233fef04768bf5a' }
+near-parameters = { git = 'https://github.com/near/nearcore.git', rev = '4429cc8682eb3c00901af5d96233fef04768bf5a' }
+near-vm-runner = { git = 'https://github.com/near/nearcore.git', rev = '4429cc8682eb3c00901af5d96233fef04768bf5a' }
 
-near-lake-framework = { git = 'https://github.com/kobayurii/near-lake-framework-rs.git', branch = '0.7.8' }
-near-jsonrpc-client = { git = 'https://github.com/kobayurii/near-jsonrpc-client-rs.git', branch = '0.8.1'}
+near-lake-framework = { git = 'https://github.com/kobayurii/near-lake-framework-rs.git', branch = '0.7.10' }
+near-jsonrpc-client = { git = 'https://github.com/kobayurii/near-jsonrpc-client-rs.git', branch = '0.8.3'}

--- a/config.toml
+++ b/config.toml
@@ -5,6 +5,7 @@
 chain_id = "${CHAIN_ID}"
 near_rpc_url = "${NEAR_RPC_URL}"
 near_archival_rpc_url = "${ARCHIVAL_NEAR_RPC_URL}"
+redis_url = "${REDIS_URL}"
 
 [general.rpc_server]
 referer_header_value = "${REFERER_HEADER_VALUE}"

--- a/configuration/example.config.toml
+++ b/configuration/example.config.toml
@@ -15,6 +15,11 @@ near_rpc_url = "https://beta.rpc.mainnet.near.org"
 ## default value is None
 #near_archival_rpc_url = "https://beta.rpc.mainnet.near.org"
 
+## redis url using for pub/sub optimistic_block and finale_block
+## from near_state_indexer to rpc_server
+## Default value is redis://127.0.0.1/
+#redis_url = "redis://127.0.0.1/"
+
 ### Rpc server general configuration
 [general.rpc_server]
 

--- a/configuration/src/configs/general.rs
+++ b/configuration/src/configs/general.rs
@@ -282,7 +282,9 @@ impl From<CommonGeneralConfig> for GeneralRpcServerConfig {
             chain_id: common_config.chain_id,
             near_rpc_url: required_value_or_panic("near_rpc_url", common_config.near_rpc_url),
             near_archival_rpc_url: common_config.near_archival_rpc_url,
-            redis_url: common_config.redis_url.unwrap_or("redis://127.0.0.1/".to_string()),
+            redis_url: common_config
+                .redis_url
+                .unwrap_or("redis://127.0.0.1/".to_string()),
             referer_header_value: common_config
                 .rpc_server
                 .referer_header_value
@@ -360,7 +362,9 @@ impl From<CommonGeneralConfig> for GeneralNearStateIndexerConfig {
     fn from(common_config: CommonGeneralConfig) -> Self {
         Self {
             chain_id: common_config.chain_id,
-            redis_url: common_config.redis_url.unwrap_or("redis://127.0.0.1/".to_string()),
+            redis_url: common_config
+                .redis_url
+                .unwrap_or("redis://127.0.0.1/".to_string()),
             metrics_server_port: common_config
                 .near_state_indexer
                 .metrics_server_port

--- a/configuration/src/configs/general.rs
+++ b/configuration/src/configs/general.rs
@@ -11,6 +11,7 @@ pub struct GeneralRpcServerConfig {
     pub chain_id: ChainId,
     pub near_rpc_url: String,
     pub near_archival_rpc_url: Option<String>,
+    pub redis_url: String,
     pub referer_header_value: String,
     pub server_port: u16,
     pub max_gas_burnt: u64,
@@ -43,6 +44,7 @@ pub struct GeneralStateIndexerConfig {
 #[derive(Debug, Clone)]
 pub struct GeneralNearStateIndexerConfig {
     pub chain_id: ChainId,
+    pub redis_url: String,
     pub metrics_server_port: u16,
     pub concurrency: usize,
 }
@@ -63,6 +65,8 @@ pub struct CommonGeneralConfig {
     pub near_rpc_url: Option<String>,
     #[serde(deserialize_with = "deserialize_optional_data_or_env", default)]
     pub near_archival_rpc_url: Option<String>,
+    #[serde(deserialize_with = "deserialize_optional_data_or_env", default)]
+    pub redis_url: Option<String>,
     #[serde(default)]
     pub rpc_server: CommonGeneralRpcServerConfig,
     #[serde(default)]
@@ -278,6 +282,7 @@ impl From<CommonGeneralConfig> for GeneralRpcServerConfig {
             chain_id: common_config.chain_id,
             near_rpc_url: required_value_or_panic("near_rpc_url", common_config.near_rpc_url),
             near_archival_rpc_url: common_config.near_archival_rpc_url,
+            redis_url: common_config.redis_url.unwrap_or("redis://127.0.0.1/".to_string()),
             referer_header_value: common_config
                 .rpc_server
                 .referer_header_value
@@ -355,6 +360,7 @@ impl From<CommonGeneralConfig> for GeneralNearStateIndexerConfig {
     fn from(common_config: CommonGeneralConfig) -> Self {
         Self {
             chain_id: common_config.chain_id,
+            redis_url: common_config.redis_url.unwrap_or("redis://127.0.0.1/".to_string()),
             metrics_server_port: common_config
                 .near_state_indexer
                 .metrics_server_port

--- a/near-state-indexer/Cargo.toml
+++ b/near-state-indexer/Cargo.toml
@@ -19,6 +19,8 @@ humantime = "2.1.0"
 lazy_static = "1.4.0"
 openssl-probe = "0.1.5"
 prometheus = "0.13.1"
+redis = { version = "0.24.0", features = ["tokio-comp", "connection-manager"] }
+serde_json = "1.0.64"
 tokio = { version = "1.36.0", features = [
     "sync",
     "time",

--- a/rpc-server/Cargo.toml
+++ b/rpc-server/Cargo.toml
@@ -52,7 +52,7 @@ near-vm-runner.workspace = true
 [features]
 default = ["send_tx_methods", "scylla_db"]
 send_tx_methods = []
-near_state_indexer_disabled = []
+near_state_indexer_disabled = []  # Use this feature if you don't run near-state-indexer
 tracing-instrumentation = ["configuration/tracing-instrumentation"]
 postgres_db = ["database/postgres_db"]
 scylla_db = ["database/scylla_db"]

--- a/rpc-server/Cargo.toml
+++ b/rpc-server/Cargo.toml
@@ -50,9 +50,9 @@ near-parameters.workspace = true
 near-vm-runner.workspace = true
 
 [features]
-default = ["send_tx_methods", "scylla_db", "near_state_indexer"]
+default = ["send_tx_methods", "scylla_db"]
 send_tx_methods = []
-near_state_indexer = []
+near_state_indexer_disabled = []
 tracing-instrumentation = ["configuration/tracing-instrumentation"]
 postgres_db = ["database/postgres_db"]
 scylla_db = ["database/scylla_db"]

--- a/rpc-server/Cargo.toml
+++ b/rpc-server/Cargo.toml
@@ -23,6 +23,7 @@ lazy_static = "1.4.0"
 lru = "0.12.2"
 paste = "1.0.14"
 prometheus = "0.13.1"
+redis = { version = "0.24.0", features = ["tokio-comp", "connection-manager"] }
 serde = { version = "1.0.145", features = ["derive"] }
 serde_json = "1.0.85"
 thiserror = "1.0.40"
@@ -49,8 +50,9 @@ near-parameters.workspace = true
 near-vm-runner.workspace = true
 
 [features]
-default = ["send_tx_methods", "scylla_db"]
+default = ["send_tx_methods", "scylla_db", "near_state_indexer"]
 send_tx_methods = []
+near_state_indexer = []
 tracing-instrumentation = ["configuration/tracing-instrumentation"]
 postgres_db = ["database/postgres_db"]
 scylla_db = ["database/scylla_db"]

--- a/rpc-server/src/config.rs
+++ b/rpc-server/src/config.rs
@@ -1,4 +1,4 @@
-use crate::modules::blocks::{CacheBlock, FinalBlockInfo};
+use crate::modules::blocks::{CacheBlock, FinalityBlocksInfo};
 use futures::executor::block_on;
 use std::string::ToString;
 
@@ -61,7 +61,7 @@ pub struct ServerContext {
     pub blocks_cache:
         std::sync::Arc<futures_locks::RwLock<crate::cache::LruMemoryCache<u64, CacheBlock>>>,
     /// Final block info include final_block_cache and current_validators_info
-    pub final_block_info: std::sync::Arc<futures_locks::RwLock<FinalBlockInfo>>,
+    pub finality_blocks_info: std::sync::Arc<futures_locks::RwLock<FinalityBlocksInfo>>,
     /// Cache to store compiled contract codes
     pub compiled_contract_code_cache: std::sync::Arc<CompiledCodeCache>,
     /// Cache to store contract codes
@@ -118,8 +118,8 @@ impl ServerContext {
             )),
         });
 
-        let final_block_info = std::sync::Arc::new(futures_locks::RwLock::new(
-            FinalBlockInfo::new(&near_rpc_client, &blocks_cache).await,
+        let finality_blocks_info = std::sync::Arc::new(futures_locks::RwLock::new(
+            FinalityBlocksInfo::new(&near_rpc_client, &blocks_cache).await,
         ));
 
         let s3_client = rpc_server_config.lake_config.lake_s3_client().await;
@@ -150,7 +150,7 @@ impl ServerContext {
             near_rpc_client,
             s3_bucket_name: rpc_server_config.lake_config.aws_bucket_name.clone(),
             blocks_cache,
-            final_block_info,
+            finality_blocks_info,
             compiled_contract_code_cache,
             contract_code_cache,
             max_gas_burnt: rpc_server_config.general.max_gas_burnt,

--- a/rpc-server/src/config.rs
+++ b/rpc-server/src/config.rs
@@ -40,7 +40,7 @@ impl GenesisInfo {
 
         Self {
             genesis_config,
-            genesis_block_cache: genesis_block.into(),
+            genesis_block_cache: CacheBlock::from(&genesis_block),
         }
     }
 }

--- a/rpc-server/src/health.rs
+++ b/rpc-server/src/health.rs
@@ -50,7 +50,7 @@ impl RPCHealthStatusResponse {
             ),
 
             final_block_height: server_context
-                .finality_blocks_info
+                .blocks_info_by_finality
                 .read()
                 .await
                 .final_block

--- a/rpc-server/src/health.rs
+++ b/rpc-server/src/health.rs
@@ -50,7 +50,7 @@ impl RPCHealthStatusResponse {
             ),
 
             final_block_height: server_context
-                .final_block_info
+                .finality_blocks_info
                 .read()
                 .await
                 .final_block

--- a/rpc-server/src/health.rs
+++ b/rpc-server/src/health.rs
@@ -53,7 +53,8 @@ impl RPCHealthStatusResponse {
                 .final_block_info
                 .read()
                 .await
-                .final_block_cache
+                .final_block
+                .block_cache
                 .block_height,
         }
     }

--- a/rpc-server/src/main.rs
+++ b/rpc-server/src/main.rs
@@ -37,13 +37,13 @@ async fn main() -> anyhow::Result<()> {
         config::ServerContext::init(rpc_server_config.clone(), near_rpc_client.clone()).await?;
 
     let blocks_cache = std::sync::Arc::clone(&server_context.blocks_cache);
-    let final_block_info = std::sync::Arc::clone(&server_context.final_block_info);
+    let finality_blocks_info = std::sync::Arc::clone(&server_context.finality_blocks_info);
 
     #[cfg(feature = "near_state_indexer_disabled")]
     tokio::spawn(async move {
         utils::update_final_block_regularly(
             blocks_cache,
-            final_block_info,
+            finality_blocks_info,
             rpc_server_config,
             near_rpc_client,
         )
@@ -57,15 +57,15 @@ async fn main() -> anyhow::Result<()> {
         tokio::spawn(async move {
             utils::update_final_block_regularly(
                 blocks_cache,
-                final_block_info,
+                finality_blocks_info,
                 redis_client_clone,
                 near_rpc_client,
             )
             .await
         });
-        let final_block_info = std::sync::Arc::clone(&server_context.final_block_info);
+        let finality_blocks_info = std::sync::Arc::clone(&server_context.finality_blocks_info);
         tokio::spawn(async move {
-            utils::update_optimistic_block_regularly(final_block_info, redis_client).await
+            utils::update_optimistic_block_regularly(finality_blocks_info, redis_client).await
         });
     }
 

--- a/rpc-server/src/main.rs
+++ b/rpc-server/src/main.rs
@@ -37,13 +37,13 @@ async fn main() -> anyhow::Result<()> {
         config::ServerContext::init(rpc_server_config.clone(), near_rpc_client.clone()).await?;
 
     let blocks_cache = std::sync::Arc::clone(&server_context.blocks_cache);
-    let finality_blocks_info = std::sync::Arc::clone(&server_context.finality_blocks_info);
+    let blocks_info_by_finality = std::sync::Arc::clone(&server_context.blocks_info_by_finality);
 
     #[cfg(feature = "near_state_indexer_disabled")]
     tokio::spawn(async move {
         utils::update_final_block_regularly(
             blocks_cache,
-            finality_blocks_info,
+            blocks_info_by_finality,
             rpc_server_config,
             near_rpc_client,
         )
@@ -57,15 +57,16 @@ async fn main() -> anyhow::Result<()> {
         tokio::spawn(async move {
             utils::update_final_block_regularly(
                 blocks_cache,
-                finality_blocks_info,
+                blocks_info_by_finality,
                 redis_client_clone,
                 near_rpc_client,
             )
             .await
         });
-        let finality_blocks_info = std::sync::Arc::clone(&server_context.finality_blocks_info);
+        let blocks_info_by_finality =
+            std::sync::Arc::clone(&server_context.blocks_info_by_finality);
         tokio::spawn(async move {
-            utils::update_optimistic_block_regularly(finality_blocks_info, redis_client).await
+            utils::update_optimistic_block_regularly(blocks_info_by_finality, redis_client).await
         });
     }
 

--- a/rpc-server/src/main.rs
+++ b/rpc-server/src/main.rs
@@ -53,11 +53,12 @@ async fn main() -> anyhow::Result<()> {
     #[cfg(not(feature = "near_state_indexer_disabled"))]
     {
         let redis_client = redis::Client::open(rpc_server_config.general.redis_url.clone())?;
+        let redis_client_clone = redis_client.clone();
         tokio::spawn(async move {
             utils::update_final_block_regularly(
                 blocks_cache,
                 final_block_info,
-                redis_client.clone(),
+                redis_client_clone,
                 near_rpc_client,
             )
             .await

--- a/rpc-server/src/main.rs
+++ b/rpc-server/src/main.rs
@@ -48,9 +48,9 @@ async fn main() -> anyhow::Result<()> {
             rpc_server_config,
             near_rpc_client,
         )
-            .await
+        .await
     });
-    
+
     #[cfg(feature = "near_state_indexer")]
     {
         let redis_client_clone = redis_client.clone();
@@ -68,8 +68,6 @@ async fn main() -> anyhow::Result<()> {
             utils::update_optimistic_block_regularly(final_block_info, redis_client.clone()).await
         });
     }
-    
-
 
     let rpc = Server::new()
         .with_data(Data::new(server_context.clone()))

--- a/rpc-server/src/modules/blocks/methods.rs
+++ b/rpc-server/src/modules/blocks/methods.rs
@@ -249,7 +249,8 @@ pub async fn fetch_block(
                 .final_block_info
                 .read()
                 .await
-                .final_block_cache
+                .final_block
+                .block_cache
                 .block_height),
             _ => Err(
                 near_jsonrpc_primitives::types::blocks::RpcBlockError::InternalError {

--- a/rpc-server/src/modules/blocks/methods.rs
+++ b/rpc-server/src/modules/blocks/methods.rs
@@ -258,7 +258,7 @@ pub async fn fetch_block(
                 near_primitives::types::Finality::Final
                 | near_primitives::types::Finality::DoomSlug => {
                     let block_view = data
-                        .final_block_info
+                        .finality_blocks_info
                         .read()
                         .await
                         .final_block
@@ -276,7 +276,7 @@ pub async fn fetch_block(
                         )
                     } else {
                         let block_view = data
-                            .final_block_info
+                            .finality_blocks_info
                             .read()
                             .await
                             .optimistic_block
@@ -496,7 +496,7 @@ async fn fetch_shards(
             near_primitives::types::Finality::None => {
                 if cfg!(feature = "near_state_indexer_disabled") {
                     Ok(data
-                        .final_block_info
+                        .finality_blocks_info
                         .read()
                         .await
                         .final_block
@@ -504,7 +504,7 @@ async fn fetch_shards(
                         .await)
                 } else {
                     Ok(data
-                        .final_block_info
+                        .finality_blocks_info
                         .read()
                         .await
                         .optimistic_block
@@ -514,7 +514,7 @@ async fn fetch_shards(
             }
             near_primitives::types::Finality::DoomSlug
             | near_primitives::types::Finality::Final => Ok(data
-                .final_block_info
+                .finality_blocks_info
                 .read()
                 .await
                 .final_block

--- a/rpc-server/src/modules/blocks/methods.rs
+++ b/rpc-server/src/modules/blocks/methods.rs
@@ -157,15 +157,15 @@ async fn changes_in_block_call(
 ) -> Result<near_jsonrpc_primitives::types::changes::RpcStateChangesInBlockByTypeResponse, RPCError>
 {
     crate::metrics::CHNGES_IN_BLOCK_REQUESTS_TOTAL.inc();
-    let block = fetch_block_from_cache_or_get(&data, params.block_reference.clone())
+    let cache_block = fetch_block_from_cache_or_get(&data, params.block_reference.clone())
         .await
         .map_err(near_jsonrpc_primitives::errors::RpcError::from)?;
-    let result = fetch_changes_in_block(&data, block, &params.block_reference).await;
+    let result = fetch_changes_in_block(&data, cache_block, &params.block_reference).await;
     #[cfg(feature = "shadow_data_consistency")]
     {
         if let near_primitives::types::BlockReference::Finality(_) = params.block_reference {
             params.block_reference = near_primitives::types::BlockReference::from(
-                near_primitives::types::BlockId::Height(block.block_height),
+                near_primitives::types::BlockId::Height(cache_block.block_height),
             )
         }
         if let Some(err_code) = crate::utils::shadow_compare_results_handler(
@@ -195,12 +195,12 @@ async fn changes_in_block_by_type_call(
     >,
 ) -> Result<near_jsonrpc_primitives::types::changes::RpcStateChangesInBlockResponse, RPCError> {
     crate::metrics::CHNGES_IN_BLOCK_BY_TYPE_REQUESTS_TOTAL.inc();
-    let block = fetch_block_from_cache_or_get(&data, params.block_reference.clone())
+    let cache_block = fetch_block_from_cache_or_get(&data, params.block_reference.clone())
         .await
         .map_err(near_jsonrpc_primitives::errors::RpcError::from)?;
     let result = fetch_changes_in_block_by_type(
         &data,
-        block,
+        cache_block,
         &params.state_changes_request,
         &params.block_reference,
     )
@@ -210,7 +210,7 @@ async fn changes_in_block_by_type_call(
     {
         if let near_primitives::types::BlockReference::Finality(_) = params.block_reference {
             params.block_reference = near_primitives::types::BlockReference::from(
-                near_primitives::types::BlockId::Height(block.block_height),
+                near_primitives::types::BlockId::Height(cache_block.block_height),
             )
         }
         if let Some(err_code) = crate::utils::shadow_compare_results_handler(
@@ -258,7 +258,7 @@ pub async fn fetch_block(
                 near_primitives::types::Finality::Final
                 | near_primitives::types::Finality::DoomSlug => {
                     let block_view = data
-                        .finality_blocks_info
+                        .blocks_info_by_finality
                         .read()
                         .await
                         .final_block
@@ -276,7 +276,7 @@ pub async fn fetch_block(
                         )
                     } else {
                         let block_view = data
-                            .finality_blocks_info
+                            .blocks_info_by_finality
                             .read()
                             .await
                             .optimistic_block
@@ -368,13 +368,13 @@ pub async fn fetch_chunk(
 #[cfg_attr(feature = "tracing-instrumentation", tracing::instrument(skip(data)))]
 async fn fetch_changes_in_block(
     data: &Data<ServerContext>,
-    block: crate::modules::blocks::CacheBlock,
+    cache_block: crate::modules::blocks::CacheBlock,
     block_reference: &near_primitives::types::BlockReference,
 ) -> Result<
     near_jsonrpc_primitives::types::changes::RpcStateChangesInBlockByTypeResponse,
     near_jsonrpc_primitives::types::changes::RpcStateChangesError,
 > {
-    let shards = fetch_shards(data, block, block_reference)
+    let shards = fetch_shards(data, cache_block, block_reference)
         .await
         .map_err(|err| {
             near_jsonrpc_primitives::types::changes::RpcStateChangesError::UnknownBlock {
@@ -449,7 +449,7 @@ async fn fetch_changes_in_block(
 
     Ok(
         near_jsonrpc_primitives::types::changes::RpcStateChangesInBlockByTypeResponse {
-            block_hash: block.block_hash,
+            block_hash: cache_block.block_hash,
             changes,
         },
     )
@@ -458,14 +458,14 @@ async fn fetch_changes_in_block(
 #[cfg_attr(feature = "tracing-instrumentation", tracing::instrument(skip(data)))]
 async fn fetch_changes_in_block_by_type(
     data: &Data<ServerContext>,
-    block: crate::modules::blocks::CacheBlock,
+    cache_block: crate::modules::blocks::CacheBlock,
     state_changes_request: &near_primitives::views::StateChangesRequestView,
     block_reference: &near_primitives::types::BlockReference,
 ) -> Result<
     near_jsonrpc_primitives::types::changes::RpcStateChangesInBlockResponse,
     near_jsonrpc_primitives::types::changes::RpcStateChangesError,
 > {
-    let shards = fetch_shards(data, block, block_reference)
+    let shards = fetch_shards(data, cache_block, block_reference)
         .await
         .map_err(|err| {
             near_jsonrpc_primitives::types::changes::RpcStateChangesError::UnknownBlock {
@@ -479,7 +479,7 @@ async fn fetch_changes_in_block_by_type(
         .collect();
     Ok(
         near_jsonrpc_primitives::types::changes::RpcStateChangesInBlockResponse {
-            block_hash: block.block_hash,
+            block_hash: cache_block.block_hash,
             changes,
         },
     )
@@ -488,23 +488,19 @@ async fn fetch_changes_in_block_by_type(
 #[cfg_attr(feature = "tracing-instrumentation", tracing::instrument(skip(data)))]
 async fn fetch_shards(
     data: &Data<ServerContext>,
-    block: crate::modules::blocks::CacheBlock,
+    cache_block: crate::modules::blocks::CacheBlock,
     block_reference: &near_primitives::types::BlockReference,
 ) -> anyhow::Result<Vec<near_indexer_primitives::IndexerShard>> {
     if let near_primitives::types::BlockReference::Finality(finality) = block_reference {
         match finality {
             near_primitives::types::Finality::None => {
                 if cfg!(feature = "near_state_indexer_disabled") {
-                    Ok(data
-                        .finality_blocks_info
-                        .read()
-                        .await
-                        .final_block
-                        .shards()
-                        .await)
+                    Err(anyhow::anyhow!(
+                        "Failed to fetch shards! Finality::None is not supported by rpc_server",
+                    ))
                 } else {
                     Ok(data
-                        .finality_blocks_info
+                        .blocks_info_by_finality
                         .read()
                         .await
                         .optimistic_block
@@ -514,7 +510,7 @@ async fn fetch_shards(
             }
             near_primitives::types::Finality::DoomSlug
             | near_primitives::types::Finality::Final => Ok(data
-                .finality_blocks_info
+                .blocks_info_by_finality
                 .read()
                 .await
                 .final_block
@@ -522,14 +518,14 @@ async fn fetch_shards(
                 .await),
         }
     } else {
-        let fetch_shards_futures = (0..block.chunks_included)
+        let fetch_shards_futures = (0..cache_block.chunks_included)
             .collect::<Vec<u64>>()
             .into_iter()
             .map(|shard_id| {
                 near_lake_framework::s3_fetchers::fetch_shard(
                     &data.s3_client,
                     &data.s3_bucket_name,
-                    block.block_height,
+                    cache_block.block_height,
                     shard_id,
                 )
             });
@@ -538,7 +534,7 @@ async fn fetch_shards(
             .map_err(|err| {
                 anyhow::anyhow!(
                     "Failed to fetch shards for block {} with error: {}",
-                    block.block_height,
+                    cache_block.block_height,
                     err
                 )
             })

--- a/rpc-server/src/modules/blocks/mod.rs
+++ b/rpc-server/src/modules/blocks/mod.rs
@@ -278,13 +278,13 @@ impl BlockInfo {
 }
 
 #[derive(Debug)]
-pub struct FinalityBlocksInfo {
+pub struct BlocksInfoByFinality {
     pub final_block: BlockInfo,
     pub optimistic_block: BlockInfo,
     pub current_validators: near_primitives::views::EpochValidatorInfo,
 }
 
-impl FinalityBlocksInfo {
+impl BlocksInfoByFinality {
     pub async fn new(
         near_rpc_client: &crate::utils::JsonRpcClient,
         blocks_cache: &std::sync::Arc<

--- a/rpc-server/src/modules/blocks/mod.rs
+++ b/rpc-server/src/modules/blocks/mod.rs
@@ -1,3 +1,5 @@
+use near_primitives::views::{StateChangeCauseView, StateChangeValueView};
+
 pub mod methods;
 pub mod utils;
 
@@ -34,6 +36,46 @@ pub struct BlockInfo {
     pub stream_message: near_indexer_primitives::StreamerMessage,
 }
 
+pub struct BlockStateChangeValue {
+    pub value: Option<Vec<u8>>,
+}
+
+impl BlockStateChangeValue {
+    pub async fn to_account(&self) -> anyhow::Result<near_primitives::account::Account> {
+        let account = borsh::from_slice::<near_primitives::account::Account>(
+            self.value
+                .as_ref()
+                .ok_or_else(|| anyhow::anyhow!("Account deleted"))?,
+        )?;
+        Ok(account)
+    }
+
+    pub async fn to_access_key(&self) -> anyhow::Result<near_primitives::account::AccessKey> {
+        let access_key = borsh::from_slice::<near_primitives::account::AccessKey>(
+            self.value
+                .as_ref()
+                .ok_or_else(|| anyhow::anyhow!("Access key deleted"))?,
+        )?;
+        Ok(access_key)
+    }
+
+    pub async fn to_contract_code(&self) -> anyhow::Result<Vec<u8>> {
+        Ok(self
+            .value
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("Contract code deleted"))?
+            .clone())
+    }
+    // TODO: handle added and deleted keys
+    // pub async fn to_data(&self) -> anyhow::Result<Vec<u8>> {
+    //     Ok(self
+    //         .value
+    //         .as_ref()
+    //         .ok_or_else(|| anyhow::anyhow!("Data deleted"))?
+    //         .clone())
+    // }
+}
+
 impl BlockInfo {
     pub fn new_from_block_view(block_view: near_primitives::views::BlockView) -> Self {
         Self {
@@ -52,6 +94,226 @@ impl BlockInfo {
             block_cache: CacheBlock::from(&stream_message.block),
             stream_message,
         }
+    }
+
+    pub fn block_view(&self) -> near_primitives::views::BlockView {
+        near_primitives::views::BlockView {
+            author: self.stream_message.block.author.clone(),
+            header: self.stream_message.block.header.clone(),
+            chunks: self.stream_message.block.chunks.clone(),
+        }
+    }
+
+    pub fn shards(&self) -> Vec<near_indexer_primitives::IndexerShard> {
+        self.stream_message
+            .shards
+            .iter()
+            .map(|shard| {
+                let state_changes = shard
+                    .state_changes
+                    .iter()
+                    .map(|state_changes| {
+                        let cause = match &state_changes.cause {
+                            StateChangeCauseView::NotWritableToDisk => {
+                                StateChangeCauseView::NotWritableToDisk
+                            }
+                            StateChangeCauseView::InitialState => {
+                                StateChangeCauseView::InitialState
+                            }
+                            StateChangeCauseView::TransactionProcessing { tx_hash } => {
+                                StateChangeCauseView::TransactionProcessing { tx_hash: *tx_hash }
+                            }
+                            StateChangeCauseView::ActionReceiptProcessingStarted {
+                                receipt_hash,
+                            } => StateChangeCauseView::ActionReceiptProcessingStarted {
+                                receipt_hash: *receipt_hash,
+                            },
+                            StateChangeCauseView::ActionReceiptGasReward { receipt_hash } => {
+                                StateChangeCauseView::ActionReceiptGasReward {
+                                    receipt_hash: *receipt_hash,
+                                }
+                            }
+                            StateChangeCauseView::ReceiptProcessing { receipt_hash } => {
+                                StateChangeCauseView::ReceiptProcessing {
+                                    receipt_hash: *receipt_hash,
+                                }
+                            }
+                            StateChangeCauseView::PostponedReceipt { receipt_hash } => {
+                                StateChangeCauseView::PostponedReceipt {
+                                    receipt_hash: *receipt_hash,
+                                }
+                            }
+                            StateChangeCauseView::UpdatedDelayedReceipts => {
+                                StateChangeCauseView::UpdatedDelayedReceipts
+                            }
+                            StateChangeCauseView::ValidatorAccountsUpdate => {
+                                StateChangeCauseView::ValidatorAccountsUpdate
+                            }
+                            StateChangeCauseView::Migration => StateChangeCauseView::Migration,
+                            StateChangeCauseView::Resharding => StateChangeCauseView::Resharding,
+                        };
+                        let value = match &state_changes.value {
+                            StateChangeValueView::AccountUpdate {
+                                account_id,
+                                account,
+                            } => StateChangeValueView::AccountUpdate {
+                                account_id: account_id.clone(),
+                                account: account.clone(),
+                            },
+                            StateChangeValueView::AccountDeletion { account_id } => {
+                                StateChangeValueView::AccountDeletion {
+                                    account_id: account_id.clone(),
+                                }
+                            }
+                            StateChangeValueView::AccessKeyUpdate {
+                                account_id,
+                                access_key,
+                                public_key,
+                            } => StateChangeValueView::AccessKeyUpdate {
+                                account_id: account_id.clone(),
+                                access_key: access_key.clone(),
+                                public_key: public_key.clone(),
+                            },
+                            StateChangeValueView::AccessKeyDeletion {
+                                account_id,
+                                public_key,
+                            } => StateChangeValueView::AccessKeyDeletion {
+                                account_id: account_id.clone(),
+                                public_key: public_key.clone(),
+                            },
+                            StateChangeValueView::DataUpdate {
+                                account_id,
+                                key,
+                                value,
+                            } => StateChangeValueView::DataUpdate {
+                                account_id: account_id.clone(),
+                                key: key.clone(),
+                                value: value.clone(),
+                            },
+                            StateChangeValueView::DataDeletion { account_id, key } => {
+                                StateChangeValueView::DataDeletion {
+                                    account_id: account_id.clone(),
+                                    key: key.clone(),
+                                }
+                            }
+                            StateChangeValueView::ContractCodeUpdate { account_id, code } => {
+                                StateChangeValueView::ContractCodeUpdate {
+                                    account_id: account_id.clone(),
+                                    code: code.clone(),
+                                }
+                            }
+                            StateChangeValueView::ContractCodeDeletion { account_id } => {
+                                StateChangeValueView::ContractCodeDeletion {
+                                    account_id: account_id.clone(),
+                                }
+                            }
+                        };
+                        near_primitives::views::StateChangeWithCauseView { cause, value }
+                    })
+                    .collect();
+                near_indexer_primitives::IndexerShard {
+                    shard_id: shard.shard_id,
+                    chunk: shard.chunk.as_ref().map(|chunk| {
+                        near_indexer_primitives::IndexerChunkView {
+                            author: chunk.author.clone(),
+                            header: chunk.header.clone(),
+                            transactions: chunk.transactions.clone(),
+                            receipts: chunk.receipts.clone(),
+                        }
+                    }),
+                    receipt_execution_outcomes: shard.receipt_execution_outcomes.clone(),
+                    state_changes,
+                }
+            })
+            .collect()
+    }
+
+    pub fn changes_in_block(&self) -> std::collections::HashMap<String, BlockStateChangeValue> {
+        let mut block_state_changes =
+            std::collections::HashMap::<String, BlockStateChangeValue>::new();
+
+        let initial_state_changes = self
+            .stream_message
+            .shards
+            .iter()
+            .flat_map(|shard| shard.state_changes.iter());
+
+        for state_change in initial_state_changes {
+            let (key, value) = match &state_change.value {
+                StateChangeValueView::DataUpdate {
+                    account_id,
+                    key,
+                    value,
+                } => {
+                    let key: &[u8] = key.as_ref();
+                    (
+                        format!("{}_data_{}", account_id.as_str(), hex::encode(key)),
+                        Some(value.to_vec()),
+                    )
+                }
+                StateChangeValueView::DataDeletion { account_id, key } => {
+                    let key: &[u8] = key.as_ref();
+                    (
+                        format!("{}_data_{}", account_id.as_str(), hex::encode(key)),
+                        None,
+                    )
+                }
+                StateChangeValueView::AccessKeyUpdate {
+                    account_id,
+                    public_key,
+                    access_key,
+                } => {
+                    let data_key =
+                        borsh::to_vec(&public_key).expect("Error to serialize public key");
+                    (
+                        format!(
+                            "{}_access_key_{}",
+                            account_id.as_str(),
+                            hex::encode(data_key)
+                        ),
+                        Some(borsh::to_vec(access_key).expect("Error to serialize access key")),
+                    )
+                }
+                StateChangeValueView::AccessKeyDeletion {
+                    account_id,
+                    public_key,
+                } => {
+                    let data_key =
+                        borsh::to_vec(&public_key).expect("Error to serialize public key");
+                    (
+                        format!(
+                            "{}_access_key_{}",
+                            account_id.as_str(),
+                            hex::encode(data_key)
+                        ),
+                        None,
+                    )
+                }
+                // ContractCode and Account changes is not separate-able by any key, we can omit the suffix
+                StateChangeValueView::ContractCodeUpdate { account_id, code } => (
+                    format!("{}_contract", account_id.as_str()),
+                    Some(code.clone()),
+                ),
+                StateChangeValueView::ContractCodeDeletion { account_id } => {
+                    (format!("{}_contract", account_id.as_str()), None)
+                }
+                StateChangeValueView::AccountUpdate {
+                    account_id,
+                    account,
+                } => (
+                    format!("{}_account", account_id.as_str()),
+                    Some(
+                        borsh::to_vec(&near_primitives::account::Account::from(account))
+                            .expect("Error to serialize account"),
+                    ),
+                ),
+                StateChangeValueView::AccountDeletion { account_id } => {
+                    (format!("{}_account", account_id.as_str()), None)
+                }
+            };
+            block_state_changes.insert(key, BlockStateChangeValue { value });
+        }
+        block_state_changes
     }
 }
 

--- a/rpc-server/src/modules/blocks/utils.rs
+++ b/rpc-server/src/modules/blocks/utils.rs
@@ -101,11 +101,17 @@ pub async fn fetch_block_from_cache_or_get(
                 near_primitives::types::Finality::None => {
                     if cfg!(feature = "near_state_indexer_disabled") {
                         // Returns the final_block for None.
-                        Some(data.final_block_info.read().await.final_block.block_cache)
+                        Some(
+                            data.finality_blocks_info
+                                .read()
+                                .await
+                                .final_block
+                                .block_cache,
+                        )
                     } else {
                         // Returns the optimistic_block for None.
                         Some(
-                            data.final_block_info
+                            data.finality_blocks_info
                                 .read()
                                 .await
                                 .optimistic_block
@@ -116,7 +122,13 @@ pub async fn fetch_block_from_cache_or_get(
                 near_primitives::types::Finality::DoomSlug
                 | near_primitives::types::Finality::Final => {
                     // Returns the final_block for DoomSlug and Final.
-                    Some(data.final_block_info.read().await.final_block.block_cache)
+                    Some(
+                        data.finality_blocks_info
+                            .read()
+                            .await
+                            .final_block
+                            .block_cache,
+                    )
                 }
             }
         }

--- a/rpc-server/src/modules/blocks/utils.rs
+++ b/rpc-server/src/modules/blocks/utils.rs
@@ -98,7 +98,7 @@ pub async fn fetch_block_from_cache_or_get(
         }
         near_primitives::types::BlockReference::Finality(_) => {
             // Returns the final_block_height for all the finalities.
-            Some(data.final_block_info.read().await.final_block_cache)
+            Some(data.final_block_info.read().await.final_block.block_cache)
         }
         near_primitives::types::BlockReference::SyncCheckpoint(_) => {
             // Return genesis_block_cache for all SyncCheckpoint
@@ -111,7 +111,7 @@ pub async fn fetch_block_from_cache_or_get(
         Some(block) => Ok(block),
         None => {
             let block_from_s3 = fetch_block(data, block_reference).await?;
-            let block: CacheBlock = block_from_s3.block_view.into();
+            let block = CacheBlock::from(&block_from_s3.block_view);
 
             data.blocks_cache
                 .write()

--- a/rpc-server/src/modules/blocks/utils.rs
+++ b/rpc-server/src/modules/blocks/utils.rs
@@ -102,7 +102,7 @@ pub async fn fetch_block_from_cache_or_get(
                     if cfg!(feature = "near_state_indexer_disabled") {
                         // Returns the final_block for None.
                         Some(
-                            data.finality_blocks_info
+                            data.blocks_info_by_finality
                                 .read()
                                 .await
                                 .final_block
@@ -111,7 +111,7 @@ pub async fn fetch_block_from_cache_or_get(
                     } else {
                         // Returns the optimistic_block for None.
                         Some(
-                            data.finality_blocks_info
+                            data.blocks_info_by_finality
                                 .read()
                                 .await
                                 .optimistic_block
@@ -123,7 +123,7 @@ pub async fn fetch_block_from_cache_or_get(
                 | near_primitives::types::Finality::Final => {
                     // Returns the final_block for DoomSlug and Final.
                     Some(
-                        data.finality_blocks_info
+                        data.blocks_info_by_finality
                             .read()
                             .await
                             .final_block

--- a/rpc-server/src/modules/blocks/utils.rs
+++ b/rpc-server/src/modules/blocks/utils.rs
@@ -99,7 +99,10 @@ pub async fn fetch_block_from_cache_or_get(
         near_primitives::types::BlockReference::Finality(finality) => {
             match finality {
                 near_primitives::types::Finality::None => {
-                    if cfg!(feature = "near_state_indexer") {
+                    if cfg!(feature = "near_state_indexer_disabled") {
+                        // Returns the final_block for None.
+                        Some(data.final_block_info.read().await.final_block.block_cache)
+                    } else {
                         // Returns the optimistic_block for None.
                         Some(
                             data.final_block_info
@@ -108,9 +111,6 @@ pub async fn fetch_block_from_cache_or_get(
                                 .optimistic_block
                                 .block_cache,
                         )
-                    } else {
-                        // Returns the final_block for None.
-                        Some(data.final_block_info.read().await.final_block.block_cache)
                     }
                 }
                 near_primitives::types::Finality::DoomSlug

--- a/rpc-server/src/modules/network/methods.rs
+++ b/rpc-server/src/modules/network/methods.rs
@@ -31,8 +31,8 @@ pub async fn status(
     data: Data<ServerContext>,
     Params(_params): Params<serde_json::Value>,
 ) -> Result<near_primitives::views::StatusResponse, RPCError> {
-    let final_block_info = data.final_block_info.read().await;
-    let validators = final_block_info
+    let finality_blocks_info = data.finality_blocks_info.read().await;
+    let validators = finality_blocks_info
         .current_validators
         .current_validators
         .iter()
@@ -46,7 +46,7 @@ pub async fn status(
         version: data.version.clone(),
         chain_id: data.genesis_info.genesis_config.chain_id.clone(),
         protocol_version: near_primitives::version::PROTOCOL_VERSION,
-        latest_protocol_version: final_block_info
+        latest_protocol_version: finality_blocks_info
             .final_block
             .block_cache
             .latest_protocol_version,
@@ -54,11 +54,11 @@ pub async fn status(
         rpc_addr: Some(format!("0.0.0.0:{}", data.server_port)),
         validators,
         sync_info: near_primitives::views::StatusSyncInfo {
-            latest_block_hash: final_block_info.final_block.block_cache.block_hash,
-            latest_block_height: final_block_info.final_block.block_cache.block_height,
-            latest_state_root: final_block_info.final_block.block_cache.state_root,
+            latest_block_hash: finality_blocks_info.final_block.block_cache.block_hash,
+            latest_block_height: finality_blocks_info.final_block.block_cache.block_height,
+            latest_state_root: finality_blocks_info.final_block.block_cache.state_root,
             latest_block_time: time::OffsetDateTime::from_unix_timestamp_nanos(
-                final_block_info.final_block.block_cache.block_timestamp as i128,
+                finality_blocks_info.final_block.block_cache.block_timestamp as i128,
             )
             .expect("Failed to parse timestamp"),
             // Always false because read_node is not need to sync
@@ -72,9 +72,9 @@ pub async fn status(
                 .expect("Failed to parse timestamp"),
             ),
             epoch_id: Some(near_primitives::types::EpochId(
-                final_block_info.final_block.block_cache.epoch_id,
+                finality_blocks_info.final_block.block_cache.epoch_id,
             )),
-            epoch_start_height: Some(final_block_info.current_validators.epoch_start_height),
+            epoch_start_height: Some(finality_blocks_info.current_validators.epoch_start_height),
         },
         validator_account_id: None,
         validator_public_key: None,
@@ -127,7 +127,7 @@ pub async fn validators(
     // Current epoch validators fetches from the Near RPC node
     if let near_primitives::types::EpochReference::EpochId(epoch_id) = &request.epoch_reference {
         if data
-            .final_block_info
+            .finality_blocks_info
             .read()
             .await
             .final_block

--- a/rpc-server/src/modules/network/methods.rs
+++ b/rpc-server/src/modules/network/methods.rs
@@ -277,6 +277,7 @@ async fn protocol_config_call(
             fees: runtime_config.fees.clone(),
             wasm_config: runtime_config.wasm_config.clone(),
             account_creation_config: runtime_config.account_creation_config.clone(),
+            storage_proof_size_soft_limit: runtime_config.storage_proof_size_soft_limit,
         },
     };
     Ok(protocol_config.into())

--- a/rpc-server/src/modules/network/methods.rs
+++ b/rpc-server/src/modules/network/methods.rs
@@ -46,16 +46,19 @@ pub async fn status(
         version: data.version.clone(),
         chain_id: data.genesis_info.genesis_config.chain_id.clone(),
         protocol_version: near_primitives::version::PROTOCOL_VERSION,
-        latest_protocol_version: final_block_info.final_block_cache.latest_protocol_version,
+        latest_protocol_version: final_block_info
+            .final_block
+            .block_cache
+            .latest_protocol_version,
         // Address for current read_node RPC server.
         rpc_addr: Some(format!("0.0.0.0:{}", data.server_port)),
         validators,
         sync_info: near_primitives::views::StatusSyncInfo {
-            latest_block_hash: final_block_info.final_block_cache.block_hash,
-            latest_block_height: final_block_info.final_block_cache.block_height,
-            latest_state_root: final_block_info.final_block_cache.state_root,
+            latest_block_hash: final_block_info.final_block.block_cache.block_hash,
+            latest_block_height: final_block_info.final_block.block_cache.block_height,
+            latest_state_root: final_block_info.final_block.block_cache.state_root,
             latest_block_time: time::OffsetDateTime::from_unix_timestamp_nanos(
-                final_block_info.final_block_cache.block_timestamp as i128,
+                final_block_info.final_block.block_cache.block_timestamp as i128,
             )
             .expect("Failed to parse timestamp"),
             // Always false because read_node is not need to sync
@@ -69,7 +72,7 @@ pub async fn status(
                 .expect("Failed to parse timestamp"),
             ),
             epoch_id: Some(near_primitives::types::EpochId(
-                final_block_info.final_block_cache.epoch_id,
+                final_block_info.final_block.block_cache.epoch_id,
             )),
             epoch_start_height: Some(final_block_info.current_validators.epoch_start_height),
         },
@@ -127,7 +130,8 @@ pub async fn validators(
             .final_block_info
             .read()
             .await
-            .final_block_cache
+            .final_block
+            .block_cache
             .epoch_id
             == epoch_id.0
         {

--- a/rpc-server/src/modules/queries/methods.rs
+++ b/rpc-server/src/modules/queries/methods.rs
@@ -70,13 +70,13 @@ async fn query_call(
             crate::metrics::QUERY_VIEW_STATE_REQUESTS_TOTAL.inc();
             if include_proof {
                 // TODO: We can calculate the proof for state only on regular or archival nodes.
-                let finality_blocks_info = data.finality_blocks_info.read().await;
+                let blocks_info_by_finality = data.blocks_info_by_finality.read().await;
                 // `expected_earliest_available_block` calculated by formula:
                 // `final_block_height` - `node_epoch_count` * `epoch_length`
                 // Now near store 5 epochs, it can be changed in the future
                 // epoch_length = 43200 blocks
                 let expected_earliest_available_block =
-                    finality_blocks_info.final_block.block_cache.block_height
+                    blocks_info_by_finality.final_block.block_cache.block_height
                         - 5 * data.genesis_info.genesis_config.epoch_length;
                 return if block.block_height > expected_earliest_available_block {
                     // Proxy to regular rpc if the block is available
@@ -276,7 +276,7 @@ async fn optimistic_view_account(
 ) -> Result<near_primitives::views::AccountView, near_jsonrpc_primitives::types::query::RpcQueryError>
 {
     if let Ok(result) = data
-        .finality_blocks_info
+        .blocks_info_by_finality
         .read()
         .await
         .optimistic_block
@@ -368,7 +368,7 @@ async fn optimistic_view_code(
     account_id: &near_primitives::types::AccountId,
 ) -> Result<Vec<u8>, near_jsonrpc_primitives::types::query::RpcQueryError> {
     let contract_code = if let Ok(result) = data
-        .finality_blocks_info
+        .blocks_info_by_finality
         .read()
         .await
         .optimistic_block
@@ -461,7 +461,7 @@ async fn optimistic_function_call(
     args: near_primitives::types::FunctionArgs,
 ) -> Result<RunContractResponse, crate::errors::FunctionCallError> {
     let optimistic_data = data
-        .finality_blocks_info
+        .blocks_info_by_finality
         .read()
         .await
         .optimistic_block
@@ -474,7 +474,7 @@ async fn optimistic_function_call(
         data.db_manager.clone(),
         &data.compiled_contract_code_cache,
         &data.contract_code_cache,
-        &data.finality_blocks_info,
+        &data.blocks_info_by_finality,
         block,
         data.max_gas_burnt,
         optimistic_data, // run contract with optimistic data
@@ -497,7 +497,7 @@ async fn database_function_call(
         data.db_manager.clone(),
         &data.compiled_contract_code_cache,
         &data.contract_code_cache,
-        &data.finality_blocks_info,
+        &data.blocks_info_by_finality,
         block,
         data.max_gas_burnt,
         Default::default(), // run contract with empty optimistic data
@@ -553,7 +553,7 @@ async fn optimistic_view_state(
     near_jsonrpc_primitives::types::query::RpcQueryError,
 > {
     let mut optimistic_data = data
-        .finality_blocks_info
+        .blocks_info_by_finality
         .read()
         .await
         .optimistic_block
@@ -673,7 +673,7 @@ async fn optimistic_view_access_key(
     near_jsonrpc_primitives::types::query::RpcQueryError,
 > {
     if let Ok(result) = data
-        .finality_blocks_info
+        .blocks_info_by_finality
         .read()
         .await
         .optimistic_block

--- a/rpc-server/src/modules/queries/methods.rs
+++ b/rpc-server/src/modules/queries/methods.rs
@@ -71,7 +71,7 @@ async fn query_call(
                 // Now near store 5 epochs, it can be changed in the future
                 // epoch_length = 43200 blocks
                 let expected_earliest_available_block =
-                    final_block_info.final_block_cache.block_height
+                    final_block_info.final_block.block_cache.block_height
                         - 5 * data.genesis_info.genesis_config.epoch_length;
                 return if block.block_height > expected_earliest_available_block {
                     // Proxy to regular rpc if the block is available

--- a/rpc-server/src/modules/queries/mod.rs
+++ b/rpc-server/src/modules/queries/mod.rs
@@ -14,6 +14,7 @@ pub struct CodeStorage {
     block_height: near_primitives::types::BlockHeight,
     validators: HashMap<near_primitives::types::AccountId, near_primitives::types::Balance>,
     data_count: u64,
+    is_optimistic: bool,
     optimistic_data:
         HashMap<readnode_primitives::StateKey, Option<readnode_primitives::StateValue>>,
 }
@@ -49,8 +50,55 @@ impl CodeStorage {
             block_height,
             validators,
             data_count: Default::default(), // TODO: Using for generate_data_id
+            is_optimistic: !optimistic_data.is_empty(),
             optimistic_data,
         }
+    }
+
+    fn optimistic_storage_get(
+        &self,
+        key: &[u8],
+    ) -> Result<Option<Box<dyn near_vm_runner::logic::ValuePtr>>> {
+        if let Some(value) = self.optimistic_data.get(key) {
+            Ok(value.as_ref().map(|data| {
+                Box::new(StorageValuePtr {
+                    value: data.clone(),
+                }) as Box<_>
+            }))
+        } else {
+            self.database_storage_get(key)
+        }
+    }
+
+    fn database_storage_get(
+        &self,
+        key: &[u8],
+    ) -> Result<Option<Box<dyn near_vm_runner::logic::ValuePtr>>> {
+        let get_db_data =
+            self.db_manager
+                .get_state_key_value(&self.account_id, self.block_height, key.to_vec());
+        let (_, data) = block_on(get_db_data);
+        Ok(if !data.is_empty() {
+            Some(Box::new(StorageValuePtr { value: data }) as Box<_>)
+        } else {
+            None
+        })
+    }
+
+    fn optimistic_storage_has_key(&mut self, key: &[u8]) -> Result<bool> {
+        if let Some(value) = self.optimistic_data.get(key) {
+            Ok(value.is_some())
+        } else {
+            self.database_storage_has_key(key)
+        }
+    }
+
+    fn database_storage_has_key(&mut self, key: &[u8]) -> Result<bool> {
+        let get_db_state_keys =
+            self.db_manager
+                .get_state_key_value(&self.account_id, self.block_height, key.to_vec());
+        let (_, data) = block_on(get_db_state_keys);
+        Ok(!data.is_empty())
     }
 }
 
@@ -73,24 +121,10 @@ impl near_vm_runner::logic::External for CodeStorage {
         key: &[u8],
         _mode: near_vm_runner::logic::StorageGetMode,
     ) -> Result<Option<Box<dyn near_vm_runner::logic::ValuePtr>>> {
-        if let Some(value) = self.optimistic_data.get(key) {
-            Ok(value.as_ref().map(|data| {
-                Box::new(StorageValuePtr {
-                    value: data.clone(),
-                }) as Box<_>
-            }))
+        if self.is_optimistic {
+            self.optimistic_storage_get(key)
         } else {
-            let get_db_data = self.db_manager.get_state_key_value(
-                &self.account_id,
-                self.block_height,
-                key.to_vec(),
-            );
-            let (_, data) = block_on(get_db_data);
-            Ok(if !data.is_empty() {
-                Some(Box::new(StorageValuePtr { value: data }) as Box<_>)
-            } else {
-                None
-            })
+            self.database_storage_get(key)
         }
     }
 
@@ -121,16 +155,10 @@ impl near_vm_runner::logic::External for CodeStorage {
         key: &[u8],
         _mode: near_vm_runner::logic::StorageGetMode,
     ) -> Result<bool> {
-        if let Some(value) = self.optimistic_data.get(key) {
-            Ok(value.is_some())
+        if self.is_optimistic {
+            self.optimistic_storage_has_key(key)
         } else {
-            let get_db_state_keys = self.db_manager.get_state_key_value(
-                &self.account_id,
-                self.block_height,
-                key.to_vec(),
-            );
-            let (_, data) = block_on(get_db_state_keys);
-            Ok(!data.is_empty())
+            self.database_storage_has_key(key)
         }
     }
 

--- a/rpc-server/src/modules/queries/utils.rs
+++ b/rpc-server/src/modules/queries/utils.rs
@@ -263,22 +263,28 @@ pub async fn run_contract(
         }
     };
 
-    let (epoch_height, epoch_validators) =
-        if final_block_info.read().await.final_block_cache.epoch_id == block.epoch_id {
-            let validators = final_block_info.read().await.current_validators.clone();
-            (validators.epoch_height, validators.current_validators)
-        } else {
-            let validators = db_manager
-                .get_validators_by_epoch_id(block.epoch_id)
-                .await
-                .map_err(|_| FunctionCallError::InternalError {
-                    error_message: "Failed to get epoch info".to_string(),
-                })?;
-            (
-                validators.epoch_height,
-                validators.validators_info.current_validators,
-            )
-        };
+    let (epoch_height, epoch_validators) = if final_block_info
+        .read()
+        .await
+        .final_block
+        .block_cache
+        .epoch_id
+        == block.epoch_id
+    {
+        let validators = final_block_info.read().await.current_validators.clone();
+        (validators.epoch_height, validators.current_validators)
+    } else {
+        let validators = db_manager
+            .get_validators_by_epoch_id(block.epoch_id)
+            .await
+            .map_err(|_| FunctionCallError::InternalError {
+                error_message: "Failed to get epoch info".to_string(),
+            })?;
+        (
+            validators.epoch_height,
+            validators.validators_info.current_validators,
+        )
+    };
 
     let public_key = near_crypto::PublicKey::empty(near_crypto::KeyType::ED25519);
     let random_seed = near_primitives::utils::create_random_seed(

--- a/rpc-server/src/utils.rs
+++ b/rpc-server/src/utils.rs
@@ -149,7 +149,7 @@ async fn handle_streamer_message(
         final_block_info.write().await.current_validators =
             get_current_validators(near_rpc_client).await?;
     }
-    let block_cache = block.block_cache.clone();
+    let block_cache = block.block_cache;
     final_block_info.write().await.final_block = block;
     blocks_cache
         .write()
@@ -231,7 +231,9 @@ pub async fn update_final_block_regularly(
                         std::sync::Arc::clone(&blocks_cache),
                         std::sync::Arc::clone(&final_block_info),
                         &near_rpc_client,
-                    ).await {
+                    )
+                    .await
+                    {
                         tracing::error!("Error to handle_streamer_message: {:?}", err);
                     }
                 }

--- a/state-indexer/src/main.rs
+++ b/state-indexer/src/main.rs
@@ -54,7 +54,7 @@ async fn handle_streamer_message(
             .collect(),
     );
     let handle_state_change_future =
-        handle_state_changes(streamer_message, db_manager, block_height, block_hash, &indexer_config);
+        handle_state_changes(&streamer_message, db_manager, block_height, block_hash, &indexer_config);
 
     let update_meta_future = db_manager.update_meta(&indexer_config.general.indexer_id, block_height);
 
@@ -125,19 +125,19 @@ async fn handle_epoch(
     tracing::instrument(skip(streamer_message, db_manager))
 )]
 async fn handle_state_changes(
-    streamer_message: near_indexer_primitives::StreamerMessage,
+    streamer_message: &near_indexer_primitives::StreamerMessage,
     db_manager: &(impl database::StateIndexerDbManager + Sync + Send + 'static),
     block_height: u64,
     block_hash: CryptoHash,
     indexer_config: &configuration::StateIndexerConfig,
 ) -> anyhow::Result<Vec<()>> {
     let mut state_changes_to_store =
-        std::collections::HashMap::<String, near_indexer_primitives::views::StateChangeWithCauseView>::new();
+        std::collections::HashMap::<String, &near_indexer_primitives::views::StateChangeWithCauseView>::new();
 
     let initial_state_changes = streamer_message
         .shards
-        .into_iter()
-        .flat_map(|shard| shard.state_changes.into_iter());
+        .iter()
+        .flat_map(|shard| shard.state_changes.iter());
 
     // Collecting a unique list of StateChangeWithCauseView for account_id + change kind + suffix
     // by overwriting the records in the HashMap


### PR DESCRIPTION
In this pull request, we introduce support optimistic blocks. 

Recently we've added additional metrics to measure the number of proxy requests from the ReadRPC to the native one. Additionally, we have a metric that counts how many of the requests are for the blocks with optimistic finality. This finality is not yet supported in the ReadRPC. The metrics revealed that a significant portion of the requests are for the optimistic blocks - 85% of all requests.

Implementation of `optimistic_blocks` support will help to reduce the number of proxied requests and help to optimize and speed up the service.

