### PR TITLE
tx request returns "Invalid params" to a totally valid request

### DIFF
--- a/rpc-server/src/modules/transactions/methods.rs
+++ b/rpc-server/src/modules/transactions/methods.rs
@@ -1,9 +1,13 @@
 use crate::config::ServerContext;
 use crate::errors::RPCError;
+use crate::modules::transactions::{
+    parse_signed_transaction, parse_transaction_status_common_request,
+};
 use jsonrpc_v2::{Data, Params};
 use near_primitives::views::FinalExecutionOutcomeViewEnum::{
     FinalExecutionOutcome, FinalExecutionOutcomeWithReceipt,
 };
+use serde_json::Value;
 
 pub async fn send_tx(
     data: Data<ServerContext>,
@@ -16,14 +20,14 @@ pub async fn send_tx(
 #[cfg_attr(feature = "tracing-instrumentation", tracing::instrument(skip(data)))]
 pub async fn tx(
     data: Data<ServerContext>,
-    Params(params): Params<
-        near_jsonrpc_primitives::types::transactions::RpcTransactionStatusRequest,
-    >,
+    Params(params): Params<Value>,
 ) -> Result<near_jsonrpc_primitives::types::transactions::RpcTransactionResponse, RPCError> {
     tracing::debug!("`tx` call. Params: {:?}", params);
     crate::metrics::TX_REQUESTS_TOTAL.inc();
 
-    let result = tx_status_common(&data, &params.transaction_info, false).await;
+    let tx_status_request = parse_transaction_status_common_request(params.clone()).await?;
+
+    let result = tx_status_common(&data, &tx_status_request.transaction_info, false).await;
 
     #[cfg(feature = "shadow_data_consistency")]
     {
@@ -37,8 +41,8 @@ pub async fn tx(
             // so we can't just pass `params` there, instead we need to craft a request manually
             // tx_status_request,
             near_jsonrpc_client::methods::tx::RpcTransactionStatusRequest {
-                transaction_info: params.transaction_info,
-                wait_until: params.wait_until,
+                transaction_info: tx_status_request.transaction_info,
+                wait_until: tx_status_request.wait_until,
             },
             "TX",
         )
@@ -55,14 +59,14 @@ pub async fn tx(
 #[cfg_attr(feature = "tracing-instrumentation", tracing::instrument(skip(data)))]
 pub async fn tx_status(
     data: Data<ServerContext>,
-    Params(params): Params<
-        near_jsonrpc_primitives::types::transactions::RpcTransactionStatusRequest,
-    >,
+    Params(params): Params<Value>,
 ) -> Result<near_jsonrpc_primitives::types::transactions::RpcTransactionResponse, RPCError> {
     tracing::debug!("`tx_status` call. Params: {:?}", params);
     crate::metrics::TX_STATUS_REQUESTS_TOTAL.inc();
 
-    let result = tx_status_common(&data, &params.transaction_info, true).await;
+    let tx_status_request = parse_transaction_status_common_request(params.clone()).await?;
+
+    let result = tx_status_common(&data, &tx_status_request.transaction_info, true).await;
 
     #[cfg(feature = "shadow_data_consistency")]
     {
@@ -75,8 +79,8 @@ pub async fn tx_status(
             // The method is `near_jsonrpc_client::methods::EXPERIMENTAL_tx_status` in the client
             // so we can't just pass `params` there, instead we need to craft a request manually
             near_jsonrpc_client::methods::EXPERIMENTAL_tx_status::RpcTransactionStatusRequest {
-                transaction_info: params.transaction_info,
-                wait_until: params.wait_until,
+                transaction_info: tx_status_request.transaction_info,
+                wait_until: tx_status_request.wait_until,
             },
             "EXPERIMENTAL_TX_STATUS",
         )
@@ -92,21 +96,22 @@ pub async fn tx_status(
 #[cfg_attr(feature = "tracing-instrumentation", tracing::instrument(skip(data)))]
 pub async fn broadcast_tx_async(
     data: Data<ServerContext>,
-    Params(params): Params<near_jsonrpc_primitives::types::transactions::RpcSendTransactionRequest>,
+    Params(params): Params<Value>,
 ) -> Result<near_primitives::hash::CryptoHash, RPCError> {
     tracing::debug!("`broadcast_tx_async` call. Params: {:?}", params);
     if cfg!(feature = "send_tx_methods") {
+        let signed_transaction = match parse_signed_transaction(params).await {
+            Ok(signed_transaction) => signed_transaction,
+            Err(err) => return Err(RPCError::parse_error(&err.to_string())),
+        };
         let proxy_params =
             near_jsonrpc_client::methods::broadcast_tx_async::RpcBroadcastTxAsyncRequest {
-                signed_transaction: params.signed_transaction,
+                signed_transaction,
             };
-        Ok(data
-            .near_rpc_client
-            .call(proxy_params)
-            .await
-            .map_err(|err| {
-                RPCError::internal_error(&format!("Failed to broadcast_tx_async: {}", err))
-            })?)
+        match data.near_rpc_client.call(proxy_params).await {
+            Ok(resp) => Ok(resp),
+            Err(err) => Err(RPCError::internal_error(&err.to_string())),
+        }
     } else {
         Err(RPCError::internal_error(
             "This method is not available because the `send_tx_methods` feature flag is disabled",
@@ -117,11 +122,30 @@ pub async fn broadcast_tx_async(
 #[cfg_attr(feature = "tracing-instrumentation", tracing::instrument(skip(data)))]
 pub async fn broadcast_tx_commit(
     data: Data<ServerContext>,
-    Params(params): Params<near_jsonrpc_primitives::types::transactions::RpcSendTransactionRequest>,
+    Params(params): Params<Value>,
 ) -> Result<near_jsonrpc_primitives::types::transactions::RpcTransactionResponse, RPCError> {
     tracing::debug!("`broadcast_tx_commit` call. Params: {:?}", params);
     if cfg!(feature = "send_tx_methods") {
-        Ok(data.near_rpc_client.call(params).await?)
+        let signed_transaction = match parse_signed_transaction(params).await {
+            Ok(signed_transaction) => signed_transaction,
+            Err(err) => return Err(RPCError::parse_error(&err.to_string())),
+        };
+        let proxy_params =
+            near_jsonrpc_client::methods::broadcast_tx_commit::RpcBroadcastTxCommitRequest {
+                signed_transaction,
+            };
+        match data.near_rpc_client.call(proxy_params).await {
+            Ok(resp) => Ok(
+                near_jsonrpc_primitives::types::transactions::RpcTransactionResponse {
+                    final_execution_outcome: Some(FinalExecutionOutcome(resp)),
+                    // With the fact that we don't support non-finalised data yet,
+                    // final_execution_status field can be always filled with FINAL.
+                    // This logic will be more complicated when we add support of optimistic blocks.
+                    final_execution_status: near_primitives::views::TxExecutionStatus::Final,
+                },
+            ),
+            Err(err) => Err(RPCError::from(err)),
+        }
     } else {
         Err(RPCError::internal_error(
             "This method is not available because the `send_tx_methods` feature flag is disabled",

--- a/rpc-server/src/modules/transactions/mod.rs
+++ b/rpc-server/src/modules/transactions/mod.rs
@@ -1,1 +1,69 @@
 pub mod methods;
+use serde_json::Value;
+
+#[cfg_attr(feature = "tracing-instrumentation", tracing::instrument(skip(value)))]
+pub async fn parse_transaction_status_common_request(
+    value: Value,
+) -> Result<
+    near_jsonrpc_primitives::types::transactions::RpcTransactionStatusRequest,
+    near_jsonrpc_primitives::errors::RpcError,
+> {
+    tracing::debug!("`parse_transaction_status_common_request` call.");
+    if let Ok(request) = serde_json::from_value::<
+        near_jsonrpc_primitives::types::transactions::RpcTransactionStatusRequest,
+    >(value.clone())
+    {
+        Ok(request)
+    } else if let Ok((tx_hash, sender_account_id)) = serde_json::from_value::<(
+        near_primitives::hash::CryptoHash,
+        near_primitives::types::AccountId,
+    )>(value.clone())
+    {
+        let transaction_info =
+            near_jsonrpc_primitives::types::transactions::TransactionInfo::TransactionId {
+                tx_hash,
+                sender_account_id,
+            };
+        Ok(
+            near_jsonrpc_primitives::types::transactions::RpcTransactionStatusRequest {
+                transaction_info,
+                wait_until: near_primitives::views::TxExecutionStatus::Final,
+            },
+        )
+    } else {
+        let signed_transaction = parse_signed_transaction(value).await.map_err(|err| {
+            near_jsonrpc_primitives::errors::RpcError::parse_error(err.to_string())
+        })?;
+
+        let transaction_info =
+            near_jsonrpc_primitives::types::transactions::TransactionInfo::Transaction(
+                near_jsonrpc_primitives::types::transactions::SignedTransaction::SignedTransaction(
+                    signed_transaction,
+                ),
+            );
+        Ok(
+            near_jsonrpc_primitives::types::transactions::RpcTransactionStatusRequest {
+                transaction_info,
+                wait_until: near_primitives::views::TxExecutionStatus::Final,
+            },
+        )
+    }
+}
+
+#[cfg_attr(feature = "tracing-instrumentation", tracing::instrument(skip(value)))]
+pub async fn parse_signed_transaction(
+    value: Value,
+) -> anyhow::Result<near_primitives::transaction::SignedTransaction> {
+    tracing::debug!("`parse_signed_transaction` call.");
+    if let Ok(signed_transaction) =
+        serde_json::from_value::<near_primitives::transaction::SignedTransaction>(value.clone())
+    {
+        Ok(signed_transaction)
+    } else {
+        let (encoded,) = serde_json::from_value::<(String,)>(value)?;
+        let bytes = near_primitives::serialize::from_base64(&encoded)?;
+        Ok(borsh::from_slice::<
+            near_primitives::transaction::SignedTransaction,
+        >(&bytes)?)
+    }
+}


### PR DESCRIPTION
In this PR  we added support new and old request style for transactions:

**old:** 
```{
  "jsonrpc": "2.0",
  "id": "dontcare",
  "method": "tx",
  "params": ["67JtSzundU2tt2wEoJYhf527QBRHSxC5FW8KDBWGbA6H", "hotwallet.kaiching"]
}
```

**new:**

```{
  "jsonrpc": "2.0",
  "id": "dontcare",
  "method": "tx",
  "params": {
    "tx_hash": "67JtSzundU2tt2wEoJYhf527QBRHSxC5FW8KDBWGbA6H",
    "sender_account_id": "hotwallet.kaiching"
  }
}
```
