### PR TITLE
Update nearcore to 1.39.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/near/read-rpc/compare/v0.2.5...HEAD)
+## [Unreleased](https://github.com/near/read-rpc/compare/v0.2.6...HEAD)
+
+## [0.2.6](https://github.com/near/read-rpc/releases/tag/v0.2.6)
+### Supported Nearcore Version
+- nearcore v1.39.0
+- rust v1.76.0
 
 ## [0.2.5](https://github.com/near/read-rpc/releases/tag/v0.2.5)
 ### Supported Nearcore Version

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6377,7 +6377,7 @@ dependencies = [
  "paste",
  "prometheus",
  "readnode-primitives",
- "redis-subscribe",
+ "redis",
  "rustc_version 0.4.0",
  "serde",
  "serde_json",
@@ -6425,21 +6425,6 @@ dependencies = [
  "tokio-retry",
  "tokio-util 0.7.10",
  "url",
-]
-
-[[package]]
-name = "redis-subscribe"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2466a48c69ca63a8753c51c3d9c31e77dcbd5f1a88618211f805e54e2415bc64"
-dependencies = [
- "async-stream",
- "nom",
- "rand 0.8.5",
- "thiserror",
- "tokio",
- "tokio-stream",
- "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,7 +130,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
 dependencies = [
  "quote",
- "syn 2.0.53",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -265,7 +265,7 @@ dependencies = [
  "actix-router",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -276,7 +276,7 @@ checksum = "7c7db3d5a9718568e4cf4a537cfd7070e6e6ff7481510d0237fb529ac850f6d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -300,7 +300,7 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
- "getrandom 0.2.12",
+ "getrandom 0.2.14",
  "once_cell",
  "version_check",
 ]
@@ -312,7 +312,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if 1.0.0",
- "getrandom 0.2.12",
+ "getrandom 0.2.14",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -428,9 +428,9 @@ dependencies = [
 
 [[package]]
 name = "arc-swap"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b3d0060af21e8d11a926981cc00c6c1541aa91dd64b9f881985c3da1094425f"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
 name = "arrayref"
@@ -490,18 +490,18 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.58",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.78"
+version = "0.1.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "461abc97219de0eaaf81fe3ef974a540158f3d079c2ab200f891f1a2ef201e85"
+checksum = "a507401cad91ec6a857ed5513a2073c82a9b9048762b885bb98655b306964681"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -522,9 +522,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
 
 [[package]]
 name = "awc"
@@ -562,9 +562,9 @@ dependencies = [
 
 [[package]]
 name = "aws-config"
-version = "1.1.8"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f4084d18094aec9f79d509f4cb6ccf6b613c5037e32f32e74312e52b836e366"
+checksum = "48730d0b4c3d91c43d0d37168831d9fd0e065ad4a889a2ee9faf8d34c3d2804d"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -579,7 +579,7 @@ dependencies = [
  "aws-smithy-types",
  "aws-types",
  "bytes",
- "fastrand 2.0.1",
+ "fastrand 2.0.2",
  "hex",
  "http 0.2.12",
  "hyper",
@@ -587,6 +587,7 @@ dependencies = [
  "time",
  "tokio",
  "tracing",
+ "url",
  "zeroize",
 ]
 
@@ -629,9 +630,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b13dc54b4b49f8288532334bba8f87386a40571c47c37b1304979b556dc613c8"
+checksum = "c4ee6903f9d0197510eb6b44c4d86b493011d08b4992938f7b9be0333b6685aa"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -642,9 +643,9 @@ dependencies = [
  "aws-smithy-types",
  "aws-types",
  "bytes",
- "fastrand 2.0.1",
+ "fastrand 2.0.2",
  "http 0.2.12",
- "http-body",
+ "http-body 0.4.6",
  "percent-encoding",
  "pin-project-lite",
  "tracing",
@@ -653,9 +654,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.20.0"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2090d4e1455988a3a09a3a695c66de0feef49ebbc3f87bf49a7344308bc5656"
+checksum = "644c5939c1b78097d37f3341708978d68490070d4b0f8fa91f0878678c06a7ef"
 dependencies = [
  "ahash 0.8.11",
  "aws-credential-types",
@@ -672,11 +673,11 @@ dependencies = [
  "aws-smithy-xml",
  "aws-types",
  "bytes",
- "fastrand 2.0.1",
+ "fastrand 2.0.2",
  "hex",
  "hmac",
  "http 0.2.12",
- "http-body",
+ "http-body 0.4.6",
  "lru 0.12.3",
  "once_cell",
  "percent-encoding",
@@ -688,9 +689,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.17.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5cc34f5925899739a3f125bd3f7d37d081234a3df218feb9c9d337fd4c70e72"
+checksum = "b2be5ba83b077b67a6f7a1927eb6b212bf556e33bd74b5eaa5aa6e421910803a"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -710,9 +711,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.17.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7327cddd32b1a6f2aaeaadb1336b671a7975e96a999d3b1bcf5aa47932dc6ddb"
+checksum = "022ca669825f841aef17b12d4354ef2b8651e4664be49f2d9ea13e4062a80c9f"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -732,9 +733,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.17.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c11981cdb80e8e205e22beb6630a8bdec380a1256bd29efaab34aaebd07cfb9"
+checksum = "8e4a5f5cb007347c1ab34a6d56456301dfada921fc9e57d687ecb08baddd11ff"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -784,9 +785,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-async"
-version = "1.1.8"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26ea8fa03025b2face2b3038a63525a10891e3d8829901d502e5384a0d8cd46"
+checksum = "62220bc6e97f946ddd51b5f1361f78996e704677afc518a4ff66b7a72ea1378c"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -806,7 +807,7 @@ dependencies = [
  "crc32fast",
  "hex",
  "http 0.2.12",
- "http-body",
+ "http-body 0.4.6",
  "md-5",
  "pin-project-lite",
  "sha1",
@@ -838,7 +839,7 @@ dependencies = [
  "bytes-utils",
  "futures-core",
  "http 0.2.12",
- "http-body",
+ "http-body 0.4.6",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -867,19 +868,20 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.1.8"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec81002d883e5a7fd2bb063d6fb51c4999eb55d404f4fff3dd878bf4733b9f01"
+checksum = "c53572b4cd934ee5e8461ad53caa36e9d246aaef42166e3ac539e206a925d330"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
- "fastrand 2.0.1",
+ "fastrand 2.0.2",
  "h2",
  "http 0.2.12",
- "http-body",
+ "http-body 0.4.6",
+ "http-body 1.0.0",
  "hyper",
  "hyper-rustls",
  "once_cell",
@@ -892,9 +894,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9acb931e0adaf5132de878f1398d83f8677f90ba70f01f65ff87f6d7244be1c5"
+checksum = "ccb2b3a7030dc9a3c9a08ce0b25decea5130e9db19619d4dffbbff34f75fe850"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-types",
@@ -918,7 +920,10 @@ dependencies = [
  "bytes-utils",
  "futures-core",
  "http 0.2.12",
- "http-body",
+ "http 1.1.0",
+ "http-body 0.4.6",
+ "http-body 1.0.0",
+ "http-body-util",
  "itoa",
  "num-integer",
  "pin-project-lite",
@@ -941,9 +946,9 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dbf2f3da841a8930f159163175cf6a3d16ddde517c1b0fba7aa776822800f40"
+checksum = "afb278e322f16f59630a83b6b2dc992a0b48aa74ed47b4130f193fae0053d713"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
@@ -956,9 +961,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.69"
+version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
 dependencies = [
  "addr2line",
  "cc",
@@ -1049,7 +1054,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.53",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -1142,11 +1147,11 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f58b559fd6448c6e2fd0adb5720cd98a2506594cafa4737ff98c396f3e82f667"
+checksum = "0901fc8eb0aca4c83be0106d6f2db17d86a08dfc2c25f0e84464bf381158add6"
 dependencies = [
- "borsh-derive 1.3.1",
+ "borsh-derive 1.4.0",
  "cfg_aliases",
 ]
 
@@ -1165,15 +1170,15 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aadb5b6ccbd078890f6d7003694e33816e6b784358f18e15e7e6d9f065a57cd"
+checksum = "51670c3aa053938b0ee3bd67c3817e471e626151131b934038e83c5bf8de48f5"
 dependencies = [
  "once_cell",
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.58",
  "syn_derive",
 ]
 
@@ -1228,9 +1233,9 @@ checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 
 [[package]]
 name = "bumpalo"
-version = "3.15.4"
+version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytecheck"
@@ -1262,9 +1267,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
 name = "bytes-utils"
@@ -1323,9 +1328,9 @@ checksum = "a2698f953def977c68f935bb0dfa959375ad4638570e969e2f1e9f433cbf1af6"
 
 [[package]]
 name = "cc"
-version = "1.0.90"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
+checksum = "2678b2e3449475e95b0aa6f9b506a28e61b3dc8996592b983695e8ebb58a8b41"
 dependencies = [
  "jobserver",
  "libc",
@@ -1360,9 +1365,9 @@ checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "chrono"
-version = "0.4.35"
+version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf5903dcbc0a39312feb77df2ff4c76387d591b9fc7b04a238dcf8bb62639a"
+checksum = "8a0d04d43504c61aa6c7531f1871dd0d418d91130162063b789da00fd7057a5e"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -1395,9 +1400,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.3"
+version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949626d00e063efc93b6dca932419ceb5432f99769911c0b995f7e884c778813"
+checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1412,19 +1417,19 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim 0.11.0",
+ "strsim 0.11.1",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.5.3"
+version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90239a040c80f5e14809ca132ddc4176ab33d5e17e49691793296e3fcb34d72f"
+checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -1706,9 +1711,9 @@ dependencies = [
 
 [[package]]
 name = "crc"
-version = "3.0.1"
+version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86ec7a15cbe22e59248fc7eadb1907dab5ba09372595da4d73dd805ed4417dfe"
+checksum = "69e6e4d7b33a94f0991c26729976b10ebde1d34c3ee82408fb536164fa10d636"
 dependencies = [
  "crc-catalog",
 ]
@@ -1918,7 +1923,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -1966,7 +1971,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.10.0",
- "syn 2.0.53",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -1988,7 +1993,7 @@ checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
 dependencies = [
  "darling_core 0.20.8",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -2011,7 +2016,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bigdecimal",
- "borsh 1.3.1",
+ "borsh 1.4.0",
  "bytes",
  "configuration",
  "diesel",
@@ -2103,7 +2108,7 @@ checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -2192,7 +2197,7 @@ dependencies = [
  "diesel_table_macro_syntax",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -2212,7 +2217,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc5557efc453706fed5e4fa85006fe9817c224c3f480a34c7e5959fd700921c5"
 dependencies = [
- "syn 2.0.53",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -2469,7 +2474,7 @@ checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -2490,7 +2495,7 @@ dependencies = [
  "darling 0.20.8",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -2594,9 +2599,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
 
 [[package]]
 name = "ff"
@@ -2789,7 +2794,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -2876,9 +2881,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.12"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
+checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -2892,7 +2897,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 dependencies = [
  "fallible-iterator 0.3.0",
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "stable_deref_trait",
 ]
 
@@ -2915,9 +2920,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fbd2820c5e49886948654ab546d0688ff24530286bdcf8fca3cefb16d4618eb"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
 dependencies = [
  "bytes",
  "fnv",
@@ -2925,7 +2930,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "slab",
  "tokio",
  "tokio-util 0.7.10",
@@ -3072,6 +3077,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-body"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+dependencies = [
+ "bytes",
+ "http 1.1.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "httparse"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3101,7 +3129,7 @@ dependencies = [
  "futures-util",
  "h2",
  "http 0.2.12",
- "http-body",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -3237,9 +3265,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.5"
+version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
+checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
@@ -3336,9 +3364,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jobserver"
@@ -3454,13 +3482,12 @@ checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "libredox"
-version = "0.0.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.5.0",
  "libc",
- "redox_syscall 0.4.1",
 ]
 
 [[package]]
@@ -3482,9 +3509,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.15"
+version = "1.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037731f5d3aaa87a5675e895b63ddff1a87624bc29f77004ea829809654e48f6"
+checksum = "5e143b5e666b2695d28f6bca6497720813f699c9602dd7f5cac91008b8ada7f9"
 dependencies = [
  "cc",
  "libc",
@@ -3590,9 +3617,9 @@ dependencies = [
 
 [[package]]
 name = "lz4_flex"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "912b45c753ff5f7f5208307e8ace7d2a2e30d024e26d3509f3dce546c044ce15"
+checksum = "75761162ae2b0e580d7e7c390558127e5f01b4194debd6221fd8c207fc80e3f5"
 dependencies = [
  "twox-hash",
 ]
@@ -3613,6 +3640,15 @@ name = "mach"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "mach2"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b955cdeb2a02b9117f121ce63aa52d08ade45de53e48fe6a38b39c10f6f709"
 dependencies = [
  "libc",
 ]
@@ -3640,7 +3676,7 @@ checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -3661,9 +3697,9 @@ checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
 name = "memfd"
@@ -3713,9 +3749,9 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
 ]
@@ -3835,7 +3871,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35cbb989542587b47205e608324ddd391f0cee1c22b4b64ae49f458334b95907"
 dependencies = [
- "borsh 1.3.1",
+ "borsh 1.4.0",
  "serde",
 ]
 
@@ -3873,7 +3909,7 @@ source = "git+https://github.com/kobayurii/nearcore.git?branch=1.39.0-fork#5a6be
 dependencies = [
  "actix",
  "assert_matches",
- "borsh 1.3.1",
+ "borsh 1.4.0",
  "bytesize",
  "chrono",
  "crossbeam-channel",
@@ -3970,7 +4006,7 @@ version = "1.39.0"
 source = "git+https://github.com/kobayurii/nearcore.git?branch=1.39.0-fork#5a6be6cf3b1eb714b5d6f036dbe1cac3caf7b270"
 dependencies = [
  "actix",
- "borsh 1.3.1",
+ "borsh 1.4.0",
  "chrono",
  "derive-enum-from-into",
  "derive_more",
@@ -4016,7 +4052,7 @@ dependencies = [
  "actix-rt",
  "anyhow",
  "async-trait",
- "borsh 1.3.1",
+ "borsh 1.4.0",
  "chrono",
  "cloud-storage",
  "derive_more",
@@ -4112,7 +4148,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2991d2912218a80ec0733ac87f84fa803accea105611eea209d4419271957667"
 dependencies = [
  "blake2",
- "borsh 1.3.1",
+ "borsh 1.4.0",
  "bs58",
  "c2-chacha",
  "curve25519-dalek",
@@ -4138,7 +4174,7 @@ version = "1.39.0"
 source = "git+https://github.com/kobayurii/nearcore.git?branch=1.39.0-fork#5a6be6cf3b1eb714b5d6f036dbe1cac3caf7b270"
 dependencies = [
  "blake2",
- "borsh 1.3.1",
+ "borsh 1.4.0",
  "bs58",
  "c2-chacha",
  "curve25519-dalek",
@@ -4181,7 +4217,7 @@ name = "near-epoch-manager"
 version = "1.39.0"
 source = "git+https://github.com/kobayurii/nearcore.git?branch=1.39.0-fork#5a6be6cf3b1eb714b5d6f036dbe1cac3caf7b270"
 dependencies = [
- "borsh 1.3.1",
+ "borsh 1.4.0",
  "itertools 0.10.5",
  "near-cache",
  "near-chain-configs 1.39.0",
@@ -4289,7 +4325,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18ad81e015f7aced8925d5b9ba3f369b36da9575c15812cfd0786bc1213284ca"
 dependencies = [
- "borsh 1.3.1",
+ "borsh 1.4.0",
  "lazy_static",
  "log",
  "near-chain-configs 0.20.1",
@@ -4307,7 +4343,7 @@ name = "near-jsonrpc-client"
 version = "0.8.0"
 source = "git+https://github.com/kobayurii/near-jsonrpc-client-rs.git?branch=0.8.6#6395a1c651b3308e5af0bd21cf489af2ea51c5b2"
 dependencies = [
- "borsh 1.3.1",
+ "borsh 1.4.0",
  "lazy_static",
  "log",
  "near-chain-configs 1.39.0",
@@ -4411,7 +4447,7 @@ dependencies = [
  "arc-swap",
  "assert_matches",
  "async-trait",
- "borsh 1.3.1",
+ "borsh 1.4.0",
  "bytes",
  "bytesize",
  "chrono",
@@ -4514,7 +4550,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9f16a59b6c3e69b0585be951af6fe42a0ba86c0e207cb8c63badd19efd16680"
 dependencies = [
  "assert_matches",
- "borsh 1.3.1",
+ "borsh 1.4.0",
  "enum-map",
  "near-account-id",
  "near-primitives-core 0.20.1",
@@ -4532,7 +4568,7 @@ version = "1.39.0"
 source = "git+https://github.com/kobayurii/nearcore.git?branch=1.39.0-fork#5a6be6cf3b1eb714b5d6f036dbe1cac3caf7b270"
 dependencies = [
  "assert_matches",
- "borsh 1.3.1",
+ "borsh 1.4.0",
  "enum-map",
  "near-account-id",
  "near-primitives-core 1.39.0",
@@ -4567,7 +4603,7 @@ version = "1.39.0"
 source = "git+https://github.com/kobayurii/nearcore.git?branch=1.39.0-fork#5a6be6cf3b1eb714b5d6f036dbe1cac3caf7b270"
 dependencies = [
  "quote",
- "syn 2.0.53",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -4575,7 +4611,7 @@ name = "near-pool"
 version = "1.39.0"
 source = "git+https://github.com/kobayurii/nearcore.git?branch=1.39.0-fork#5a6be6cf3b1eb714b5d6f036dbe1cac3caf7b270"
 dependencies = [
- "borsh 1.3.1",
+ "borsh 1.4.0",
  "near-crypto 1.39.0",
  "near-o11y 1.39.0",
  "near-primitives 1.39.0",
@@ -4591,7 +4627,7 @@ checksum = "0462b067732132babcc89d5577db3bfcb0a1bcfbaaed3f2db4c11cd033666314"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
- "borsh 1.3.1",
+ "borsh 1.4.0",
  "bytesize",
  "cfg-if 1.0.0",
  "chrono",
@@ -4632,7 +4668,7 @@ source = "git+https://github.com/kobayurii/nearcore.git?branch=1.39.0-fork#5a6be
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
- "borsh 1.3.1",
+ "borsh 1.4.0",
  "bytesize",
  "cfg-if 1.0.0",
  "chrono",
@@ -4674,7 +4710,7 @@ checksum = "8443eb718606f572c438be6321a097a8ebd69f8e48d953885b4f16601af88225"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
- "borsh 1.3.1",
+ "borsh 1.4.0",
  "bs58",
  "derive_more",
  "enum-map",
@@ -4695,7 +4731,7 @@ source = "git+https://github.com/kobayurii/nearcore.git?branch=1.39.0-fork#5a6be
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
- "borsh 1.3.1",
+ "borsh 1.4.0",
  "bs58",
  "derive_more",
  "enum-map",
@@ -4749,7 +4785,7 @@ checksum = "80fca203c51edd9595ec14db1d13359fb9ede32314990bf296b6c5c4502f6ab7"
 dependencies = [
  "quote",
  "serde",
- "syn 2.0.53",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -4759,7 +4795,7 @@ source = "git+https://github.com/kobayurii/nearcore.git?branch=1.39.0-fork#5a6be
 dependencies = [
  "quote",
  "serde",
- "syn 2.0.53",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -4771,7 +4807,7 @@ dependencies = [
  "fs2",
  "near-rpc-error-core 0.20.1",
  "serde",
- "syn 2.0.53",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -4782,7 +4818,7 @@ dependencies = [
  "fs2",
  "near-rpc-error-core 1.39.0",
  "serde",
- "syn 2.0.53",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -4797,7 +4833,7 @@ dependencies = [
  "actix",
  "actix-web",
  "anyhow",
- "borsh 1.3.1",
+ "borsh 1.4.0",
  "clap",
  "configuration",
  "database",
@@ -4836,7 +4872,7 @@ dependencies = [
  "actix",
  "actix-rt",
  "anyhow",
- "borsh 1.3.1",
+ "borsh 1.4.0",
  "bytesize",
  "crossbeam",
  "derive_more",
@@ -4958,7 +4994,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c56c80bdb1954808f59bd36a9112377197b38d424991383bf05f52d0fe2e0da5"
 dependencies = [
  "base64 0.21.7",
- "borsh 1.3.1",
+ "borsh 1.4.0",
  "ed25519-dalek",
  "enum-map",
  "memoffset 0.8.0",
@@ -4988,7 +5024,7 @@ source = "git+https://github.com/kobayurii/nearcore.git?branch=1.39.0-fork#5a6be
 dependencies = [
  "anyhow",
  "base64 0.21.7",
- "borsh 1.3.1",
+ "borsh 1.4.0",
  "ed25519-dalek",
  "enum-map",
  "finite-wasm",
@@ -5087,7 +5123,7 @@ dependencies = [
  "actix-web",
  "anyhow",
  "awc",
- "borsh 1.3.1",
+ "borsh 1.4.0",
  "chrono",
  "cloud-storage",
  "dirs",
@@ -5171,7 +5207,7 @@ name = "node-runtime"
 version = "1.39.0"
 source = "git+https://github.com/kobayurii/nearcore.git?branch=1.39.0-fork#5a6be6cf3b1eb714b5d6f036dbe1cac3caf7b270"
 dependencies = [
- "borsh 1.3.1",
+ "borsh 1.4.0",
  "hex",
  "near-chain-configs 1.39.0",
  "near-crypto 1.39.0",
@@ -5331,7 +5367,7 @@ dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -5348,7 +5384,7 @@ checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
 dependencies = [
  "crc32fast",
  "hashbrown 0.14.3",
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "memchr",
 ]
 
@@ -5387,7 +5423,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -5407,9 +5443,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.101"
+version = "0.9.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dda2b0f344e78efc2facf7d195d098df0dd72151b26ab98da807afc26c198dff"
+checksum = "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
 dependencies = [
  "cc",
  "libc",
@@ -5801,7 +5837,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
 ]
 
 [[package]]
@@ -5839,14 +5875,14 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.58",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
+checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
 name = "pin-utils"
@@ -5872,9 +5908,9 @@ checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "platforms"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "626dec3cac7cc0e1577a2ec3fc496277ec2baa084bebad95bb6fdbfae235f84c"
+checksum = "db23d408679286588f4d4644f965003d056e3dd5abcaaa938116871d7ce2fee7"
 
 [[package]]
 name = "polling"
@@ -5950,12 +5986,12 @@ checksum = "aa06bd51638b6e76ac9ba9b6afb4164fa647bd2916d722f2623fbb6d1ed8bdba"
 
 [[package]]
 name = "prettyplease"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a41cf62165e97c7f814d2221421dbb9afcbcdb0a88068e5ea206e19951c2cbb5"
+checksum = "8d3928fb5db768cb86f891ff014f0144589297e3c6a1aba6ed7cecfdace270c7"
 dependencies = [
  "proc-macro2",
- "syn 2.0.53",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -6282,7 +6318,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.12",
+ "getrandom 0.2.14",
 ]
 
 [[package]]
@@ -6332,9 +6368,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4963ed1bc86e4f3ee217022bd855b297cef07fb9eac5dfa1f788b220b49b3bd"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
 dependencies = [
  "either",
  "rayon-core",
@@ -6358,7 +6394,7 @@ dependencies = [
  "actix-web",
  "anyhow",
  "assert-json-diff",
- "borsh 1.3.1",
+ "borsh 1.4.0",
  "chrono",
  "configuration",
  "database",
@@ -6385,7 +6421,7 @@ dependencies = [
  "rustc_version 0.4.0",
  "serde",
  "serde_json",
- "sysinfo 0.30.7",
+ "sysinfo 0.30.9",
  "thiserror",
  "time",
  "tokio",
@@ -6399,7 +6435,7 @@ name = "readnode-primitives"
 version = "0.2.5"
 dependencies = [
  "anyhow",
- "borsh 1.3.1",
+ "borsh 1.4.0",
  "near-chain-configs 1.39.0",
  "near-indexer-primitives",
  "num-traits",
@@ -6409,9 +6445,9 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "0.25.2"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71d64e978fd98a0e6b105d066ba4889a7301fca65aeac850a877d8797343feeb"
+checksum = "6472825949c09872e8f2c50bde59fcefc17748b6be5c90fd67cd8b4daca73bfd"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -6448,11 +6484,11 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
+checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
 dependencies = [
- "getrandom 0.2.12",
+ "getrandom 0.2.14",
  "libredox",
  "thiserror",
 ]
@@ -6481,14 +6517,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.3"
+version = "1.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
+checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
 dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata 0.4.6",
- "regex-syntax 0.8.2",
+ "regex-syntax 0.8.3",
 ]
 
 [[package]]
@@ -6508,7 +6544,7 @@ checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.2",
+ "regex-syntax 0.8.3",
 ]
 
 [[package]]
@@ -6525,20 +6561,20 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "region"
-version = "3.0.0"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76e189c2369884dce920945e2ddf79b3dff49e071a167dd1817fa9c4c00d512e"
+checksum = "e6b6ebd13bc009aef9cd476c1310d49ac354d36e240cf1bd753290f3dc7199a7"
 dependencies = [
  "bitflags 1.3.2",
  "libc",
- "mach",
- "winapi",
+ "mach2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6563,7 +6599,7 @@ dependencies = [
  "futures-util",
  "h2",
  "http 0.2.12",
- "http-body",
+ "http-body 0.4.6",
  "hyper",
  "hyper-tls",
  "ipnet",
@@ -6632,7 +6668,7 @@ checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
  "cfg-if 1.0.0",
- "getrandom 0.2.12",
+ "getrandom 0.2.14",
  "libc",
  "spin 0.9.8",
  "untrusted 0.9.0",
@@ -6832,9 +6868,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+checksum = "80af6f9131f277a45a3fba6ce8e2258037bb0477a67e610d3c1fe046ab31de47"
 
 [[package]]
 name = "rxml"
@@ -6959,7 +6995,7 @@ dependencies = [
  "darling 0.20.8",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -7012,9 +7048,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.9.2"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de"
+checksum = "770452e37cad93e0a50d5abc3990d2bc351c36d0328f86cefec2f2fb206eaef6"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
@@ -7025,9 +7061,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.9.1"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
+checksum = "41f3cc463c0ef97e11c3461a9d3787412d30e8e7eb907c79180c4a57bf7c04ef"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -7102,7 +7138,7 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -7116,9 +7152,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.114"
+version = "1.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
+checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
 dependencies = [
  "itoa",
  "ryu",
@@ -7127,13 +7163,13 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b2e6b945e9d3df726b65d6ee24060aff8e3533d431f677a9695db04eff9dfdb"
+checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -7167,7 +7203,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "serde",
  "serde_derive",
  "serde_json",
@@ -7184,16 +7220,16 @@ dependencies = [
  "darling 0.20.8",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.58",
 ]
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.33"
+version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0623d197252096520c6f2a5e1171ee436e5af99a5d7caa2891e55e61950e6d9"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "itoa",
  "ryu",
  "serde",
@@ -7339,9 +7375,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "smart-default"
@@ -7421,7 +7457,7 @@ version = "0.2.5"
 dependencies = [
  "actix-web",
  "anyhow",
- "borsh 1.3.1",
+ "borsh 1.4.0",
  "clap",
  "configuration",
  "database",
@@ -7466,9 +7502,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strsim"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
@@ -7549,9 +7585,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.53"
+version = "2.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7383cd0e49fff4b6b90ca5670bfd3e9d6a733b3f90c686605aa7eec8c4996032"
+checksum = "44cfb93f38070beee36b3fef7d4f5a16f27751d94b187b666a5cc5e9b0d30687"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7567,7 +7603,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -7593,9 +7629,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.30.7"
+version = "0.30.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c385888ef380a852a16209afc8cfad22795dd8873d69c9a14d2e2088f118d18"
+checksum = "e9a84fe4cfc513b41cb2596b624e561ec9e7e1c4b46328e496ed56a53514ef2a"
 dependencies = [
  "cfg-if 1.0.0",
  "core-foundation-sys",
@@ -7652,7 +7688,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
  "cfg-if 1.0.0",
- "fastrand 2.0.1",
+ "fastrand 2.0.2",
  "rustix",
  "windows-sys 0.52.0",
 ]
@@ -7685,7 +7721,7 @@ checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -7778,9 +7814,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.36.0"
+version = "1.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
+checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
 dependencies = [
  "backtrace",
  "bytes",
@@ -7814,7 +7850,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -7955,7 +7991,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.8",
+ "toml_edit 0.22.9",
 ]
 
 [[package]]
@@ -7973,7 +8009,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -7986,18 +8022,18 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "toml_datetime",
  "winnow 0.5.40",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.8"
+version = "0.22.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c12219811e0c1ba077867254e5ad62ee2c9c190b0d957110750ac0cda1ae96cd"
+checksum = "8e40bb779c5187258fd7aad0eb68cb8706a0a81fa712fbea808ab43c4b8374c4"
 dependencies = [
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -8018,7 +8054,7 @@ dependencies = [
  "futures-util",
  "h2",
  "http 0.2.12",
- "http-body",
+ "http-body 0.4.6",
  "hyper",
  "hyper-timeout",
  "percent-encoding",
@@ -8124,7 +8160,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -8265,7 +8301,7 @@ version = "0.2.5"
 dependencies = [
  "actix-web",
  "anyhow",
- "borsh 1.3.1",
+ "borsh 1.4.0",
  "clap",
  "configuration",
  "database",
@@ -8390,7 +8426,7 @@ version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
 dependencies = [
- "getrandom 0.2.12",
+ "getrandom 0.2.14",
 ]
 
 [[package]]
@@ -8499,7 +8535,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.58",
  "wasm-bindgen-shared",
 ]
 
@@ -8533,7 +8569,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.58",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -8781,7 +8817,7 @@ version = "0.115.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e06c0641a4add879ba71ccb3a1e4278fd546f76f1eafb21d8f7b07733b547cd5"
 dependencies = [
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "semver 1.0.22",
 ]
 
@@ -8806,7 +8842,7 @@ dependencies = [
  "bumpalo",
  "cfg-if 1.0.0",
  "fxprof-processed-profile",
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "libc",
  "log",
  "object",
@@ -8885,7 +8921,7 @@ dependencies = [
  "anyhow",
  "cranelift-entity",
  "gimli",
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "log",
  "object",
  "serde",
@@ -8951,12 +8987,12 @@ dependencies = [
  "anyhow",
  "cc",
  "cfg-if 1.0.0",
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "libc",
  "log",
  "mach",
  "memfd",
- "memoffset 0.9.0",
+ "memoffset 0.9.1",
  "paste",
  "rand 0.8.5",
  "rustix",
@@ -8991,7 +9027,7 @@ checksum = "09b5575a75e711ca6c36bb9ad647c93541cdc8e34218031acba5da3f35919dd3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -9272,9 +9308,9 @@ dependencies = [
 
 [[package]]
 name = "xml-rs"
-version = "0.8.19"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fcb9cbac069e033553e8bb871be2fbdffcab578eb25bd0f7c508cedc6dcd75a"
+checksum = "791978798f0597cfc70478424c2b4fdc2b7a8024aaff78497ef00f24ef674193"
 
 [[package]]
 name = "xmlparser"
@@ -9314,7 +9350,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -9338,27 +9374,27 @@ dependencies = [
 
 [[package]]
 name = "zstd"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bffb3309596d527cfcba7dfc6ed6052f1d39dfbd7c867aa2e865e4a449c10110"
+checksum = "2d789b1514203a1120ad2429eae43a7bd32b90976a7bb8a05f7ec02fa88cc23a"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "7.0.0"
+version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43747c7422e2924c11144d5229878b98180ef8b06cca4ab5af37afc8a8d8ea3e"
+checksum = "1cd99b45c6bc03a018c8b8a86025678c87e55526064e38f9df301989dce7ec0a"
 dependencies = [
  "zstd-sys",
 ]
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.9+zstd.1.5.5"
+version = "2.0.10+zstd.1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e16efa8a874a0481a574084d34cc26fdb3b99627480f785888deb6386506656"
+checksum = "c253a4914af5bafc8fa8c86ee400827e83cf6ec01195ec1f1ed8441bf00d65aa"
 dependencies = [
  "cc",
  "pkg-config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2019,10 +2019,10 @@ dependencies = [
  "diesel_migrations",
  "futures",
  "hex",
- "near-chain-configs 1.38.0",
- "near-crypto 1.38.0",
+ "near-chain-configs 1.39.0",
+ "near-crypto 1.39.0",
  "near-indexer-primitives",
- "near-primitives 1.38.0",
+ "near-primitives 1.39.0",
  "num-bigint 0.4.4",
  "num-traits",
  "prettytable-rs",
@@ -2501,9 +2501,9 @@ dependencies = [
  "clap",
  "configuration",
  "database",
- "near-chain-configs 1.38.0",
+ "near-chain-configs 1.39.0",
  "near-indexer-primitives",
- "near-jsonrpc-client 0.8.0 (git+https://github.com/kobayurii/near-jsonrpc-client-rs.git?branch=0.8.5)",
+ "near-jsonrpc-client 0.8.0 (git+https://github.com/kobayurii/near-jsonrpc-client-rs.git?branch=0.8.6)",
  "near-lake-framework",
  "readnode-primitives",
  "tokio",
@@ -3841,16 +3841,16 @@ dependencies = [
 
 [[package]]
 name = "near-async"
-version = "1.38.0"
-source = "git+https://github.com/kobayurii/nearcore.git?branch=1.38.0-fork#7a99abb10ca29e9bcc8b0e51f4e009ad07aded81"
+version = "1.39.0"
+source = "git+https://github.com/kobayurii/nearcore.git?branch=1.39.0-fork#5a6be6cf3b1eb714b5d6f036dbe1cac3caf7b270"
 dependencies = [
  "actix",
  "derive-enum-from-into",
  "derive_more",
  "futures",
- "near-o11y 1.38.0",
+ "near-o11y 1.39.0",
  "near-performance-metrics",
- "near-primitives 1.38.0",
+ "near-primitives 1.39.0",
  "once_cell",
  "serde",
  "serde_json",
@@ -3860,16 +3860,16 @@ dependencies = [
 
 [[package]]
 name = "near-cache"
-version = "1.38.0"
-source = "git+https://github.com/kobayurii/nearcore.git?branch=1.38.0-fork#7a99abb10ca29e9bcc8b0e51f4e009ad07aded81"
+version = "1.39.0"
+source = "git+https://github.com/kobayurii/nearcore.git?branch=1.39.0-fork#5a6be6cf3b1eb714b5d6f036dbe1cac3caf7b270"
 dependencies = [
  "lru 0.7.8",
 ]
 
 [[package]]
 name = "near-chain"
-version = "1.38.0"
-source = "git+https://github.com/kobayurii/nearcore.git?branch=1.38.0-fork#7a99abb10ca29e9bcc8b0e51f4e009ad07aded81"
+version = "1.39.0"
+source = "git+https://github.com/kobayurii/nearcore.git?branch=1.39.0-fork#5a6be6cf3b1eb714b5d6f036dbe1cac3caf7b270"
 dependencies = [
  "actix",
  "assert_matches",
@@ -3883,17 +3883,17 @@ dependencies = [
  "lru 0.7.8",
  "near-async",
  "near-cache",
- "near-chain-configs 1.38.0",
+ "near-chain-configs 1.39.0",
  "near-chain-primitives",
  "near-client-primitives",
- "near-crypto 1.38.0",
+ "near-crypto 1.39.0",
  "near-epoch-manager",
  "near-network",
- "near-o11y 1.38.0",
+ "near-o11y 1.39.0",
  "near-performance-metrics",
  "near-performance-metrics-macros",
  "near-pool",
- "near-primitives 1.38.0",
+ "near-primitives 1.39.0",
  "near-store",
  "num-rational",
  "once_cell",
@@ -3931,18 +3931,18 @@ dependencies = [
 
 [[package]]
 name = "near-chain-configs"
-version = "1.38.0"
-source = "git+https://github.com/kobayurii/nearcore.git?branch=1.38.0-fork#7a99abb10ca29e9bcc8b0e51f4e009ad07aded81"
+version = "1.39.0"
+source = "git+https://github.com/kobayurii/nearcore.git?branch=1.39.0-fork#5a6be6cf3b1eb714b5d6f036dbe1cac3caf7b270"
 dependencies = [
  "anyhow",
  "bytesize",
  "chrono",
  "derive_more",
- "near-config-utils 1.38.0",
- "near-crypto 1.38.0",
- "near-o11y 1.38.0",
- "near-parameters 1.38.0",
- "near-primitives 1.38.0",
+ "near-config-utils 1.39.0",
+ "near-crypto 1.39.0",
+ "near-o11y 1.39.0",
+ "near-parameters 1.39.0",
+ "near-primitives 1.39.0",
  "num-rational",
  "once_cell",
  "serde",
@@ -3954,20 +3954,20 @@ dependencies = [
 
 [[package]]
 name = "near-chain-primitives"
-version = "1.38.0"
-source = "git+https://github.com/kobayurii/nearcore.git?branch=1.38.0-fork#7a99abb10ca29e9bcc8b0e51f4e009ad07aded81"
+version = "1.39.0"
+source = "git+https://github.com/kobayurii/nearcore.git?branch=1.39.0-fork#5a6be6cf3b1eb714b5d6f036dbe1cac3caf7b270"
 dependencies = [
  "chrono",
- "near-crypto 1.38.0",
- "near-primitives 1.38.0",
+ "near-crypto 1.39.0",
+ "near-primitives 1.39.0",
  "thiserror",
  "tracing",
 ]
 
 [[package]]
 name = "near-chunks"
-version = "1.38.0"
-source = "git+https://github.com/kobayurii/nearcore.git?branch=1.38.0-fork#7a99abb10ca29e9bcc8b0e51f4e009ad07aded81"
+version = "1.39.0"
+source = "git+https://github.com/kobayurii/nearcore.git?branch=1.39.0-fork#5a6be6cf3b1eb714b5d6f036dbe1cac3caf7b270"
 dependencies = [
  "actix",
  "borsh 1.3.1",
@@ -3979,16 +3979,16 @@ dependencies = [
  "lru 0.7.8",
  "near-async",
  "near-chain",
- "near-chain-configs 1.38.0",
+ "near-chain-configs 1.39.0",
  "near-chunks-primitives",
- "near-crypto 1.38.0",
+ "near-crypto 1.39.0",
  "near-epoch-manager",
  "near-network",
- "near-o11y 1.38.0",
+ "near-o11y 1.39.0",
  "near-performance-metrics",
  "near-performance-metrics-macros",
  "near-pool",
- "near-primitives 1.38.0",
+ "near-primitives 1.39.0",
  "near-store",
  "once_cell",
  "rand 0.8.5",
@@ -4000,17 +4000,17 @@ dependencies = [
 
 [[package]]
 name = "near-chunks-primitives"
-version = "1.38.0"
-source = "git+https://github.com/kobayurii/nearcore.git?branch=1.38.0-fork#7a99abb10ca29e9bcc8b0e51f4e009ad07aded81"
+version = "1.39.0"
+source = "git+https://github.com/kobayurii/nearcore.git?branch=1.39.0-fork#5a6be6cf3b1eb714b5d6f036dbe1cac3caf7b270"
 dependencies = [
  "near-chain-primitives",
- "near-primitives 1.38.0",
+ "near-primitives 1.39.0",
 ]
 
 [[package]]
 name = "near-client"
-version = "1.38.0"
-source = "git+https://github.com/kobayurii/nearcore.git?branch=1.38.0-fork#7a99abb10ca29e9bcc8b0e51f4e009ad07aded81"
+version = "1.39.0"
+source = "git+https://github.com/kobayurii/nearcore.git?branch=1.39.0-fork#5a6be6cf3b1eb714b5d6f036dbe1cac3caf7b270"
 dependencies = [
  "actix",
  "actix-rt",
@@ -4025,22 +4025,23 @@ dependencies = [
  "lru 0.7.8",
  "near-async",
  "near-chain",
- "near-chain-configs 1.38.0",
+ "near-chain-configs 1.39.0",
  "near-chain-primitives",
  "near-chunks",
  "near-client-primitives",
- "near-crypto 1.38.0",
+ "near-crypto 1.39.0",
  "near-dyn-configs",
  "near-epoch-manager",
  "near-network",
- "near-o11y 1.38.0",
- "near-parameters 1.38.0",
+ "near-o11y 1.39.0",
+ "near-parameters 1.39.0",
  "near-performance-metrics",
  "near-performance-metrics-macros",
  "near-pool",
- "near-primitives 1.38.0",
+ "near-primitives 1.39.0",
  "near-store",
  "near-telemetry",
+ "near-vm-runner 1.39.0",
  "num-rational",
  "once_cell",
  "percent-encoding",
@@ -4063,16 +4064,16 @@ dependencies = [
 
 [[package]]
 name = "near-client-primitives"
-version = "1.38.0"
-source = "git+https://github.com/kobayurii/nearcore.git?branch=1.38.0-fork#7a99abb10ca29e9bcc8b0e51f4e009ad07aded81"
+version = "1.39.0"
+source = "git+https://github.com/kobayurii/nearcore.git?branch=1.39.0-fork#5a6be6cf3b1eb714b5d6f036dbe1cac3caf7b270"
 dependencies = [
  "actix",
  "chrono",
- "near-chain-configs 1.38.0",
+ "near-chain-configs 1.39.0",
  "near-chain-primitives",
  "near-chunks-primitives",
- "near-crypto 1.38.0",
- "near-primitives 1.38.0",
+ "near-crypto 1.39.0",
+ "near-primitives 1.39.0",
  "serde",
  "serde_json",
  "strum 0.24.1",
@@ -4095,8 +4096,8 @@ dependencies = [
 
 [[package]]
 name = "near-config-utils"
-version = "1.38.0"
-source = "git+https://github.com/kobayurii/nearcore.git?branch=1.38.0-fork#7a99abb10ca29e9bcc8b0e51f4e009ad07aded81"
+version = "1.39.0"
+source = "git+https://github.com/kobayurii/nearcore.git?branch=1.39.0-fork#5a6be6cf3b1eb714b5d6f036dbe1cac3caf7b270"
 dependencies = [
  "anyhow",
  "json_comments",
@@ -4133,8 +4134,8 @@ dependencies = [
 
 [[package]]
 name = "near-crypto"
-version = "1.38.0"
-source = "git+https://github.com/kobayurii/nearcore.git?branch=1.38.0-fork#7a99abb10ca29e9bcc8b0e51f4e009ad07aded81"
+version = "1.39.0"
+source = "git+https://github.com/kobayurii/nearcore.git?branch=1.39.0-fork#5a6be6cf3b1eb714b5d6f036dbe1cac3caf7b270"
 dependencies = [
  "blake2",
  "borsh 1.3.1",
@@ -4145,8 +4146,8 @@ dependencies = [
  "ed25519-dalek",
  "hex",
  "near-account-id",
- "near-config-utils 1.38.0",
- "near-stdx 1.38.0",
+ "near-config-utils 1.39.0",
+ "near-stdx 1.39.0",
  "once_cell",
  "primitive-types",
  "rand 0.7.3",
@@ -4159,13 +4160,13 @@ dependencies = [
 
 [[package]]
 name = "near-dyn-configs"
-version = "1.38.0"
-source = "git+https://github.com/kobayurii/nearcore.git?branch=1.38.0-fork#7a99abb10ca29e9bcc8b0e51f4e009ad07aded81"
+version = "1.39.0"
+source = "git+https://github.com/kobayurii/nearcore.git?branch=1.39.0-fork#5a6be6cf3b1eb714b5d6f036dbe1cac3caf7b270"
 dependencies = [
  "anyhow",
- "near-chain-configs 1.38.0",
- "near-o11y 1.38.0",
- "near-primitives 1.38.0",
+ "near-chain-configs 1.39.0",
+ "near-o11y 1.39.0",
+ "near-primitives 1.39.0",
  "once_cell",
  "prometheus",
  "serde",
@@ -4177,16 +4178,16 @@ dependencies = [
 
 [[package]]
 name = "near-epoch-manager"
-version = "1.38.0"
-source = "git+https://github.com/kobayurii/nearcore.git?branch=1.38.0-fork#7a99abb10ca29e9bcc8b0e51f4e009ad07aded81"
+version = "1.39.0"
+source = "git+https://github.com/kobayurii/nearcore.git?branch=1.39.0-fork#5a6be6cf3b1eb714b5d6f036dbe1cac3caf7b270"
 dependencies = [
  "borsh 1.3.1",
  "itertools 0.10.5",
  "near-cache",
- "near-chain-configs 1.38.0",
+ "near-chain-configs 1.39.0",
  "near-chain-primitives",
- "near-crypto 1.38.0",
- "near-primitives 1.38.0",
+ "near-crypto 1.39.0",
+ "near-primitives 1.39.0",
  "near-store",
  "num-rational",
  "primitive-types",
@@ -4208,29 +4209,29 @@ dependencies = [
 
 [[package]]
 name = "near-fmt"
-version = "1.38.0"
-source = "git+https://github.com/kobayurii/nearcore.git?branch=1.38.0-fork#7a99abb10ca29e9bcc8b0e51f4e009ad07aded81"
+version = "1.39.0"
+source = "git+https://github.com/kobayurii/nearcore.git?branch=1.39.0-fork#5a6be6cf3b1eb714b5d6f036dbe1cac3caf7b270"
 dependencies = [
- "near-primitives-core 1.38.0",
+ "near-primitives-core 1.39.0",
 ]
 
 [[package]]
 name = "near-indexer"
-version = "1.38.0"
-source = "git+https://github.com/kobayurii/nearcore.git?branch=1.38.0-fork#7a99abb10ca29e9bcc8b0e51f4e009ad07aded81"
+version = "1.39.0"
+source = "git+https://github.com/kobayurii/nearcore.git?branch=1.39.0-fork#5a6be6cf3b1eb714b5d6f036dbe1cac3caf7b270"
 dependencies = [
  "actix",
  "anyhow",
  "futures",
  "lazy_static",
- "near-chain-configs 1.38.0",
+ "near-chain-configs 1.39.0",
  "near-client",
- "near-crypto 1.38.0",
+ "near-crypto 1.39.0",
  "near-dyn-configs",
  "near-indexer-primitives",
- "near-o11y 1.38.0",
- "near-parameters 1.38.0",
- "near-primitives 1.38.0",
+ "near-o11y 1.39.0",
+ "near-parameters 1.39.0",
+ "near-primitives 1.39.0",
  "near-store",
  "nearcore",
  "node-runtime",
@@ -4244,18 +4245,18 @@ dependencies = [
 
 [[package]]
 name = "near-indexer-primitives"
-version = "1.38.0"
-source = "git+https://github.com/kobayurii/nearcore.git?branch=1.38.0-fork#7a99abb10ca29e9bcc8b0e51f4e009ad07aded81"
+version = "1.39.0"
+source = "git+https://github.com/kobayurii/nearcore.git?branch=1.39.0-fork#5a6be6cf3b1eb714b5d6f036dbe1cac3caf7b270"
 dependencies = [
- "near-primitives 1.38.0",
+ "near-primitives 1.39.0",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "near-jsonrpc"
-version = "1.38.0"
-source = "git+https://github.com/kobayurii/nearcore.git?branch=1.38.0-fork#7a99abb10ca29e9bcc8b0e51f4e009ad07aded81"
+version = "1.39.0"
+source = "git+https://github.com/kobayurii/nearcore.git?branch=1.39.0-fork#5a6be6cf3b1eb714b5d6f036dbe1cac3caf7b270"
 dependencies = [
  "actix",
  "actix-cors 0.6.5",
@@ -4264,15 +4265,15 @@ dependencies = [
  "easy-ext",
  "futures",
  "hex",
- "near-chain-configs 1.38.0",
+ "near-chain-configs 1.39.0",
  "near-client",
  "near-client-primitives",
- "near-jsonrpc-client 1.38.0",
- "near-jsonrpc-primitives 1.38.0",
+ "near-jsonrpc-client 1.39.0",
+ "near-jsonrpc-primitives 1.39.0",
  "near-network",
- "near-o11y 1.38.0",
- "near-primitives 1.38.0",
- "near-rpc-error-macro 1.38.0",
+ "near-o11y 1.39.0",
+ "near-primitives 1.39.0",
+ "near-rpc-error-macro 1.39.0",
  "once_cell",
  "serde",
  "serde_json",
@@ -4304,15 +4305,15 @@ dependencies = [
 [[package]]
 name = "near-jsonrpc-client"
 version = "0.8.0"
-source = "git+https://github.com/kobayurii/near-jsonrpc-client-rs.git?branch=0.8.5#9131d6b364a398db77c5fa402d8a1c0f3feaad8f"
+source = "git+https://github.com/kobayurii/near-jsonrpc-client-rs.git?branch=0.8.6#6395a1c651b3308e5af0bd21cf489af2ea51c5b2"
 dependencies = [
  "borsh 1.3.1",
  "lazy_static",
  "log",
- "near-chain-configs 1.38.0",
- "near-crypto 1.38.0",
- "near-jsonrpc-primitives 1.38.0",
- "near-primitives 1.38.0",
+ "near-chain-configs 1.39.0",
+ "near-crypto 1.39.0",
+ "near-jsonrpc-primitives 1.39.0",
+ "near-primitives 1.39.0",
  "reqwest",
  "serde",
  "serde_json",
@@ -4321,14 +4322,14 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-client"
-version = "1.38.0"
-source = "git+https://github.com/kobayurii/nearcore.git?branch=1.38.0-fork#7a99abb10ca29e9bcc8b0e51f4e009ad07aded81"
+version = "1.39.0"
+source = "git+https://github.com/kobayurii/nearcore.git?branch=1.39.0-fork#5a6be6cf3b1eb714b5d6f036dbe1cac3caf7b270"
 dependencies = [
  "actix-http",
  "awc",
  "futures",
- "near-jsonrpc-primitives 1.38.0",
- "near-primitives 1.38.0",
+ "near-jsonrpc-primitives 1.39.0",
+ "near-primitives 1.39.0",
  "serde",
  "serde_json",
 ]
@@ -4351,15 +4352,15 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-primitives"
-version = "1.38.0"
-source = "git+https://github.com/kobayurii/nearcore.git?branch=1.38.0-fork#7a99abb10ca29e9bcc8b0e51f4e009ad07aded81"
+version = "1.39.0"
+source = "git+https://github.com/kobayurii/nearcore.git?branch=1.39.0-fork#5a6be6cf3b1eb714b5d6f036dbe1cac3caf7b270"
 dependencies = [
  "arbitrary",
- "near-chain-configs 1.38.0",
+ "near-chain-configs 1.39.0",
  "near-client-primitives",
- "near-crypto 1.38.0",
- "near-primitives 1.38.0",
- "near-rpc-error-macro 1.38.0",
+ "near-crypto 1.39.0",
+ "near-primitives 1.39.0",
+ "near-rpc-error-macro 1.39.0",
  "serde",
  "serde_json",
  "thiserror",
@@ -4368,7 +4369,7 @@ dependencies = [
 [[package]]
 name = "near-lake-framework"
 version = "0.0.0"
-source = "git+https://github.com/kobayurii/near-lake-framework-rs.git?branch=0.7.11#c19f8e0c44c5289bd6077c1f828ebbae99a42660"
+source = "git+https://github.com/kobayurii/near-lake-framework-rs.git?branch=0.7.12#d88918094a99198d36131082321022909dba0044"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4391,19 +4392,19 @@ dependencies = [
 
 [[package]]
 name = "near-mainnet-res"
-version = "1.38.0"
-source = "git+https://github.com/kobayurii/nearcore.git?branch=1.38.0-fork#7a99abb10ca29e9bcc8b0e51f4e009ad07aded81"
+version = "1.39.0"
+source = "git+https://github.com/kobayurii/nearcore.git?branch=1.39.0-fork#5a6be6cf3b1eb714b5d6f036dbe1cac3caf7b270"
 dependencies = [
  "near-account-id",
- "near-chain-configs 1.38.0",
- "near-primitives 1.38.0",
+ "near-chain-configs 1.39.0",
+ "near-primitives 1.39.0",
  "serde_json",
 ]
 
 [[package]]
 name = "near-network"
-version = "1.38.0"
-source = "git+https://github.com/kobayurii/nearcore.git?branch=1.38.0-fork#7a99abb10ca29e9bcc8b0e51f4e009ad07aded81"
+version = "1.39.0"
+source = "git+https://github.com/kobayurii/nearcore.git?branch=1.39.0-fork#5a6be6cf3b1eb714b5d6f036dbe1cac3caf7b270"
 dependencies = [
  "actix",
  "anyhow",
@@ -4422,12 +4423,12 @@ dependencies = [
  "itertools 0.10.5",
  "lru 0.7.8",
  "near-async",
- "near-crypto 1.38.0",
- "near-fmt 1.38.0",
- "near-o11y 1.38.0",
+ "near-crypto 1.39.0",
+ "near-fmt 1.39.0",
+ "near-o11y 1.39.0",
  "near-performance-metrics",
  "near-performance-metrics-macros",
- "near-primitives 1.38.0",
+ "near-primitives 1.39.0",
  "near-stable-hasher",
  "near-store",
  "once_cell",
@@ -4481,15 +4482,15 @@ dependencies = [
 
 [[package]]
 name = "near-o11y"
-version = "1.38.0"
-source = "git+https://github.com/kobayurii/nearcore.git?branch=1.38.0-fork#7a99abb10ca29e9bcc8b0e51f4e009ad07aded81"
+version = "1.39.0"
+source = "git+https://github.com/kobayurii/nearcore.git?branch=1.39.0-fork#5a6be6cf3b1eb714b5d6f036dbe1cac3caf7b270"
 dependencies = [
  "actix",
  "base64 0.21.7",
  "clap",
- "near-crypto 1.38.0",
- "near-fmt 1.38.0",
- "near-primitives-core 1.38.0",
+ "near-crypto 1.39.0",
+ "near-fmt 1.39.0",
+ "near-primitives-core 1.39.0",
  "once_cell",
  "opentelemetry 0.17.0",
  "opentelemetry-otlp",
@@ -4527,14 +4528,14 @@ dependencies = [
 
 [[package]]
 name = "near-parameters"
-version = "1.38.0"
-source = "git+https://github.com/kobayurii/nearcore.git?branch=1.38.0-fork#7a99abb10ca29e9bcc8b0e51f4e009ad07aded81"
+version = "1.39.0"
+source = "git+https://github.com/kobayurii/nearcore.git?branch=1.39.0-fork#5a6be6cf3b1eb714b5d6f036dbe1cac3caf7b270"
 dependencies = [
  "assert_matches",
  "borsh 1.3.1",
  "enum-map",
  "near-account-id",
- "near-primitives-core 1.38.0",
+ "near-primitives-core 1.39.0",
  "num-rational",
  "serde",
  "serde_repr",
@@ -4545,8 +4546,8 @@ dependencies = [
 
 [[package]]
 name = "near-performance-metrics"
-version = "1.38.0"
-source = "git+https://github.com/kobayurii/nearcore.git?branch=1.38.0-fork#7a99abb10ca29e9bcc8b0e51f4e009ad07aded81"
+version = "1.39.0"
+source = "git+https://github.com/kobayurii/nearcore.git?branch=1.39.0-fork#5a6be6cf3b1eb714b5d6f036dbe1cac3caf7b270"
 dependencies = [
  "actix",
  "bitflags 1.3.2",
@@ -4562,8 +4563,8 @@ dependencies = [
 
 [[package]]
 name = "near-performance-metrics-macros"
-version = "1.38.0"
-source = "git+https://github.com/kobayurii/nearcore.git?branch=1.38.0-fork#7a99abb10ca29e9bcc8b0e51f4e009ad07aded81"
+version = "1.39.0"
+source = "git+https://github.com/kobayurii/nearcore.git?branch=1.39.0-fork#5a6be6cf3b1eb714b5d6f036dbe1cac3caf7b270"
 dependencies = [
  "quote",
  "syn 2.0.53",
@@ -4571,13 +4572,13 @@ dependencies = [
 
 [[package]]
 name = "near-pool"
-version = "1.38.0"
-source = "git+https://github.com/kobayurii/nearcore.git?branch=1.38.0-fork#7a99abb10ca29e9bcc8b0e51f4e009ad07aded81"
+version = "1.39.0"
+source = "git+https://github.com/kobayurii/nearcore.git?branch=1.39.0-fork#5a6be6cf3b1eb714b5d6f036dbe1cac3caf7b270"
 dependencies = [
  "borsh 1.3.1",
- "near-crypto 1.38.0",
- "near-o11y 1.38.0",
- "near-primitives 1.38.0",
+ "near-crypto 1.39.0",
+ "near-o11y 1.39.0",
+ "near-primitives 1.39.0",
  "once_cell",
  "rand 0.8.5",
 ]
@@ -4626,8 +4627,8 @@ dependencies = [
 
 [[package]]
 name = "near-primitives"
-version = "1.38.0"
-source = "git+https://github.com/kobayurii/nearcore.git?branch=1.38.0-fork#7a99abb10ca29e9bcc8b0e51f4e009ad07aded81"
+version = "1.39.0"
+source = "git+https://github.com/kobayurii/nearcore.git?branch=1.39.0-fork#5a6be6cf3b1eb714b5d6f036dbe1cac3caf7b270"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -4639,14 +4640,14 @@ dependencies = [
  "easy-ext",
  "enum-map",
  "hex",
- "near-crypto 1.38.0",
- "near-fmt 1.38.0",
- "near-o11y 1.38.0",
- "near-parameters 1.38.0",
- "near-primitives-core 1.38.0",
- "near-rpc-error-macro 1.38.0",
- "near-stdx 1.38.0",
- "near-vm-runner 1.38.0",
+ "near-crypto 1.39.0",
+ "near-fmt 1.39.0",
+ "near-o11y 1.39.0",
+ "near-parameters 1.39.0",
+ "near-primitives-core 1.39.0",
+ "near-rpc-error-macro 1.39.0",
+ "near-stdx 1.39.0",
+ "near-vm-runner 1.39.0",
  "num-rational",
  "once_cell",
  "primitive-types",
@@ -4689,8 +4690,8 @@ dependencies = [
 
 [[package]]
 name = "near-primitives-core"
-version = "1.38.0"
-source = "git+https://github.com/kobayurii/nearcore.git?branch=1.38.0-fork#7a99abb10ca29e9bcc8b0e51f4e009ad07aded81"
+version = "1.39.0"
+source = "git+https://github.com/kobayurii/nearcore.git?branch=1.39.0-fork#5a6be6cf3b1eb714b5d6f036dbe1cac3caf7b270"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -4710,8 +4711,8 @@ dependencies = [
 
 [[package]]
 name = "near-rosetta-rpc"
-version = "1.38.0"
-source = "git+https://github.com/kobayurii/nearcore.git?branch=1.38.0-fork#7a99abb10ca29e9bcc8b0e51f4e009ad07aded81"
+version = "1.39.0"
+source = "git+https://github.com/kobayurii/nearcore.git?branch=1.39.0-fork#5a6be6cf3b1eb714b5d6f036dbe1cac3caf7b270"
 dependencies = [
  "actix",
  "actix-cors 0.6.5",
@@ -4722,14 +4723,14 @@ dependencies = [
  "futures",
  "hex",
  "near-account-id",
- "near-chain-configs 1.38.0",
+ "near-chain-configs 1.39.0",
  "near-client",
  "near-client-primitives",
- "near-crypto 1.38.0",
+ "near-crypto 1.39.0",
  "near-network",
- "near-o11y 1.38.0",
- "near-parameters 1.38.0",
- "near-primitives 1.38.0",
+ "near-o11y 1.39.0",
+ "near-parameters 1.39.0",
+ "near-primitives 1.39.0",
  "node-runtime",
  "paperclip",
  "serde",
@@ -4753,8 +4754,8 @@ dependencies = [
 
 [[package]]
 name = "near-rpc-error-core"
-version = "1.38.0"
-source = "git+https://github.com/kobayurii/nearcore.git?branch=1.38.0-fork#7a99abb10ca29e9bcc8b0e51f4e009ad07aded81"
+version = "1.39.0"
+source = "git+https://github.com/kobayurii/nearcore.git?branch=1.39.0-fork#5a6be6cf3b1eb714b5d6f036dbe1cac3caf7b270"
 dependencies = [
  "quote",
  "serde",
@@ -4775,19 +4776,19 @@ dependencies = [
 
 [[package]]
 name = "near-rpc-error-macro"
-version = "1.38.0"
-source = "git+https://github.com/kobayurii/nearcore.git?branch=1.38.0-fork#7a99abb10ca29e9bcc8b0e51f4e009ad07aded81"
+version = "1.39.0"
+source = "git+https://github.com/kobayurii/nearcore.git?branch=1.39.0-fork#5a6be6cf3b1eb714b5d6f036dbe1cac3caf7b270"
 dependencies = [
  "fs2",
- "near-rpc-error-core 1.38.0",
+ "near-rpc-error-core 1.39.0",
  "serde",
  "syn 2.0.53",
 ]
 
 [[package]]
 name = "near-stable-hasher"
-version = "1.38.0"
-source = "git+https://github.com/kobayurii/nearcore.git?branch=1.38.0-fork#7a99abb10ca29e9bcc8b0e51f4e009ad07aded81"
+version = "1.39.0"
+source = "git+https://github.com/kobayurii/nearcore.git?branch=1.39.0-fork#5a6be6cf3b1eb714b5d6f036dbe1cac3caf7b270"
 
 [[package]]
 name = "near-state-indexer"
@@ -4805,7 +4806,7 @@ dependencies = [
  "humantime",
  "near-client",
  "near-indexer",
- "near-o11y 1.38.0",
+ "near-o11y 1.39.0",
  "once_cell",
  "openssl-probe",
  "redis",
@@ -4824,13 +4825,13 @@ checksum = "855fd5540e3b4ff6fedf12aba2db1ee4b371b36f465da1363a6d022b27cb43b8"
 
 [[package]]
 name = "near-stdx"
-version = "1.38.0"
-source = "git+https://github.com/kobayurii/nearcore.git?branch=1.38.0-fork#7a99abb10ca29e9bcc8b0e51f4e009ad07aded81"
+version = "1.39.0"
+source = "git+https://github.com/kobayurii/nearcore.git?branch=1.39.0-fork#5a6be6cf3b1eb714b5d6f036dbe1cac3caf7b270"
 
 [[package]]
 name = "near-store"
-version = "1.38.0"
-source = "git+https://github.com/kobayurii/nearcore.git?branch=1.38.0-fork#7a99abb10ca29e9bcc8b0e51f4e009ad07aded81"
+version = "1.39.0"
+source = "git+https://github.com/kobayurii/nearcore.git?branch=1.39.0-fork#5a6be6cf3b1eb714b5d6f036dbe1cac3caf7b270"
 dependencies = [
  "actix",
  "actix-rt",
@@ -4846,14 +4847,14 @@ dependencies = [
  "itertools 0.10.5",
  "itoa",
  "lru 0.7.8",
- "near-chain-configs 1.38.0",
- "near-crypto 1.38.0",
- "near-fmt 1.38.0",
- "near-o11y 1.38.0",
- "near-parameters 1.38.0",
- "near-primitives 1.38.0",
- "near-stdx 1.38.0",
- "near-vm-runner 1.38.0",
+ "near-chain-configs 1.39.0",
+ "near-crypto 1.39.0",
+ "near-fmt 1.39.0",
+ "near-o11y 1.39.0",
+ "near-parameters 1.39.0",
+ "near-primitives 1.39.0",
+ "near-stdx 1.39.0",
+ "near-vm-runner 1.39.0",
  "num_cpus",
  "once_cell",
  "rand 0.8.5",
@@ -4871,16 +4872,16 @@ dependencies = [
 
 [[package]]
 name = "near-telemetry"
-version = "1.38.0"
-source = "git+https://github.com/kobayurii/nearcore.git?branch=1.38.0-fork#7a99abb10ca29e9bcc8b0e51f4e009ad07aded81"
+version = "1.39.0"
+source = "git+https://github.com/kobayurii/nearcore.git?branch=1.39.0-fork#5a6be6cf3b1eb714b5d6f036dbe1cac3caf7b270"
 dependencies = [
  "actix",
  "awc",
  "futures",
- "near-o11y 1.38.0",
+ "near-o11y 1.39.0",
  "near-performance-metrics",
  "near-performance-metrics-macros",
- "near-primitives 1.38.0",
+ "near-primitives 1.39.0",
  "once_cell",
  "openssl",
  "serde",
@@ -4890,8 +4891,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler"
-version = "1.38.0"
-source = "git+https://github.com/kobayurii/nearcore.git?branch=1.38.0-fork#7a99abb10ca29e9bcc8b0e51f4e009ad07aded81"
+version = "1.39.0"
+source = "git+https://github.com/kobayurii/nearcore.git?branch=1.39.0-fork#5a6be6cf3b1eb714b5d6f036dbe1cac3caf7b270"
 dependencies = [
  "enumset",
  "finite-wasm",
@@ -4907,8 +4908,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler-singlepass"
-version = "1.38.0"
-source = "git+https://github.com/kobayurii/nearcore.git?branch=1.38.0-fork#7a99abb10ca29e9bcc8b0e51f4e009ad07aded81"
+version = "1.39.0"
+source = "git+https://github.com/kobayurii/nearcore.git?branch=1.39.0-fork#5a6be6cf3b1eb714b5d6f036dbe1cac3caf7b270"
 dependencies = [
  "dynasm 2.0.0",
  "dynasmrt 2.0.0",
@@ -4928,8 +4929,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-engine"
-version = "1.38.0"
-source = "git+https://github.com/kobayurii/nearcore.git?branch=1.38.0-fork#7a99abb10ca29e9bcc8b0e51f4e009ad07aded81"
+version = "1.39.0"
+source = "git+https://github.com/kobayurii/nearcore.git?branch=1.39.0-fork#5a6be6cf3b1eb714b5d6f036dbe1cac3caf7b270"
 dependencies = [
  "backtrace",
  "cfg-if 1.0.0",
@@ -4944,6 +4945,7 @@ dependencies = [
  "region",
  "rkyv",
  "rustc-demangle",
+ "rustix",
  "target-lexicon 0.12.14",
  "thiserror",
  "tracing",
@@ -4981,8 +4983,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner"
-version = "1.38.0"
-source = "git+https://github.com/kobayurii/nearcore.git?branch=1.38.0-fork#7a99abb10ca29e9bcc8b0e51f4e009ad07aded81"
+version = "1.39.0"
+source = "git+https://github.com/kobayurii/nearcore.git?branch=1.39.0-fork#5a6be6cf3b1eb714b5d6f036dbe1cac3caf7b270"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -4991,12 +4993,12 @@ dependencies = [
  "enum-map",
  "finite-wasm",
  "loupe",
+ "lru 0.12.3",
  "memoffset 0.8.0",
- "near-cache",
- "near-crypto 1.38.0",
- "near-parameters 1.38.0",
- "near-primitives-core 1.38.0",
- "near-stdx 1.38.0",
+ "near-crypto 1.39.0",
+ "near-parameters 1.39.0",
+ "near-primitives-core 1.39.0",
+ "near-stdx 1.39.0",
  "near-vm-compiler",
  "near-vm-compiler-singlepass",
  "near-vm-engine",
@@ -5009,12 +5011,14 @@ dependencies = [
  "prefix-sum-vec",
  "pwasm-utils",
  "ripemd",
+ "rustix",
  "serde",
  "serde_repr",
  "serde_with",
  "sha2",
  "sha3",
  "strum 0.24.1",
+ "tempfile",
  "thiserror",
  "tracing",
  "wasm-encoder 0.27.0",
@@ -5033,8 +5037,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-types"
-version = "1.38.0"
-source = "git+https://github.com/kobayurii/nearcore.git?branch=1.38.0-fork#7a99abb10ca29e9bcc8b0e51f4e009ad07aded81"
+version = "1.39.0"
+source = "git+https://github.com/kobayurii/nearcore.git?branch=1.39.0-fork#5a6be6cf3b1eb714b5d6f036dbe1cac3caf7b270"
 dependencies = [
  "indexmap 1.9.3",
  "num-traits",
@@ -5044,8 +5048,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-vm"
-version = "1.38.0"
-source = "git+https://github.com/kobayurii/nearcore.git?branch=1.38.0-fork#7a99abb10ca29e9bcc8b0e51f4e009ad07aded81"
+version = "1.39.0"
+source = "git+https://github.com/kobayurii/nearcore.git?branch=1.39.0-fork#5a6be6cf3b1eb714b5d6f036dbe1cac3caf7b270"
 dependencies = [
  "backtrace",
  "cc",
@@ -5066,17 +5070,17 @@ dependencies = [
 
 [[package]]
 name = "near-wallet-contract"
-version = "1.38.0"
-source = "git+https://github.com/kobayurii/nearcore.git?branch=1.38.0-fork#7a99abb10ca29e9bcc8b0e51f4e009ad07aded81"
+version = "1.39.0"
+source = "git+https://github.com/kobayurii/nearcore.git?branch=1.39.0-fork#5a6be6cf3b1eb714b5d6f036dbe1cac3caf7b270"
 dependencies = [
  "anyhow",
- "near-vm-runner 1.38.0",
+ "near-vm-runner 1.39.0",
 ]
 
 [[package]]
 name = "nearcore"
-version = "1.38.0"
-source = "git+https://github.com/kobayurii/nearcore.git?branch=1.38.0-fork#7a99abb10ca29e9bcc8b0e51f4e009ad07aded81"
+version = "1.39.0"
+source = "git+https://github.com/kobayurii/nearcore.git?branch=1.39.0-fork#5a6be6cf3b1eb714b5d6f036dbe1cac3caf7b270"
 dependencies = [
  "actix",
  "actix-rt",
@@ -5095,27 +5099,27 @@ dependencies = [
  "indicatif",
  "near-async",
  "near-chain",
- "near-chain-configs 1.38.0",
+ "near-chain-configs 1.39.0",
  "near-chunks",
  "near-client",
  "near-client-primitives",
- "near-config-utils 1.38.0",
- "near-crypto 1.38.0",
+ "near-config-utils 1.39.0",
+ "near-crypto 1.39.0",
  "near-dyn-configs",
  "near-epoch-manager",
  "near-jsonrpc",
- "near-jsonrpc-primitives 1.38.0",
+ "near-jsonrpc-primitives 1.39.0",
  "near-mainnet-res",
  "near-network",
- "near-o11y 1.38.0",
- "near-parameters 1.38.0",
+ "near-o11y 1.39.0",
+ "near-parameters 1.39.0",
  "near-performance-metrics",
  "near-pool",
- "near-primitives 1.38.0",
+ "near-primitives 1.39.0",
  "near-rosetta-rpc",
  "near-store",
  "near-telemetry",
- "near-vm-runner 1.38.0",
+ "near-vm-runner 1.39.0",
  "node-runtime",
  "num-rational",
  "once_cell",
@@ -5164,19 +5168,19 @@ dependencies = [
 
 [[package]]
 name = "node-runtime"
-version = "1.38.0"
-source = "git+https://github.com/kobayurii/nearcore.git?branch=1.38.0-fork#7a99abb10ca29e9bcc8b0e51f4e009ad07aded81"
+version = "1.39.0"
+source = "git+https://github.com/kobayurii/nearcore.git?branch=1.39.0-fork#5a6be6cf3b1eb714b5d6f036dbe1cac3caf7b270"
 dependencies = [
  "borsh 1.3.1",
  "hex",
- "near-chain-configs 1.38.0",
- "near-crypto 1.38.0",
- "near-o11y 1.38.0",
- "near-parameters 1.38.0",
- "near-primitives 1.38.0",
- "near-primitives-core 1.38.0",
+ "near-chain-configs 1.39.0",
+ "near-crypto 1.39.0",
+ "near-o11y 1.39.0",
+ "near-parameters 1.39.0",
+ "near-primitives 1.39.0",
+ "near-primitives-core 1.39.0",
  "near-store",
- "near-vm-runner 1.38.0",
+ "near-vm-runner 1.39.0",
  "near-wallet-contract",
  "num-bigint 0.3.3",
  "num-rational",
@@ -6365,15 +6369,15 @@ dependencies = [
  "jsonrpc-v2",
  "lazy_static",
  "lru 0.12.3",
- "near-chain-configs 1.38.0",
- "near-crypto 1.38.0",
+ "near-chain-configs 1.39.0",
+ "near-crypto 1.39.0",
  "near-indexer-primitives",
  "near-jsonrpc",
- "near-jsonrpc-client 0.8.0 (git+https://github.com/kobayurii/near-jsonrpc-client-rs.git?branch=0.8.5)",
+ "near-jsonrpc-client 0.8.0 (git+https://github.com/kobayurii/near-jsonrpc-client-rs.git?branch=0.8.6)",
  "near-lake-framework",
- "near-parameters 1.38.0",
- "near-primitives 1.38.0",
- "near-vm-runner 1.38.0",
+ "near-parameters 1.39.0",
+ "near-primitives 1.39.0",
+ "near-vm-runner 1.39.0",
  "paste",
  "prometheus",
  "readnode-primitives",
@@ -6396,7 +6400,7 @@ version = "0.2.5"
 dependencies = [
  "anyhow",
  "borsh 1.3.1",
- "near-chain-configs 1.38.0",
+ "near-chain-configs 1.39.0",
  "near-indexer-primitives",
  "num-traits",
  "serde",
@@ -7427,9 +7431,9 @@ dependencies = [
  "humantime",
  "lazy_static",
  "near-indexer-primitives",
- "near-jsonrpc-client 0.8.0 (git+https://github.com/kobayurii/near-jsonrpc-client-rs.git?branch=0.8.5)",
+ "near-jsonrpc-client 0.8.0 (git+https://github.com/kobayurii/near-jsonrpc-client-rs.git?branch=0.8.6)",
  "near-lake-framework",
- "near-primitives 1.38.0",
+ "near-primitives 1.39.0",
  "openssl-probe",
  "prometheus",
  "tokio",
@@ -8270,7 +8274,7 @@ dependencies = [
  "humantime",
  "lazy_static",
  "near-indexer-primitives",
- "near-jsonrpc-client 0.8.0 (git+https://github.com/kobayurii/near-jsonrpc-client-rs.git?branch=0.8.5)",
+ "near-jsonrpc-client 0.8.0 (git+https://github.com/kobayurii/near-jsonrpc-client-rs.git?branch=0.8.6)",
  "near-lake-framework",
  "prometheus",
  "readnode-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,18 +28,18 @@ readnode-primitives = { path = "readnode-primitives" }
 epoch-indexer = { path = "epoch-indexer" }
 
 # Please, update the supported nearcore version in .cargo/config.toml file
-near-indexer = { git = 'https://github.com/kobayurii/nearcore.git', branch = "1.38.0-fork" }
-near-client = { git = 'https://github.com/kobayurii/nearcore.git', branch = "1.38.0-fork" }
-near-o11y = { git = 'https://github.com/kobayurii/nearcore.git', branch = "1.38.0-fork" }
-near-indexer-primitives = { git = 'https://github.com/kobayurii/nearcore.git', branch = "1.38.0-fork" }
-near-primitives = { git = 'https://github.com/kobayurii/nearcore.git', branch = "1.38.0-fork" }
-near-chain-configs = { git = 'https://github.com/kobayurii/nearcore.git', branch = "1.38.0-fork" }
-near-crypto = { git = 'https://github.com/kobayurii/nearcore.git', branch = "1.38.0-fork" }
-near-jsonrpc = { git = 'https://github.com/kobayurii/nearcore.git', branch = "1.38.0-fork" }
-near-parameters = { git = 'https://github.com/kobayurii/nearcore.git', branch = "1.38.0-fork" }
-near-vm-runner = { git = 'https://github.com/kobayurii/nearcore.git', branch = "1.38.0-fork", features = [
+near-indexer = { git = 'https://github.com/kobayurii/nearcore.git', branch = "1.39.0-fork" }
+near-client = { git = 'https://github.com/kobayurii/nearcore.git', branch = "1.39.0-fork" }
+near-o11y = { git = 'https://github.com/kobayurii/nearcore.git', branch = "1.39.0-fork" }
+near-indexer-primitives = { git = 'https://github.com/kobayurii/nearcore.git', branch = "1.39.0-fork" }
+near-primitives = { git = 'https://github.com/kobayurii/nearcore.git', branch = "1.39.0-fork" }
+near-chain-configs = { git = 'https://github.com/kobayurii/nearcore.git', branch = "1.39.0-fork" }
+near-crypto = { git = 'https://github.com/kobayurii/nearcore.git', branch = "1.39.0-fork" }
+near-jsonrpc = { git = 'https://github.com/kobayurii/nearcore.git', branch = "1.39.0-fork" }
+near-parameters = { git = 'https://github.com/kobayurii/nearcore.git', branch = "1.39.0-fork" }
+near-vm-runner = { git = 'https://github.com/kobayurii/nearcore.git', branch = "1.39.0-fork", features = [
     "wasmer0_vm", "wasmer2_vm", "near_vm", "wasmtime_vm"
 ] }
 
-near-lake-framework = { git = 'https://github.com/kobayurii/near-lake-framework-rs.git', branch = '0.7.11' }
-near-jsonrpc-client = { git = 'https://github.com/kobayurii/near-jsonrpc-client-rs.git', branch = '0.8.5' }
+near-lake-framework = { git = 'https://github.com/kobayurii/near-lake-framework-rs.git', branch = '0.7.12' }
+near-jsonrpc-client = { git = 'https://github.com/kobayurii/near-jsonrpc-client-rs.git', branch = '0.8.6' }

--- a/database/src/scylladb/tx_indexer.rs
+++ b/database/src/scylladb/tx_indexer.rs
@@ -505,17 +505,17 @@ impl crate::TxIndexerDbManager for ScyllaDBManager {
         transaction_hash: &str,
         block_height: u64,
     ) -> anyhow::Result<()> {
-        let delete_transaction_feature = Self::execute_prepared_query(
+        let delete_transaction_future = Self::execute_prepared_query(
             &self.scylla_session,
             &self.cache_delete_transaction,
             (num_bigint::BigInt::from(block_height), transaction_hash),
         );
-        let delete_receipts_feature = Self::execute_prepared_query(
+        let delete_receipts_future = Self::execute_prepared_query(
             &self.scylla_session,
             &self.cache_delete_receipts,
             (num_bigint::BigInt::from(block_height), transaction_hash),
         );
-        futures::try_join!(delete_transaction_feature, delete_receipts_feature)?;
+        futures::try_join!(delete_transaction_future, delete_receipts_future)?;
         Ok(())
     }
 

--- a/near-state-indexer/src/main.rs
+++ b/near-state-indexer/src/main.rs
@@ -1,5 +1,6 @@
 use clap::Parser;
 use futures::StreamExt;
+use near_indexer::near_primitives;
 
 use crate::configs::Opts;
 use near_indexer::near_primitives::hash::CryptoHash;
@@ -70,14 +71,17 @@ async fn handle_streamer_message(
         &indexer_config,
     );
 
-    let update_block_streamer_message_feature =
-        utils::update_block_streamer_message("final_block", &streamer_message, redis_client);
+    let update_block_streamer_message_future = utils::update_block_streamer_message(
+        near_primitives::types::Finality::Final,
+        &streamer_message,
+        redis_client,
+    );
 
     futures::try_join!(
         handle_epoch_future,
         handle_block_future,
         handle_state_change_future,
-        update_block_streamer_message_feature,
+        update_block_streamer_message_future,
     )?;
 
     let mut stats_lock = stats.write().await;

--- a/near-state-indexer/src/main.rs
+++ b/near-state-indexer/src/main.rs
@@ -70,14 +70,14 @@ async fn handle_streamer_message(
         &indexer_config,
     );
 
-    let published_streamer_message_feature =
-        utils::publish_streamer_message("final_block", &streamer_message, redis_client);
+    let update_block_streamer_message_feature =
+        utils::update_block_streamer_message("final_block", &streamer_message, redis_client);
 
     futures::try_join!(
         handle_epoch_future,
         handle_block_future,
         handle_state_change_future,
-        published_streamer_message_feature,
+        update_block_streamer_message_feature,
     )?;
 
     let mut stats_lock = stats.write().await;

--- a/rpc-server/Cargo.toml
+++ b/rpc-server/Cargo.toml
@@ -27,7 +27,7 @@ lazy_static = "1.4.0"
 lru = "0.12.2"
 paste = "1.0.14"
 prometheus = "0.13.1"
-redis-subscribe = "0.2.1"
+redis = { version = "0.25.2", features = ["tokio-comp", "connection-manager"] }
 serde = { version = "1.0.145", features = ["derive"] }
 serde_json = "1.0.85"
 thiserror = "1.0.40"

--- a/rpc-server/src/config.rs
+++ b/rpc-server/src/config.rs
@@ -163,7 +163,7 @@ pub struct CompiledCodeCache {
     pub local_cache: std::sync::Arc<
         crate::cache::RwLockLruMemoryCache<
             near_primitives::hash::CryptoHash,
-            near_vm_runner::logic::CompiledContract,
+            near_vm_runner::CompiledContractInfo,
         >,
     >,
 }
@@ -178,11 +178,15 @@ impl CompiledCodeCache {
     }
 }
 
-impl near_vm_runner::logic::CompiledContractCache for CompiledCodeCache {
+impl near_vm_runner::ContractRuntimeCache for CompiledCodeCache {
+    fn handle(&self) -> Box<dyn near_vm_runner::ContractRuntimeCache> {
+        Box::new(self.clone())
+    }
+
     fn put(
         &self,
         key: &near_primitives::hash::CryptoHash,
-        value: near_vm_runner::logic::CompiledContract,
+        value: near_vm_runner::CompiledContractInfo,
     ) -> std::io::Result<()> {
         block_on(self.local_cache.put(*key, value));
         Ok(())
@@ -191,7 +195,7 @@ impl near_vm_runner::logic::CompiledContractCache for CompiledCodeCache {
     fn get(
         &self,
         key: &near_primitives::hash::CryptoHash,
-    ) -> std::io::Result<Option<near_vm_runner::logic::CompiledContract>> {
+    ) -> std::io::Result<Option<near_vm_runner::CompiledContractInfo>> {
         Ok(block_on(self.local_cache.get(key)))
     }
 

--- a/rpc-server/src/utils.rs
+++ b/rpc-server/src/utils.rs
@@ -184,7 +184,13 @@ pub async fn update_final_block_regularly_from_lake(
             tracing::warn!("{:?}", err);
         };
         let new_optimistic_block_height = crate::metrics::OPTIMISTIC_BLOCK_HEIGHT.get();
-        if new_optimistic_block_height > last_optimistic_block_height {
+        // if the optimistic block is updated and the difference between the optimistic block and the final block is less than 5 blocks
+        // we stop the task to get the final block from the lake and store in the cache
+        if new_optimistic_block_height > last_optimistic_block_height
+            && crate::metrics::OPTIMISTIC_BLOCK_HEIGHT.get()
+                - crate::metrics::FINAL_BLOCK_HEIGHT.get()
+                < 5
+        {
             tracing::info!("Task to get final block from lake and store in the cache stop");
             drop(handlers); // close the channel so the sender will stop
             return Ok(());
@@ -200,7 +206,7 @@ pub async fn update_final_block_regularly_from_lake(
     }
 }
 
-pub async fn check_updating_optimistic_block_regularly(
+pub async fn check_updating_blocks_by_finality_regularly(
     blocks_cache: std::sync::Arc<crate::cache::RwLockLruMemoryCache<u64, CacheBlock>>,
     blocks_info_by_finality: std::sync::Arc<BlocksInfoByFinality>,
     rpc_server_config: configuration::RpcServerConfig,
@@ -212,11 +218,16 @@ pub async fn check_updating_optimistic_block_regularly(
     loop {
         tokio::time::sleep(std::time::Duration::from_secs(5)).await;
         let new_optimistic_block_height = crate::metrics::OPTIMISTIC_BLOCK_HEIGHT.get();
-        if new_optimistic_block_height > current_optimistic_block_height {
+        if new_optimistic_block_height > current_optimistic_block_height
+            && crate::metrics::OPTIMISTIC_BLOCK_HEIGHT.get()
+                - crate::metrics::FINAL_BLOCK_HEIGHT.get()
+                < 5
+        {
             current_optimistic_block_height = new_optimistic_block_height;
         } else {
             tracing::warn!(
-                "Optimistic block in is not updated. Start to update final block from the Lake"
+                "Optimistic block in is not updated or difference between the optimistic block and the final block is more than 4 blocks. \
+                Start to update final block from the Lake"
             );
             crate::metrics::OPTIMISTIC_UPDATING.set_not_working();
             update_final_block_regularly_from_lake(
@@ -233,81 +244,83 @@ pub async fn check_updating_optimistic_block_regularly(
     }
 }
 
+// Helper function to get the finality blocks streamer_message from the redis
+pub(crate) async fn get_block_streamer_message(
+    block_type: &str,
+    redis_client: redis::aio::ConnectionManager,
+) -> anyhow::Result<near_indexer_primitives::StreamerMessage> {
+    let resp: String = redis::cmd("GET")
+        .arg(block_type)
+        .query_async(&mut redis_client.clone())
+        .await?;
+    Ok(serde_json::from_str(&resp)?)
+}
+
 // Task to get and store final block in the cache
 // Subscribe to the redis channel and update the final block in the cache
 pub async fn update_final_block_regularly_from_redis(
     blocks_cache: std::sync::Arc<crate::cache::RwLockLruMemoryCache<u64, CacheBlock>>,
     blocks_info_by_finality: std::sync::Arc<BlocksInfoByFinality>,
-    redis_url: String,
+    redis_client: redis::aio::ConnectionManager,
     near_rpc_client: JsonRpcClient,
-) -> anyhow::Result<()> {
+) {
     tracing::info!("Task to get and store final block in the cache started");
-    let subscriber = redis_subscribe::RedisSub::new(&redis_url);
-    let mut stream = subscriber.listen().await?;
-    subscriber.subscribe("final_block".to_string()).await?;
-    while let Some(message) = stream.next().await {
-        if let redis_subscribe::Message::Message { message, .. } = message {
-            match serde_json::from_str(&message) {
-                Ok(streamer_message) => {
-                    if let Err(err) = handle_streamer_message(
-                        streamer_message,
-                        std::sync::Arc::clone(&blocks_cache),
-                        std::sync::Arc::clone(&blocks_info_by_finality),
-                        &near_rpc_client,
-                    )
-                    .await
-                    {
-                        tracing::error!("Error to handle_streamer_message: {:?}", err);
-                    }
-                }
-                Err(err) => {
-                    tracing::error!("Error parse payload: {:?}", err);
+    loop {
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+        match get_block_streamer_message("final_block", redis_client.clone()).await {
+            Ok(streamer_message) => {
+                if let Err(err) = handle_streamer_message(
+                    streamer_message,
+                    std::sync::Arc::clone(&blocks_cache),
+                    std::sync::Arc::clone(&blocks_info_by_finality),
+                    &near_rpc_client,
+                )
+                .await
+                {
+                    tracing::error!("Error to handle_streamer_message: {:?}", err);
                 }
             }
-        } else {
-            tracing::info!("Redis `final_block` message: {:?}", message);
+            Err(err) => {
+                tracing::error!("Error to get finale block from redis: {:?}", err);
+            }
         }
-
-        // when optimistic updating is not working, we start update final block from the Lake
-        // and wait until optimistic updating is resumed
-        while crate::metrics::OPTIMISTIC_UPDATING.is_not_working() {
+        // when optimistic updating is not working or difference between the optimistic block and the final block is more than 4 blocks,
+        // we start update final block from the Lake and wait until optimistic updating is resumed
+        while crate::metrics::OPTIMISTIC_UPDATING.is_not_working()
+            || crate::metrics::OPTIMISTIC_BLOCK_HEIGHT.get()
+                - crate::metrics::FINAL_BLOCK_HEIGHT.get()
+                > 5
+        {
             tokio::time::sleep(std::time::Duration::from_secs(5)).await;
         }
     }
-    Ok(())
 }
 
 // Task to get and store optimistic block in the cache
 // Subscribe to the redis channel and update the optimistic block in the cache
 pub async fn update_optimistic_block_regularly(
     blocks_info_by_finality: std::sync::Arc<BlocksInfoByFinality>,
-    redis_url: String,
-) -> anyhow::Result<()> {
+    redis_client: redis::aio::ConnectionManager,
+) {
     tracing::info!("Task to get and store optimistic block in the cache started");
-    let subscriber = redis_subscribe::RedisSub::new(&redis_url);
-    let mut stream = subscriber.listen().await?;
-    subscriber.subscribe("optimistic_block".to_string()).await?;
-    while let Some(message) = stream.next().await {
-        if let redis_subscribe::Message::Message { message, .. } = message {
-            match serde_json::from_str(&message) {
-                Ok(streamer_message) => {
-                    let optimistic_block =
-                        BlockInfo::new_from_streamer_message(streamer_message).await;
-                    crate::metrics::OPTIMISTIC_BLOCK_HEIGHT
-                        .set(i64::try_from(optimistic_block.block_cache.block_height)?);
-                    blocks_info_by_finality
-                        .update_optimistic_block(optimistic_block)
-                        .await;
-                }
-                Err(err) => {
-                    tracing::error!("Error parse payload: {:?}", err);
-                }
+    loop {
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+        match get_block_streamer_message("optimistic_block", redis_client.clone()).await {
+            Ok(streamer_message) => {
+                let optimistic_block = BlockInfo::new_from_streamer_message(streamer_message).await;
+                crate::metrics::OPTIMISTIC_BLOCK_HEIGHT.set(
+                    i64::try_from(optimistic_block.block_cache.block_height)
+                        .expect("Invalid optimistic block height"),
+                );
+                blocks_info_by_finality
+                    .update_optimistic_block(optimistic_block)
+                    .await;
             }
-        } else {
-            tracing::info!("Redis `optimistic_block` message: {:?}", message);
+            Err(err) => {
+                tracing::error!("Error to get optimistic block from redis: {:?}", err);
+            }
         }
     }
-    Ok(())
 }
 
 /// Calculate the cache size based on the available memory.


### PR DESCRIPTION
This PR includes changes:

1. Update nearcore dependencies to 1.39.0 
2. Improvement logic to set and get finalities blocks from Redis
