### PR TITLE
chore: Enable GitHub action checks workflow for develop branch

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -4,9 +4,11 @@ on:
   pull_request:
     branches:
       - main
+      - develop
   push:
     branches:
       - main
+      - develop
 
 jobs:
   check:


### PR DESCRIPTION
We recently introduced a `develop` branch to separate the production-ready code from the one being developed.

This small PR enables the GH Actions checks for the new branch