### PR TITLE
Create GitHub Action to build a binary for `near-state-indexer`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,50 @@
+name: Release NearStateIndexer Workflow
+
+on:
+  release:
+    types: [created, published]
+
+jobs:
+  build-and-release:
+    permissions:
+      contents: write
+    runs-on: ubuntu-22.04
+    if: >
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) ||
+      (github.event_name == 'release' && github.event.action == 'created')
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Rust toolchain
+        run: |
+          rustup update stable
+          rustup default stable
+
+      - name: Build release binary
+        run: |
+          cargo build --release --package near-state-indexer --verbose
+          strip target/release/near-state-indexer
+          cp target/release/near-state-indexer near-state-indexer
+
+      - name: Determine UPLOAD_URL
+        run: |
+          if [[ "${{ github.event_name }}" == "push" ]]; then
+            TAG_NAME=${GITHUB_REF#refs/tags/}
+            RELEASE_RESPONSE=$(curl -s -X GET -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/repos/${{ github.repository }}/releases/tags/$TAG_NAME")
+            UPLOAD_URL=$(echo "$RELEASE_RESPONSE" | jq -r .upload_url)
+            echo "UPLOAD_URL=$UPLOAD_URL" >> $GITHUB_ENV
+          else
+            echo "UPLOAD_URL=${{ github.event.release.upload_url }}" >> $GITHUB_ENV
+          fi
+
+      - name: Upload release asset
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ env.UPLOAD_URL }}
+          asset_path: ./near-state-indexer/near-state-indexer
+          asset_name: near-state-indexer
+          asset_content_type: application/octet-stream
+


### PR DESCRIPTION
This PR introduces a GitHub Action to automate building the `near-state-indexer` binary. 
It streamlines the compilation process and enhances project workflow efficiency.