### PR TITLE
(rpc_server): Performance problem ft. near-vm

### DIFF
--- a/rpc-server/src/metrics.rs
+++ b/rpc-server/src/metrics.rs
@@ -665,18 +665,6 @@ lazy_static! {
     ).unwrap();
 }
 
-lazy_static! {
-    // Execute contract counters
-    pub(crate) static ref START_EXETUTING_CONTRACT_COUNTER: IntCounter = try_create_int_counter(
-        "start_executing_contract_counter",
-        "Total number of the started executing contracts"
-    ).unwrap();
-    pub(crate) static ref FINISH_EXECUTING_CONTRACT_COUNTER: IntCounter = try_create_int_counter(
-        "finish_executing_contract_counter",
-        "Total number of the finish executing contracts"
-    ).unwrap();
-}
-
 /// Exposes prometheus metrics
 #[get("/metrics")]
 pub(crate) async fn get_metrics() -> impl Responder {

--- a/rpc-server/src/modules/queries/methods.rs
+++ b/rpc-server/src/modules/queries/methods.rs
@@ -107,7 +107,7 @@ async fn query_call(
                 &data,
                 block,
                 account_id,
-                &method_name,
+                method_name,
                 args.clone(),
                 is_optimistic,
             )
@@ -436,7 +436,7 @@ async fn function_call(
     data: &Data<ServerContext>,
     block: CacheBlock,
     account_id: near_primitives::types::AccountId,
-    method_name: &str,
+    method_name: String,
     args: near_primitives::types::FunctionArgs,
     is_optimistic: bool,
 ) -> Result<
@@ -476,7 +476,7 @@ async fn optimistic_function_call(
     data: &Data<ServerContext>,
     block: CacheBlock,
     account_id: near_primitives::types::AccountId,
-    method_name: &str,
+    method_name: String,
     args: near_primitives::types::FunctionArgs,
 ) -> Result<RunContractResponse, crate::errors::FunctionCallError> {
     let optimistic_data = data
@@ -503,7 +503,7 @@ async fn database_function_call(
     data: &Data<ServerContext>,
     block: CacheBlock,
     account_id: near_primitives::types::AccountId,
-    method_name: &str,
+    method_name: String,
     args: near_primitives::types::FunctionArgs,
 ) -> Result<RunContractResponse, crate::errors::FunctionCallError> {
     run_contract(

--- a/rpc-server/src/modules/queries/utils.rs
+++ b/rpc-server/src/modules/queries/utils.rs
@@ -223,7 +223,6 @@ pub async fn run_contract(
         near_vm_runner::ContractRuntimeCache::handle(compiled_contract_code_cache);
 
     // Execute the contract code in the NearVM
-    crate::metrics::START_EXETUTING_CONTRACT_COUNTER.inc();
     let result = match tokio::task::spawn_blocking(move || {
         near_vm_runner::run(
             &contract.data,
@@ -249,7 +248,6 @@ pub async fn run_contract(
     .map_err(|e| FunctionCallError::InternalError {
         error_message: e.to_string(),
     })?;
-    crate::metrics::FINISH_EXECUTING_CONTRACT_COUNTER.inc();
 
     if let Some(err) = result.aborted {
         let message = format!("wasm execution failed with error: {:?}", err);


### PR DESCRIPTION
When we call `near_vm_runner::run` method accepts the code: Option<&ContractCode>

ref: https://github.com/near/nearcore/blob/14334b9e4e2bff198537130324f2bb9702f54d6d/runtime/near-vm-runner/src/runner.rs#L46

And following down the road, it appears that if this value is None, it is a signal for the near-vm-runner to compile the contract even if we have it in the cache, and it hasn't changed ever since.

After updating nearcore to 1.39.x we use the near-vm-runner crate incorrectly 🤦‍♂️ We naively pass the code every time, hoping near-vm-runner handles it automatically, but it appears it does not.