### PR TITLE
improvement to save finalities blocks streamer_message

### DIFF
--- a/near-state-indexer/src/utils.rs
+++ b/near-state-indexer/src/utils.rs
@@ -70,7 +70,8 @@ pub(crate) async fn update_block_streamer_message(
     let last_height = redis::cmd("GET")
         .arg(format!("{}_height", block_type))
         .query_async(&mut redis_client.clone())
-        .await.unwrap_or(0);
+        .await
+        .unwrap_or(0);
 
     // If the block height is greater than the last height, update the block streamer message
     // if we have a few indexers running, we need to make sure that we are not updating the same block


### PR DESCRIPTION
In this pr, we improve the process to update finalities blocks. 
When running multiple indexers, we should avoid competitiveness in updating the finalities blocks streamer message in the redis.