### PR TITLE
chore: release 0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,7 +130,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
 dependencies = [
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -265,7 +265,7 @@ dependencies = [
  "actix-router",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -276,7 +276,7 @@ checksum = "7c7db3d5a9718568e4cf4a537cfd7070e6e6ff7481510d0237fb529ac850f6d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -472,17 +472,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-recursion"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd55a5ba1179988837d24ab4c7cc8ed6efdeff578ede0416b4225a5fca35bd0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.52",
-]
-
-[[package]]
 name = "async-stream"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -501,18 +490,18 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.77"
+version = "0.1.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
+checksum = "461abc97219de0eaaf81fe3ef974a540158f3d079c2ab200f891f1a2ef201e85"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -664,9 +653,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.18.0"
+version = "1.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be7167516f69aff3acca64e47c993336105e62f008067d2695324dfa5cbfdba6"
+checksum = "54dd36a773ad90e8ae6b8464e51af0312b5422418ae1fd80c7a647975e1846b6"
 dependencies = [
  "ahash 0.8.11",
  "aws-credential-types",
@@ -699,9 +688,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6729c96a2bc5acdbc0d6f406415678c24de30a9999f33084a34e64fc415cc365"
+checksum = "c5cc34f5925899739a3f125bd3f7d37d081234a3df218feb9c9d337fd4c70e72"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -721,9 +710,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ccdd38f35f089c16fe0641cda34f2d06e3ab7b99a884407bce350a9fa70b1a9"
+checksum = "7327cddd32b1a6f2aaeaadb1336b671a7975e96a999d3b1bcf5aa47932dc6ddb"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -743,9 +732,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "396e8064892a3c08b25b60fe3abda7ff5afa74efee500572cae65122ba5afd0d"
+checksum = "6c11981cdb80e8e205e22beb6630a8bdec380a1256bd29efaab34aaebd07cfb9"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1060,7 +1049,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -1184,7 +1173,7 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
  "syn_derive",
 ]
 
@@ -1212,9 +1201,9 @@ dependencies = [
 
 [[package]]
 name = "brotli"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "516074a47ef4bce09577a3b379392300159ce5b1ba2e501ff1c819950066100f"
+checksum = "d640d25bc63c50fb1f0b545ffd80207d2e10a4c965530809b40ba3386825c391"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -1406,9 +1395,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.2"
+version = "4.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b230ab84b0ffdf890d5a10abdbc8b83ae1c4918275daea1ab8801f71536b2651"
+checksum = "949626d00e063efc93b6dca932419ceb5432f99769911c0b995f7e884c778813"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1428,14 +1417,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.0"
+version = "4.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "307bc0538d5f0f83b8248db3087aa92fe504e4691294d0c96c0eabc33f47ba47"
+checksum = "90239a040c80f5e14809ca132ddc4176ab33d5e17e49691793296e3fcb34d72f"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -1507,7 +1496,7 @@ dependencies = [
 
 [[package]]
 name = "configuration"
-version = "0.1.0"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "aws-credential-types",
@@ -1928,7 +1917,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -1976,7 +1965,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.10.0",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -1998,7 +1987,7 @@ checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
 dependencies = [
  "darling_core 0.20.8",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -2016,7 +2005,7 @@ dependencies = [
 
 [[package]]
 name = "database"
-version = "0.1.0"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2102,7 +2091,7 @@ checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -2151,9 +2140,9 @@ dependencies = [
 
 [[package]]
 name = "diesel"
-version = "2.1.4"
+version = "2.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62c6fcf842f17f8c78ecf7c81d75c5ce84436b41ee07e03f490fbb5f5a8731d8"
+checksum = "03fc05c17098f21b89bc7d98fe1dd3cce2c11c2ad8e145f2a44fe08ed28eb559"
 dependencies = [
  "bigdecimal",
  "bitflags 2.4.2",
@@ -2184,14 +2173,14 @@ dependencies = [
 
 [[package]]
 name = "diesel_derives"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef8337737574f55a468005a83499da720f20c65586241ffea339db9ecdfd2b44"
+checksum = "5d02eecb814ae714ffe61ddc2db2dd03e6c49a42e269b5001355500d431cce0c"
 dependencies = [
  "diesel_table_macro_syntax",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -2211,7 +2200,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc5557efc453706fed5e4fa85006fe9817c224c3f480a34c7e5959fd700921c5"
 dependencies = [
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -2468,7 +2457,7 @@ checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -2489,12 +2478,12 @@ dependencies = [
  "darling 0.20.8",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
 name = "epoch-indexer"
-version = "0.1.0"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -2502,7 +2491,7 @@ dependencies = [
  "database",
  "near-chain-configs 0.0.0",
  "near-indexer-primitives",
- "near-jsonrpc-client 0.8.0 (git+https://github.com/kobayurii/near-jsonrpc-client-rs.git?branch=0.8.2)",
+ "near-jsonrpc-client 0.8.0 (git+https://github.com/kobayurii/near-jsonrpc-client-rs.git?branch=0.8.3)",
  "near-lake-framework",
  "readnode-primitives",
  "tokio",
@@ -2788,7 +2777,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -2914,9 +2903,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
+checksum = "4fbd2820c5e49886948654ab546d0688ff24530286bdcf8fca3cefb16d4618eb"
 dependencies = [
  "bytes",
  "fnv",
@@ -2991,6 +2980,12 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -3596,7 +3591,7 @@ checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -3798,7 +3793,7 @@ dependencies = [
 [[package]]
 name = "near-async"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=836dbb7971a8d183e02f95d81d8a9ae18e731b37#836dbb7971a8d183e02f95d81d8a9ae18e731b37"
+source = "git+https://github.com/near/nearcore.git?rev=511414a5091c3bef5c447a5644ba903dc050b715#511414a5091c3bef5c447a5644ba903dc050b715"
 dependencies = [
  "actix",
  "derive_more",
@@ -3816,17 +3811,17 @@ dependencies = [
 [[package]]
 name = "near-async-derive"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=836dbb7971a8d183e02f95d81d8a9ae18e731b37#836dbb7971a8d183e02f95d81d8a9ae18e731b37"
+source = "git+https://github.com/near/nearcore.git?rev=511414a5091c3bef5c447a5644ba903dc050b715#511414a5091c3bef5c447a5644ba903dc050b715"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
 name = "near-cache"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=836dbb7971a8d183e02f95d81d8a9ae18e731b37#836dbb7971a8d183e02f95d81d8a9ae18e731b37"
+source = "git+https://github.com/near/nearcore.git?rev=511414a5091c3bef5c447a5644ba903dc050b715#511414a5091c3bef5c447a5644ba903dc050b715"
 dependencies = [
  "lru 0.7.8",
 ]
@@ -3834,7 +3829,7 @@ dependencies = [
 [[package]]
 name = "near-chain"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=836dbb7971a8d183e02f95d81d8a9ae18e731b37#836dbb7971a8d183e02f95d81d8a9ae18e731b37"
+source = "git+https://github.com/near/nearcore.git?rev=511414a5091c3bef5c447a5644ba903dc050b715#511414a5091c3bef5c447a5644ba903dc050b715"
 dependencies = [
  "actix",
  "assert_matches",
@@ -3880,7 +3875,7 @@ dependencies = [
 [[package]]
 name = "near-chain-configs"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=836dbb7971a8d183e02f95d81d8a9ae18e731b37#836dbb7971a8d183e02f95d81d8a9ae18e731b37"
+source = "git+https://github.com/near/nearcore.git?rev=511414a5091c3bef5c447a5644ba903dc050b715#511414a5091c3bef5c447a5644ba903dc050b715"
 dependencies = [
  "anyhow",
  "bytesize",
@@ -3928,7 +3923,7 @@ dependencies = [
 [[package]]
 name = "near-chain-primitives"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=836dbb7971a8d183e02f95d81d8a9ae18e731b37#836dbb7971a8d183e02f95d81d8a9ae18e731b37"
+source = "git+https://github.com/near/nearcore.git?rev=511414a5091c3bef5c447a5644ba903dc050b715#511414a5091c3bef5c447a5644ba903dc050b715"
 dependencies = [
  "near-async",
  "near-crypto 0.0.0",
@@ -3941,7 +3936,7 @@ dependencies = [
 [[package]]
 name = "near-chunks"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=836dbb7971a8d183e02f95d81d8a9ae18e731b37#836dbb7971a8d183e02f95d81d8a9ae18e731b37"
+source = "git+https://github.com/near/nearcore.git?rev=511414a5091c3bef5c447a5644ba903dc050b715#511414a5091c3bef5c447a5644ba903dc050b715"
 dependencies = [
  "actix",
  "borsh 1.3.1",
@@ -3974,7 +3969,7 @@ dependencies = [
 [[package]]
 name = "near-chunks-primitives"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=836dbb7971a8d183e02f95d81d8a9ae18e731b37#836dbb7971a8d183e02f95d81d8a9ae18e731b37"
+source = "git+https://github.com/near/nearcore.git?rev=511414a5091c3bef5c447a5644ba903dc050b715#511414a5091c3bef5c447a5644ba903dc050b715"
 dependencies = [
  "near-chain-primitives",
  "near-primitives 0.0.0",
@@ -3983,7 +3978,7 @@ dependencies = [
 [[package]]
 name = "near-client"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=836dbb7971a8d183e02f95d81d8a9ae18e731b37#836dbb7971a8d183e02f95d81d8a9ae18e731b37"
+source = "git+https://github.com/near/nearcore.git?rev=511414a5091c3bef5c447a5644ba903dc050b715#511414a5091c3bef5c447a5644ba903dc050b715"
 dependencies = [
  "actix",
  "actix-rt",
@@ -4039,7 +4034,7 @@ dependencies = [
 [[package]]
 name = "near-client-primitives"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=836dbb7971a8d183e02f95d81d8a9ae18e731b37#836dbb7971a8d183e02f95d81d8a9ae18e731b37"
+source = "git+https://github.com/near/nearcore.git?rev=511414a5091c3bef5c447a5644ba903dc050b715#511414a5091c3bef5c447a5644ba903dc050b715"
 dependencies = [
  "actix",
  "chrono",
@@ -4061,7 +4056,7 @@ dependencies = [
 [[package]]
 name = "near-config-utils"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=836dbb7971a8d183e02f95d81d8a9ae18e731b37#836dbb7971a8d183e02f95d81d8a9ae18e731b37"
+source = "git+https://github.com/near/nearcore.git?rev=511414a5091c3bef5c447a5644ba903dc050b715#511414a5091c3bef5c447a5644ba903dc050b715"
 dependencies = [
  "anyhow",
  "json_comments",
@@ -4084,7 +4079,7 @@ dependencies = [
 [[package]]
 name = "near-crypto"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=836dbb7971a8d183e02f95d81d8a9ae18e731b37#836dbb7971a8d183e02f95d81d8a9ae18e731b37"
+source = "git+https://github.com/near/nearcore.git?rev=511414a5091c3bef5c447a5644ba903dc050b715#511414a5091c3bef5c447a5644ba903dc050b715"
 dependencies = [
  "blake2",
  "borsh 1.3.1",
@@ -4135,7 +4130,7 @@ dependencies = [
 [[package]]
 name = "near-dyn-configs"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=836dbb7971a8d183e02f95d81d8a9ae18e731b37#836dbb7971a8d183e02f95d81d8a9ae18e731b37"
+source = "git+https://github.com/near/nearcore.git?rev=511414a5091c3bef5c447a5644ba903dc050b715#511414a5091c3bef5c447a5644ba903dc050b715"
 dependencies = [
  "anyhow",
  "near-async",
@@ -4154,7 +4149,7 @@ dependencies = [
 [[package]]
 name = "near-epoch-manager"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=836dbb7971a8d183e02f95d81d8a9ae18e731b37#836dbb7971a8d183e02f95d81d8a9ae18e731b37"
+source = "git+https://github.com/near/nearcore.git?rev=511414a5091c3bef5c447a5644ba903dc050b715#511414a5091c3bef5c447a5644ba903dc050b715"
 dependencies = [
  "borsh 1.3.1",
  "itertools 0.10.5",
@@ -4177,7 +4172,7 @@ dependencies = [
 [[package]]
 name = "near-fmt"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=836dbb7971a8d183e02f95d81d8a9ae18e731b37#836dbb7971a8d183e02f95d81d8a9ae18e731b37"
+source = "git+https://github.com/near/nearcore.git?rev=511414a5091c3bef5c447a5644ba903dc050b715#511414a5091c3bef5c447a5644ba903dc050b715"
 dependencies = [
  "near-primitives-core 0.0.0",
 ]
@@ -4194,12 +4189,12 @@ dependencies = [
 [[package]]
 name = "near-indexer"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=836dbb7971a8d183e02f95d81d8a9ae18e731b37#836dbb7971a8d183e02f95d81d8a9ae18e731b37"
+source = "git+https://github.com/near/nearcore.git?rev=511414a5091c3bef5c447a5644ba903dc050b715#511414a5091c3bef5c447a5644ba903dc050b715"
 dependencies = [
  "actix",
  "anyhow",
- "async-recursion",
  "futures",
+ "lazy_static",
  "near-chain-configs 0.0.0",
  "near-client",
  "near-crypto 0.0.0",
@@ -4222,7 +4217,7 @@ dependencies = [
 [[package]]
 name = "near-indexer-primitives"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=836dbb7971a8d183e02f95d81d8a9ae18e731b37#836dbb7971a8d183e02f95d81d8a9ae18e731b37"
+source = "git+https://github.com/near/nearcore.git?rev=511414a5091c3bef5c447a5644ba903dc050b715#511414a5091c3bef5c447a5644ba903dc050b715"
 dependencies = [
  "near-primitives 0.0.0",
  "serde",
@@ -4232,7 +4227,7 @@ dependencies = [
 [[package]]
 name = "near-jsonrpc"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=836dbb7971a8d183e02f95d81d8a9ae18e731b37#836dbb7971a8d183e02f95d81d8a9ae18e731b37"
+source = "git+https://github.com/near/nearcore.git?rev=511414a5091c3bef5c447a5644ba903dc050b715#511414a5091c3bef5c447a5644ba903dc050b715"
 dependencies = [
  "actix",
  "actix-cors 0.6.5",
@@ -4264,7 +4259,7 @@ dependencies = [
 [[package]]
 name = "near-jsonrpc-client"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=836dbb7971a8d183e02f95d81d8a9ae18e731b37#836dbb7971a8d183e02f95d81d8a9ae18e731b37"
+source = "git+https://github.com/near/nearcore.git?rev=511414a5091c3bef5c447a5644ba903dc050b715#511414a5091c3bef5c447a5644ba903dc050b715"
 dependencies = [
  "actix-http",
  "awc",
@@ -4297,7 +4292,7 @@ dependencies = [
 [[package]]
 name = "near-jsonrpc-client"
 version = "0.8.0"
-source = "git+https://github.com/kobayurii/near-jsonrpc-client-rs.git?branch=0.8.2#a73423f1e348210466da7c82bd610b02f8aad80e"
+source = "git+https://github.com/kobayurii/near-jsonrpc-client-rs.git?branch=0.8.3#1f8e6f62f3fd02082df881de4d64cc19fe0759ad"
 dependencies = [
  "borsh 1.3.1",
  "lazy_static",
@@ -4315,7 +4310,7 @@ dependencies = [
 [[package]]
 name = "near-jsonrpc-primitives"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=836dbb7971a8d183e02f95d81d8a9ae18e731b37#836dbb7971a8d183e02f95d81d8a9ae18e731b37"
+source = "git+https://github.com/near/nearcore.git?rev=511414a5091c3bef5c447a5644ba903dc050b715#511414a5091c3bef5c447a5644ba903dc050b715"
 dependencies = [
  "arbitrary",
  "near-chain-configs 0.0.0",
@@ -4348,7 +4343,7 @@ dependencies = [
 [[package]]
 name = "near-lake-framework"
 version = "0.0.0"
-source = "git+https://github.com/kobayurii/near-lake-framework-rs.git?branch=0.7.8#84cf76a39669914bd46a01d8463761efd576c230"
+source = "git+https://github.com/kobayurii/near-lake-framework-rs.git?branch=0.7.9#88c93d2af21d91eb1f62020baf55f599956f3708"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4372,7 +4367,7 @@ dependencies = [
 [[package]]
 name = "near-mainnet-res"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=836dbb7971a8d183e02f95d81d8a9ae18e731b37#836dbb7971a8d183e02f95d81d8a9ae18e731b37"
+source = "git+https://github.com/near/nearcore.git?rev=511414a5091c3bef5c447a5644ba903dc050b715#511414a5091c3bef5c447a5644ba903dc050b715"
 dependencies = [
  "near-account-id",
  "near-chain-configs 0.0.0",
@@ -4383,7 +4378,7 @@ dependencies = [
 [[package]]
 name = "near-network"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=836dbb7971a8d183e02f95d81d8a9ae18e731b37#836dbb7971a8d183e02f95d81d8a9ae18e731b37"
+source = "git+https://github.com/near/nearcore.git?rev=511414a5091c3bef5c447a5644ba903dc050b715#511414a5091c3bef5c447a5644ba903dc050b715"
 dependencies = [
  "actix",
  "anyhow",
@@ -4432,7 +4427,7 @@ dependencies = [
 [[package]]
 name = "near-o11y"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=836dbb7971a8d183e02f95d81d8a9ae18e731b37#836dbb7971a8d183e02f95d81d8a9ae18e731b37"
+source = "git+https://github.com/near/nearcore.git?rev=511414a5091c3bef5c447a5644ba903dc050b715#511414a5091c3bef5c447a5644ba903dc050b715"
 dependencies = [
  "actix",
  "base64 0.21.7",
@@ -4485,7 +4480,7 @@ dependencies = [
 [[package]]
 name = "near-parameters"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=836dbb7971a8d183e02f95d81d8a9ae18e731b37#836dbb7971a8d183e02f95d81d8a9ae18e731b37"
+source = "git+https://github.com/near/nearcore.git?rev=511414a5091c3bef5c447a5644ba903dc050b715#511414a5091c3bef5c447a5644ba903dc050b715"
 dependencies = [
  "borsh 1.3.1",
  "enum-map",
@@ -4521,7 +4516,7 @@ dependencies = [
 [[package]]
 name = "near-performance-metrics"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=836dbb7971a8d183e02f95d81d8a9ae18e731b37#836dbb7971a8d183e02f95d81d8a9ae18e731b37"
+source = "git+https://github.com/near/nearcore.git?rev=511414a5091c3bef5c447a5644ba903dc050b715#511414a5091c3bef5c447a5644ba903dc050b715"
 dependencies = [
  "actix",
  "bitflags 1.3.2",
@@ -4537,16 +4532,16 @@ dependencies = [
 [[package]]
 name = "near-performance-metrics-macros"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=836dbb7971a8d183e02f95d81d8a9ae18e731b37#836dbb7971a8d183e02f95d81d8a9ae18e731b37"
+source = "git+https://github.com/near/nearcore.git?rev=511414a5091c3bef5c447a5644ba903dc050b715#511414a5091c3bef5c447a5644ba903dc050b715"
 dependencies = [
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
 name = "near-pool"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=836dbb7971a8d183e02f95d81d8a9ae18e731b37#836dbb7971a8d183e02f95d81d8a9ae18e731b37"
+source = "git+https://github.com/near/nearcore.git?rev=511414a5091c3bef5c447a5644ba903dc050b715#511414a5091c3bef5c447a5644ba903dc050b715"
 dependencies = [
  "borsh 1.3.1",
  "near-crypto 0.0.0",
@@ -4559,7 +4554,7 @@ dependencies = [
 [[package]]
 name = "near-primitives"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=836dbb7971a8d183e02f95d81d8a9ae18e731b37#836dbb7971a8d183e02f95d81d8a9ae18e731b37"
+source = "git+https://github.com/near/nearcore.git?rev=511414a5091c3bef5c447a5644ba903dc050b715#511414a5091c3bef5c447a5644ba903dc050b715"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -4642,7 +4637,7 @@ dependencies = [
 [[package]]
 name = "near-primitives-core"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=836dbb7971a8d183e02f95d81d8a9ae18e731b37#836dbb7971a8d183e02f95d81d8a9ae18e731b37"
+source = "git+https://github.com/near/nearcore.git?rev=511414a5091c3bef5c447a5644ba903dc050b715#511414a5091c3bef5c447a5644ba903dc050b715"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -4683,7 +4678,7 @@ dependencies = [
 [[package]]
 name = "near-rosetta-rpc"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=836dbb7971a8d183e02f95d81d8a9ae18e731b37#836dbb7971a8d183e02f95d81d8a9ae18e731b37"
+source = "git+https://github.com/near/nearcore.git?rev=511414a5091c3bef5c447a5644ba903dc050b715#511414a5091c3bef5c447a5644ba903dc050b715"
 dependencies = [
  "actix",
  "actix-cors 0.6.5",
@@ -4714,11 +4709,11 @@ dependencies = [
 [[package]]
 name = "near-rpc-error-core"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=836dbb7971a8d183e02f95d81d8a9ae18e731b37#836dbb7971a8d183e02f95d81d8a9ae18e731b37"
+source = "git+https://github.com/near/nearcore.git?rev=511414a5091c3bef5c447a5644ba903dc050b715#511414a5091c3bef5c447a5644ba903dc050b715"
 dependencies = [
  "quote",
  "serde",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -4729,17 +4724,17 @@ checksum = "80fca203c51edd9595ec14db1d13359fb9ede32314990bf296b6c5c4502f6ab7"
 dependencies = [
  "quote",
  "serde",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
 name = "near-rpc-error-macro"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=836dbb7971a8d183e02f95d81d8a9ae18e731b37#836dbb7971a8d183e02f95d81d8a9ae18e731b37"
+source = "git+https://github.com/near/nearcore.git?rev=511414a5091c3bef5c447a5644ba903dc050b715#511414a5091c3bef5c447a5644ba903dc050b715"
 dependencies = [
  "near-rpc-error-core 0.0.0",
  "serde",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -4751,12 +4746,12 @@ dependencies = [
  "fs2",
  "near-rpc-error-core 0.20.1",
  "serde",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
 name = "near-state-indexer"
-version = "0.1.0"
+version = "0.2.2"
 dependencies = [
  "actix",
  "actix-web",
@@ -4784,7 +4779,7 @@ dependencies = [
 [[package]]
 name = "near-stdx"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=836dbb7971a8d183e02f95d81d8a9ae18e731b37#836dbb7971a8d183e02f95d81d8a9ae18e731b37"
+source = "git+https://github.com/near/nearcore.git?rev=511414a5091c3bef5c447a5644ba903dc050b715#511414a5091c3bef5c447a5644ba903dc050b715"
 
 [[package]]
 name = "near-stdx"
@@ -4795,7 +4790,7 @@ checksum = "855fd5540e3b4ff6fedf12aba2db1ee4b371b36f465da1363a6d022b27cb43b8"
 [[package]]
 name = "near-store"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=836dbb7971a8d183e02f95d81d8a9ae18e731b37#836dbb7971a8d183e02f95d81d8a9ae18e731b37"
+source = "git+https://github.com/near/nearcore.git?rev=511414a5091c3bef5c447a5644ba903dc050b715#511414a5091c3bef5c447a5644ba903dc050b715"
 dependencies = [
  "actix",
  "actix-rt",
@@ -4837,7 +4832,7 @@ dependencies = [
 [[package]]
 name = "near-telemetry"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=836dbb7971a8d183e02f95d81d8a9ae18e731b37#836dbb7971a8d183e02f95d81d8a9ae18e731b37"
+source = "git+https://github.com/near/nearcore.git?rev=511414a5091c3bef5c447a5644ba903dc050b715#511414a5091c3bef5c447a5644ba903dc050b715"
 dependencies = [
  "actix",
  "awc",
@@ -4856,7 +4851,7 @@ dependencies = [
 [[package]]
 name = "near-vm-compiler"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=836dbb7971a8d183e02f95d81d8a9ae18e731b37#836dbb7971a8d183e02f95d81d8a9ae18e731b37"
+source = "git+https://github.com/near/nearcore.git?rev=511414a5091c3bef5c447a5644ba903dc050b715#511414a5091c3bef5c447a5644ba903dc050b715"
 dependencies = [
  "enumset",
  "finite-wasm",
@@ -4872,7 +4867,7 @@ dependencies = [
 [[package]]
 name = "near-vm-compiler-singlepass"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=836dbb7971a8d183e02f95d81d8a9ae18e731b37#836dbb7971a8d183e02f95d81d8a9ae18e731b37"
+source = "git+https://github.com/near/nearcore.git?rev=511414a5091c3bef5c447a5644ba903dc050b715#511414a5091c3bef5c447a5644ba903dc050b715"
 dependencies = [
  "dynasm 2.0.0",
  "dynasmrt 2.0.0",
@@ -4893,7 +4888,7 @@ dependencies = [
 [[package]]
 name = "near-vm-engine"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=836dbb7971a8d183e02f95d81d8a9ae18e731b37#836dbb7971a8d183e02f95d81d8a9ae18e731b37"
+source = "git+https://github.com/near/nearcore.git?rev=511414a5091c3bef5c447a5644ba903dc050b715#511414a5091c3bef5c447a5644ba903dc050b715"
 dependencies = [
  "backtrace",
  "cfg-if 1.0.0",
@@ -4916,7 +4911,7 @@ dependencies = [
 [[package]]
 name = "near-vm-runner"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=836dbb7971a8d183e02f95d81d8a9ae18e731b37#836dbb7971a8d183e02f95d81d8a9ae18e731b37"
+source = "git+https://github.com/near/nearcore.git?rev=511414a5091c3bef5c447a5644ba903dc050b715#511414a5091c3bef5c447a5644ba903dc050b715"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -4995,7 +4990,7 @@ dependencies = [
 [[package]]
 name = "near-vm-types"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=836dbb7971a8d183e02f95d81d8a9ae18e731b37#836dbb7971a8d183e02f95d81d8a9ae18e731b37"
+source = "git+https://github.com/near/nearcore.git?rev=511414a5091c3bef5c447a5644ba903dc050b715#511414a5091c3bef5c447a5644ba903dc050b715"
 dependencies = [
  "indexmap 1.9.3",
  "num-traits",
@@ -5006,7 +5001,7 @@ dependencies = [
 [[package]]
 name = "near-vm-vm"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=836dbb7971a8d183e02f95d81d8a9ae18e731b37#836dbb7971a8d183e02f95d81d8a9ae18e731b37"
+source = "git+https://github.com/near/nearcore.git?rev=511414a5091c3bef5c447a5644ba903dc050b715#511414a5091c3bef5c447a5644ba903dc050b715"
 dependencies = [
  "backtrace",
  "cc",
@@ -5027,7 +5022,7 @@ dependencies = [
 [[package]]
 name = "near-wallet-contract"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=836dbb7971a8d183e02f95d81d8a9ae18e731b37#836dbb7971a8d183e02f95d81d8a9ae18e731b37"
+source = "git+https://github.com/near/nearcore.git?rev=511414a5091c3bef5c447a5644ba903dc050b715#511414a5091c3bef5c447a5644ba903dc050b715"
 dependencies = [
  "anyhow",
  "near-vm-runner 0.0.0",
@@ -5036,7 +5031,7 @@ dependencies = [
 [[package]]
 name = "nearcore"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=836dbb7971a8d183e02f95d81d8a9ae18e731b37#836dbb7971a8d183e02f95d81d8a9ae18e731b37"
+source = "git+https://github.com/near/nearcore.git?rev=511414a5091c3bef5c447a5644ba903dc050b715#511414a5091c3bef5c447a5644ba903dc050b715"
 dependencies = [
  "actix",
  "actix-rt",
@@ -5125,7 +5120,7 @@ dependencies = [
 [[package]]
 name = "node-runtime"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=836dbb7971a8d183e02f95d81d8a9ae18e731b37#836dbb7971a8d183e02f95d81d8a9ae18e731b37"
+source = "git+https://github.com/near/nearcore.git?rev=511414a5091c3bef5c447a5644ba903dc050b715#511414a5091c3bef5c447a5644ba903dc050b715"
 dependencies = [
  "borsh 1.3.1",
  "hex",
@@ -5287,7 +5282,7 @@ dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -5343,7 +5338,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -5733,7 +5728,7 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "perf-testing"
-version = "0.1.0"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5795,7 +5790,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -5911,7 +5906,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a41cf62165e97c7f814d2221421dbb9afcbcdb0a88068e5ea206e19951c2cbb5"
 dependencies = [
  "proc-macro2",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -6299,7 +6294,7 @@ dependencies = [
 
 [[package]]
 name = "read-rpc-server"
-version = "0.1.0"
+version = "0.2.2"
 dependencies = [
  "actix-cors 0.7.0",
  "actix-web",
@@ -6319,7 +6314,7 @@ dependencies = [
  "near-chain-configs 0.0.0",
  "near-crypto 0.0.0",
  "near-indexer-primitives",
- "near-jsonrpc-client 0.8.0 (git+https://github.com/kobayurii/near-jsonrpc-client-rs.git?branch=0.8.2)",
+ "near-jsonrpc-client 0.8.0 (git+https://github.com/kobayurii/near-jsonrpc-client-rs.git?branch=0.8.3)",
  "near-jsonrpc-primitives 0.0.0",
  "near-lake-framework",
  "near-parameters 0.0.0",
@@ -6343,7 +6338,7 @@ dependencies = [
 
 [[package]]
 name = "readnode-primitives"
-version = "0.1.0"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "borsh 1.3.1",
@@ -6906,7 +6901,7 @@ dependencies = [
  "darling 0.20.8",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -7049,7 +7044,7 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -7080,7 +7075,7 @@ checksum = "0b2e6b945e9d3df726b65d6ee24060aff8e3533d431f677a9695db04eff9dfdb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -7131,14 +7126,14 @@ dependencies = [
  "darling 0.20.8",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.32"
+version = "0.9.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd075d994154d4a774f95b51fb96bdc2832b0ea48425c92546073816cda1f2f"
+checksum = "a0623d197252096520c6f2a5e1171ee436e5af99a5d7caa2891e55e61950e6d9"
 dependencies = [
  "indexmap 2.2.5",
  "itoa",
@@ -7374,7 +7369,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "state-indexer"
-version = "0.1.0"
+version = "0.2.2"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -7388,7 +7383,7 @@ dependencies = [
  "humantime",
  "lazy_static",
  "near-indexer-primitives",
- "near-jsonrpc-client 0.8.0 (git+https://github.com/kobayurii/near-jsonrpc-client-rs.git?branch=0.8.2)",
+ "near-jsonrpc-client 0.8.0 (git+https://github.com/kobayurii/near-jsonrpc-client-rs.git?branch=0.8.3)",
  "near-lake-framework",
  "near-primitives 0.0.0",
  "openssl-probe",
@@ -7506,9 +7501,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.52"
+version = "2.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07"
+checksum = "7383cd0e49fff4b6b90ca5670bfd3e9d6a733b3f90c686605aa7eec8c4996032"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7524,7 +7519,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -7642,7 +7637,7 @@ checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -7771,7 +7766,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -7845,9 +7840,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
+checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -8081,7 +8076,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -8218,7 +8213,7 @@ dependencies = [
 
 [[package]]
 name = "tx-indexer"
-version = "0.1.0"
+version = "0.2.2"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -8230,7 +8225,7 @@ dependencies = [
  "humantime",
  "lazy_static",
  "near-indexer-primitives",
- "near-jsonrpc-client 0.8.0 (git+https://github.com/kobayurii/near-jsonrpc-client-rs.git?branch=0.8.2)",
+ "near-jsonrpc-client 0.8.0 (git+https://github.com/kobayurii/near-jsonrpc-client-rs.git?branch=0.8.3)",
  "near-lake-framework",
  "prometheus",
  "readnode-primitives",
@@ -8301,9 +8296,9 @@ checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
 name = "unsafe-libyaml"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab4c90930b95a82d00dc9e9ac071b4991924390d46cbd0dfe566148667605e4b"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
@@ -8433,7 +8428,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
  "wasm-bindgen-shared",
 ]
 
@@ -8467,7 +8462,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -8925,7 +8920,7 @@ checksum = "09b5575a75e711ca6c36bb9ad647c93541cdc8e34218031acba5da3f35919dd3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -8990,9 +8985,9 @@ dependencies = [
 
 [[package]]
 name = "wildmatch"
-version = "2.3.2"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9d63b4687b0737f3b9e0f3a299ffd65824623859303a8e148443c3611c5c445"
+checksum = "939e59c1bc731542357fdaad98b209ef78c8743d652bb61439d16b16a79eb025"
 
 [[package]]
 name = "winapi"
@@ -9248,7 +9243,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [workspace.package]
-version = "0.1.0"
+version = "0.2.2"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
-rust-version = "1.73.0"
+rust-version = "1.76.0"
 repository = "https://github.com/near/read-rpc"
 license = "MIT OR Apache-2.0"
 
@@ -28,16 +28,16 @@ readnode-primitives = { path = "readnode-primitives" }
 epoch-indexer = { path = "epoch-indexer" }
 
 # Please, update the supported nearcore version in .cargo/config.toml file
-near-indexer = { git = 'https://github.com/near/nearcore.git', rev = '836dbb7971a8d183e02f95d81d8a9ae18e731b37' }
-near-client = { git = 'https://github.com/near/nearcore.git', rev = '836dbb7971a8d183e02f95d81d8a9ae18e731b37' }
-near-o11y = { git = 'https://github.com/near/nearcore.git', rev = '836dbb7971a8d183e02f95d81d8a9ae18e731b37' }
-near-indexer-primitives = { git = 'https://github.com/near/nearcore.git', rev = '836dbb7971a8d183e02f95d81d8a9ae18e731b37' }
-near-primitives = { git = 'https://github.com/near/nearcore.git', rev = '836dbb7971a8d183e02f95d81d8a9ae18e731b37' }
-near-chain-configs = { git = 'https://github.com/near/nearcore.git', rev = '836dbb7971a8d183e02f95d81d8a9ae18e731b37' }
-near-crypto = { git = 'https://github.com/near/nearcore.git', rev = '836dbb7971a8d183e02f95d81d8a9ae18e731b37' }
-near-jsonrpc-primitives = { git = 'https://github.com/near/nearcore.git', rev = '836dbb7971a8d183e02f95d81d8a9ae18e731b37' }
-near-parameters = { git = 'https://github.com/near/nearcore.git', rev = '836dbb7971a8d183e02f95d81d8a9ae18e731b37' }
-near-vm-runner = { git = 'https://github.com/near/nearcore.git', rev = '836dbb7971a8d183e02f95d81d8a9ae18e731b37' }
+near-indexer = { git = 'https://github.com/near/nearcore.git', rev = '511414a5091c3bef5c447a5644ba903dc050b715' }
+near-client = { git = 'https://github.com/near/nearcore.git', rev = '511414a5091c3bef5c447a5644ba903dc050b715' }
+near-o11y = { git = 'https://github.com/near/nearcore.git', rev = '511414a5091c3bef5c447a5644ba903dc050b715' }
+near-indexer-primitives = { git = 'https://github.com/near/nearcore.git', rev = '511414a5091c3bef5c447a5644ba903dc050b715' }
+near-primitives = { git = 'https://github.com/near/nearcore.git', rev = '511414a5091c3bef5c447a5644ba903dc050b715' }
+near-chain-configs = { git = 'https://github.com/near/nearcore.git', rev = '511414a5091c3bef5c447a5644ba903dc050b715' }
+near-crypto = { git = 'https://github.com/near/nearcore.git', rev = '511414a5091c3bef5c447a5644ba903dc050b715' }
+near-jsonrpc-primitives = { git = 'https://github.com/near/nearcore.git', rev = '511414a5091c3bef5c447a5644ba903dc050b715' }
+near-parameters = { git = 'https://github.com/near/nearcore.git', rev = '511414a5091c3bef5c447a5644ba903dc050b715' }
+near-vm-runner = { git = 'https://github.com/near/nearcore.git', rev = '511414a5091c3bef5c447a5644ba903dc050b715' }
 
-near-lake-framework = { git = 'https://github.com/kobayurii/near-lake-framework-rs.git', branch = '0.7.8' }
-near-jsonrpc-client = { git = 'https://github.com/kobayurii/near-jsonrpc-client-rs.git', branch = '0.8.2'}
+near-lake-framework = { git = 'https://github.com/kobayurii/near-lake-framework-rs.git', branch = '0.7.9' }
+near-jsonrpc-client = { git = 'https://github.com/kobayurii/near-jsonrpc-client-rs.git', branch = '0.8.3'}


### PR DESCRIPTION
This PR update new nearcore dependencies which include necessary fixes for near-indexer.
More details read in this PR: https://github.com/near/nearcore/pull/10798