### PR TITLE
add warning when we could't borsh dezerialize tx deteils

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8270,6 +8270,7 @@ version = "0.2.5"
 dependencies = [
  "actix-web",
  "anyhow",
+ "borsh 1.3.1",
  "clap",
  "configuration",
  "database",

--- a/database/src/base/tx_indexer.rs
+++ b/database/src/base/tx_indexer.rs
@@ -8,6 +8,10 @@ pub trait TxIndexerDbManager {
         signer_id: &str,
     ) -> anyhow::Result<()>;
 
+    // This function is used to validate that the transaction is saved correctly.
+    // For some unknown reason, tx-indexer saves invalid data for transactions. 
+    // We want to avoid these problems and get more information. 
+    // That's why we added this method.
     async fn validate_saved_transaction_deserializable(
         &self,
         transaction_hash: &str,

--- a/database/src/base/tx_indexer.rs
+++ b/database/src/base/tx_indexer.rs
@@ -2,14 +2,16 @@
 pub trait TxIndexerDbManager {
     async fn add_transaction(
         &self,
-        transaction: readnode_primitives::TransactionDetails,
-        block_height: u64,
-    ) -> anyhow::Result<()>;
-
-    async fn check_transaction_save_correctly(
-        &self,
         transaction_hash: &str,
         tx_bytes: Vec<u8>,
+        block_height: u64,
+        signer_id: &str,
+    ) -> anyhow::Result<()>;
+
+    async fn validate_saved_transaction_deserializable(
+        &self,
+        transaction_hash: &str,
+        tx_bytes: &[u8],
     ) -> anyhow::Result<bool>;
 
     async fn add_receipt(

--- a/database/src/base/tx_indexer.rs
+++ b/database/src/base/tx_indexer.rs
@@ -6,6 +6,12 @@ pub trait TxIndexerDbManager {
         block_height: u64,
     ) -> anyhow::Result<()>;
 
+    async fn check_transaction_save_correctly(
+        &self,
+        transaction_hash: &str,
+        tx_bytes: Vec<u8>,
+    ) -> anyhow::Result<bool>;
+
     async fn add_receipt(
         &self,
         receipt_id: &str,

--- a/database/src/base/tx_indexer.rs
+++ b/database/src/base/tx_indexer.rs
@@ -9,8 +9,8 @@ pub trait TxIndexerDbManager {
     ) -> anyhow::Result<()>;
 
     // This function is used to validate that the transaction is saved correctly.
-    // For some unknown reason, tx-indexer saves invalid data for transactions. 
-    // We want to avoid these problems and get more information. 
+    // For some unknown reason, tx-indexer saves invalid data for transactions.
+    // We want to avoid these problems and get more information.
     // That's why we added this method.
     async fn validate_saved_transaction_deserializable(
         &self,

--- a/database/src/postgres/tx_indexer.rs
+++ b/database/src/postgres/tx_indexer.rs
@@ -39,6 +39,15 @@ impl crate::TxIndexerDbManager for PostgresDBManager {
         .await
     }
 
+    async fn check_transaction_save_correctly(
+        &self,
+        _transaction_hash: &str,
+        _tx_bytes: Vec<u8>,
+    ) -> anyhow::Result<bool> {
+        // return always true, because we don't have any checks for Postgres database
+        Ok(true)
+    }
+
     async fn add_receipt(
         &self,
         receipt_id: &str,

--- a/database/src/postgres/tx_indexer.rs
+++ b/database/src/postgres/tx_indexer.rs
@@ -26,25 +26,27 @@ impl PostgresStorageManager for PostgresDBManager {}
 impl crate::TxIndexerDbManager for PostgresDBManager {
     async fn add_transaction(
         &self,
-        transaction: readnode_primitives::TransactionDetails,
+        transaction_hash: &str,
+        tx_bytes: Vec<u8>,
         block_height: u64,
+        signer_id: &str,
     ) -> anyhow::Result<()> {
         crate::models::TransactionDetail {
-            transaction_hash: transaction.transaction.hash.to_string(),
+            transaction_hash: transaction_hash.to_string(),
             block_height: bigdecimal::BigDecimal::from(block_height),
-            account_id: transaction.transaction.signer_id.to_string(),
-            transaction_details: borsh::to_vec(&transaction)?,
+            account_id: signer_id.to_string(),
+            transaction_details: tx_bytes,
         }
         .insert_or_ignore(Self::get_connection(&self.pg_pool).await?)
         .await
     }
 
-    async fn check_transaction_save_correctly(
+    async fn validate_saved_transaction_deserializable(
         &self,
         _transaction_hash: &str,
-        _tx_bytes: Vec<u8>,
+        _tx_bytes: &[u8],
     ) -> anyhow::Result<bool> {
-        // return always true, because we don't have any checks for Postgres database
+        // return always true, because we don't have tx_save_validation for Postgres database
         Ok(true)
     }
 

--- a/database/src/postgres/tx_indexer.rs
+++ b/database/src/postgres/tx_indexer.rs
@@ -41,12 +41,12 @@ impl crate::TxIndexerDbManager for PostgresDBManager {
         .await
     }
 
+    // return always true, because we don't have tx_save_validation for Postgres database
     async fn validate_saved_transaction_deserializable(
         &self,
         _transaction_hash: &str,
         _tx_bytes: &[u8],
     ) -> anyhow::Result<bool> {
-        // return always true, because we don't have tx_save_validation for Postgres database
         Ok(true)
     }
 

--- a/database/src/scylladb/rpc_server.rs
+++ b/database/src/scylladb/rpc_server.rs
@@ -458,8 +458,13 @@ impl crate::ReaderDbManager for ScyllaDBManager {
         .await?
         .single_row()?
         .into_typed::<(Vec<u8>,)>()?;
-
-        Ok(borsh::from_slice::<readnode_primitives::TransactionDetails>(&data_value)?)
+        match borsh::from_slice::<readnode_primitives::TransactionDetails>(&data_value) {
+            Ok(tx) => Ok(tx),
+            Err(e) => {
+                tracing::warn!("Failed tx_details borsh deserialize: TX_HASH - {}, ERROR: {:?}", transaction_hash, e);
+                anyhow::bail!("Failed to parse transaction details")
+            }
+        }
     }
 
     /// Returns the readnode_primitives::TransactionDetails

--- a/database/src/scylladb/rpc_server.rs
+++ b/database/src/scylladb/rpc_server.rs
@@ -461,7 +461,11 @@ impl crate::ReaderDbManager for ScyllaDBManager {
         match borsh::from_slice::<readnode_primitives::TransactionDetails>(&data_value) {
             Ok(tx) => Ok(tx),
             Err(e) => {
-                tracing::warn!("Failed tx_details borsh deserialize: TX_HASH - {}, ERROR: {:?}", transaction_hash, e);
+                tracing::warn!(
+                    "Failed tx_details borsh deserialize: TX_HASH - {}, ERROR: {:?}",
+                    transaction_hash,
+                    e
+                );
                 anyhow::bail!("Failed to parse transaction details")
             }
         }

--- a/database/src/scylladb/tx_indexer.rs
+++ b/database/src/scylladb/tx_indexer.rs
@@ -268,6 +268,10 @@ impl crate::TxIndexerDbManager for ScyllaDBManager {
         Ok(())
     }
 
+    // This function is used to validate that the transaction is saved correctly.
+    // For some unknown reason, tx-indexer saves invalid data for transactions. 
+    // We want to avoid these problems and get more information. 
+    // That's why we added this method.
     async fn validate_saved_transaction_deserializable(
         &self,
         transaction_hash: &str,

--- a/database/src/scylladb/tx_indexer.rs
+++ b/database/src/scylladb/tx_indexer.rs
@@ -269,8 +269,8 @@ impl crate::TxIndexerDbManager for ScyllaDBManager {
     }
 
     // This function is used to validate that the transaction is saved correctly.
-    // For some unknown reason, tx-indexer saves invalid data for transactions. 
-    // We want to avoid these problems and get more information. 
+    // For some unknown reason, tx-indexer saves invalid data for transactions.
+    // We want to avoid these problems and get more information.
     // That's why we added this method.
     async fn validate_saved_transaction_deserializable(
         &self,

--- a/tx-indexer/Cargo.toml
+++ b/tx-indexer/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace = true
 [dependencies]
 actix-web = "4.5.1"
 anyhow = "1.0.70"
+borsh = "1.3.1"
 clap = "4.4.18"
 futures = "0.3.5"
 futures-locks = "0.7.1"

--- a/tx-indexer/src/collector.rs
+++ b/tx-indexer/src/collector.rs
@@ -318,6 +318,11 @@ async fn save_transaction_details(
                     err
                 );
                 if attempts >= 3 {
+                    tracing::error!(
+                        target: crate::INDEXER,
+                        "Failed to validate transaction {} after 3 attempts",
+                        transaction_hash
+                    );
                     return false;
                 } else {
                     attempts += 1;

--- a/tx-indexer/src/collector.rs
+++ b/tx-indexer/src/collector.rs
@@ -2,7 +2,6 @@ use futures::{
     future::{join_all, try_join_all},
     StreamExt,
 };
-use near_indexer_primitives::near_primitives::borsh;
 use near_indexer_primitives::IndexerTransactionWithOutcome;
 
 /// Blocks #47317863 and #47317864 with restored receipts.


### PR DESCRIPTION
For some unknown reason, tx-indexer saves invalid data for transactions. We want to avoid these problems and get more information. That's why we added a mechanism to check and resave transactions. We have also expanded logging so that we can determine the causes in more detail.