### PR TITLE
fix: Fix Dockerfile for read-rpc server

### DIFF
--- a/rpc-server/Dockerfile
+++ b/rpc-server/Dockerfile
@@ -11,6 +11,8 @@ COPY rpc-server/Cargo.toml rpc-server/Cargo.toml
 COPY configuration configuration
 COPY database database
 COPY readnode-primitives readnode-primitives
+RUN apt update && apt install -yy llvm \
+    clang
 RUN mkdir rpc-server/src && echo 'fn main() {}' > rpc-server/src/main.rs cargo build --release && rm -r rpc-server/src
 
 # copy your source tree


### PR DESCRIPTION
To fix the problem with parsing, we had to depend on additional parts of `nearcore`, which require redundant dependency. Right now we need to make the ReadRPC working