### PR TITLE
feat: Store `TransactionDetails` in object storage (GCS) 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/near/read-rpc/compare/main...develop)
+### Supported Nearcore Version
+- nearcore v1.40.0
+- rust v1.77.0
+
+### What's Changed
+* Change main data source for `transaction_details` from database to the object storage (GCS Bucket)
+  * Add `tx-details-storage` library to handle the GCS communication
+  * Update `rpc-server` to read from the GCS Bucket when transaction is requested
+  * Keep the database as a backup data source for the migration period
+  * Add metric `legacy_database_tx_details` to track the number of requests to the database to monitor the transition progress (expected to decrease over time to zero)
+  * Extend the number of save attempts to ensure the transaction is saved to the GCS Bucket and is deserializable correctly
+* Refactor `tx-indexer` to store the transaction details in the GCS Bucket
+  * Still storing `ExecutionOutcome` and `Receipt` in the database
 
 ## [0.2.10](https://github.com/near/read-rpc/releases/tag/v0.2.10)
 ### Supported Nearcore Version

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6603,6 +6603,7 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "tracing-actix-web",
+ "tx-details-storage",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -658,9 +658,15 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
+<<<<<<< HEAD
 version = "1.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "966646a69665bb0427460d78747204317f6639bdf5ec61305c4c5195af3dc086"
+=======
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cedc97499da49c3e36cde578340f9925284685073cb3e512aaf9ab16cd9a2541"
+>>>>>>> bc78c15 (feat: tx-indexer to store transactions to object storage (GCS))
 dependencies = [
  "ahash 0.8.11",
  "aws-credential-types",
@@ -872,9 +878,15 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
+<<<<<<< HEAD
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9ac79e9f3a4d576f3cd4a470a0275b138d9e7b11b1cd514a6858ae0a79dd5bb"
+=======
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cf64e73ef8d4dac6c933230d56d136b75b252edcf82ed36e37d603090cd7348"
+>>>>>>> bc78c15 (feat: tx-indexer to store transactions to object storage (GCS))
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -898,9 +910,15 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
+<<<<<<< HEAD
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04ec42c2f5c0e7796a2848dde4d9f3bf8ce12ccbb3d5aa40c52fa0cdd61a1c47"
+=======
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c19fdae6e3d5ac9cd01f2d6e6c359c5f5a3e028c2d148a8f5b90bf3399a18a7"
+>>>>>>> bc78c15 (feat: tx-indexer to store transactions to object storage (GCS))
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-types",
@@ -950,9 +968,15 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
+<<<<<<< HEAD
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a807d90cd50a969b3d95e4e7ad1491fcae13c6e83948d8728363ecc09d66343a"
+=======
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a43b56df2c529fe44cb4d92bd64d0479883fb9608ff62daede4df5405381814"
+>>>>>>> bc78c15 (feat: tx-indexer to store transactions to object storage (GCS))
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
@@ -8500,6 +8524,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tx-details-storage"
+version = "0.2.5"
+dependencies = [
+ "anyhow",
+ "aws-credential-types",
+ "aws-sdk-s3",
+ "aws-types",
+]
+
+[[package]]
 name = "tx-indexer"
 version = "0.2.10"
 dependencies = [
@@ -8521,6 +8555,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
+ "tx-details-storage",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,14 +14,14 @@ dependencies = [
 
 [[package]]
 name = "actix"
-version = "0.13.3"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb72882332b6d6282f428b77ba0358cb2687e61a6f6df6a6d3871e8a177c2d4f"
+checksum = "de7fa236829ba0841304542f7614c42b80fca007455315c45c785ccfa873a85b"
 dependencies = [
  "actix-macros",
  "actix-rt",
  "actix_derive",
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "bytes",
  "crossbeam-channel",
  "futures-core",
@@ -30,7 +30,7 @@ dependencies = [
  "futures-util",
  "log",
  "once_cell",
- "parking_lot 0.12.2",
+ "parking_lot 0.12.3",
  "pin-project-lite",
  "smallvec",
  "tokio",
@@ -43,7 +43,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f7b0a21988c1bf877cf4759ef5ddaac04c1c9fe808c9142ecb78ba97d97a28a"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "bytes",
  "futures-core",
  "futures-sink",
@@ -86,9 +86,9 @@ dependencies = [
 
 [[package]]
 name = "actix-http"
-version = "3.7.0"
+version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eb9843d84c775696c37d9a418bbb01b932629d01870722c0f13eb3f95e2536d"
+checksum = "3ae682f693a9cd7b058f2b0b5d9a6d7728a8555779bedbbc35dd88528611d020"
 dependencies = [
  "actix-codec",
  "actix-rt",
@@ -96,7 +96,7 @@ dependencies = [
  "actix-utils",
  "ahash 0.8.11",
  "base64 0.22.1",
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "brotli",
  "bytes",
  "bytestring",
@@ -130,7 +130,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
 dependencies = [
  "quote",
- "syn 2.0.65",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -150,9 +150,9 @@ dependencies = [
 
 [[package]]
 name = "actix-rt"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28f32d40287d3f402ae0028a9d54bef51af15c8769492826a69d28f81893151d"
+checksum = "24eda4e2a6e042aa4e55ac438a2ae052d3b5da0ecf83d7411e1a368946925208"
 dependencies = [
  "actix-macros",
  "futures-core",
@@ -161,9 +161,9 @@ dependencies = [
 
 [[package]]
 name = "actix-server"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eb13e7eef0423ea6eab0e59f6c72e7cb46d33691ad56a726b3cd07ddec2c2d4"
+checksum = "b02303ce8d4e8be5b855af6cf3c3a08f3eff26880faad82bab679c22d3650cb5"
 dependencies = [
  "actix-rt",
  "actix-service",
@@ -220,9 +220,9 @@ dependencies = [
 
 [[package]]
 name = "actix-web"
-version = "4.6.0"
+version = "4.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1cf67dadb19d7c95e5a299e2dda24193b89d5d4f33a3b9800888ede9e19aa32"
+checksum = "1988c02af8d2b718c05bc4aeb6a66395b7cdf32858c2c71131e5637a8c05a9ff"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -261,14 +261,14 @@ dependencies = [
 
 [[package]]
 name = "actix-web-codegen"
-version = "4.2.2"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb1f50ebbb30eca122b188319a4398b3f7bb4a8cdf50ecfb73bfc6a3c3ce54f5"
+checksum = "f591380e2e68490b5dfaf1dd1aa0ebe78d84ba7067078512b4ea6e4492d622b8"
 dependencies = [
  "actix-router",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -279,7 +279,7 @@ checksum = "7c7db3d5a9718568e4cf4a537cfd7070e6e6ff7481510d0237fb529ac850f6d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -288,7 +288,16 @@ version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
 dependencies = [
- "gimli",
+ "gimli 0.28.1",
+]
+
+[[package]]
+name = "addr2line"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
+dependencies = [
+ "gimli 0.29.0",
 ]
 
 [[package]]
@@ -398,9 +407,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a64c907d4e79225ac72e2a354c9ce84d50ebb4586dee56c82b3ee73004f537f5"
+checksum = "ad186efb764318d35165f1758e7dcef3b10628e26d41a44bc5550652e6804391"
 dependencies = [
  "windows-sys 0.52.0",
 ]
@@ -494,7 +503,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -505,7 +514,7 @@ checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -566,9 +575,9 @@ dependencies = [
 
 [[package]]
 name = "aws-config"
-version = "1.4.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ddbfb5db93d62521f47b3f223da0884a2f02741ff54cb9cda192a0e73ba08b"
+checksum = "2ac9889352d632214df943e26740c46a0f3da6e329fbd28164fe7ae1b061da7b"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -634,9 +643,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.2.2"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75588e7ee5e8496eed939adac2035a6dbab9f7eb2acdd9ab2d31856dab6f3955"
+checksum = "9a4a5e448145999d7de17bf44a886900ecb834953408dae8aaf90465ce91c1dd"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -658,15 +667,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-<<<<<<< HEAD
-version = "1.29.0"
+version = "1.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "966646a69665bb0427460d78747204317f6639bdf5ec61305c4c5195af3dc086"
-=======
-version = "1.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cedc97499da49c3e36cde578340f9925284685073cb3e512aaf9ab16cd9a2541"
->>>>>>> bc78c15 (feat: tx-indexer to store transactions to object storage (GCS))
+checksum = "724119d8fd2d2638b9979673f3b5c2979fa388c9ca27815e3cb5ad6234fac3f5"
 dependencies = [
  "ahash 0.8.11",
  "aws-credential-types",
@@ -699,9 +702,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.25.0"
+version = "1.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fef2d9ca2b43051224ed326ed9960a85e277b7d554a2cd0397e57c0553d86e64"
+checksum = "da75cf91cbb46686a27436d639a720a3a198b148efa76dc2467b7e5374a67fc0"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -721,9 +724,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.26.0"
+version = "1.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c869d1f5c4ee7437b79c3c1664ddbf7a60231e893960cf82b2b299a5ccf2cc5d"
+checksum = "cf2ec8a6687299685ed0a4a3137c129cdb132b5235bc3aa3443f6cffe468b9ff"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -743,9 +746,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.25.0"
+version = "1.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e2b4a632a59e4fab7abf1db0d94a3136ad7871aba46bebd1fdb95c7054afcdb"
+checksum = "458f1031e094b1411b59b49b19e4118f069e1fe13a9c5b8888e933daaf7ffdd6"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -766,9 +769,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58b56f1cbe6fd4d0c2573df72868f20ab1c125ca9c9dbce17927a463433a2e57"
+checksum = "31eed8d45759b2c5fe7fd304dd70739060e9e0de509209036eabea14d0720cce"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
@@ -806,9 +809,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.60.7"
+version = "0.60.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fa43bc04a6b2441968faeab56e68da3812f978a670a5db32accbdcafddd12f"
+checksum = "c5b30ea96823b8b25fb6471643a516e1bd475fd5575304e6240aea179f213216"
 dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",
@@ -878,15 +881,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-<<<<<<< HEAD
-version = "1.5.0"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9ac79e9f3a4d576f3cd4a470a0275b138d9e7b11b1cd514a6858ae0a79dd5bb"
-=======
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cf64e73ef8d4dac6c933230d56d136b75b252edcf82ed36e37d603090cd7348"
->>>>>>> bc78c15 (feat: tx-indexer to store transactions to object storage (GCS))
+checksum = "d0d3965f6417a92a6d1009c5958a67042f57e46342afb37ca58f9ad26744ec73"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -910,15 +907,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-<<<<<<< HEAD
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04ec42c2f5c0e7796a2848dde4d9f3bf8ce12ccbb3d5aa40c52fa0cdd61a1c47"
-=======
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c19fdae6e3d5ac9cd01f2d6e6c359c5f5a3e028c2d148a8f5b90bf3399a18a7"
->>>>>>> bc78c15 (feat: tx-indexer to store transactions to object storage (GCS))
+checksum = "1b570ea39eb95bd32543f6e4032bce172cb6209b9bc8c83c770d08169e875afc"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-types",
@@ -933,9 +924,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.1.9"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf98d97bba6ddaba180f1b1147e202d8fe04940403a95a3f826c790f931bbd1"
+checksum = "cfe321a6b21f5d8eabd0ade9c55d3d0335f3c3157fc2b3e87f05f34b539e4df5"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -968,21 +959,14 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-<<<<<<< HEAD
-version = "1.2.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a807d90cd50a969b3d95e4e7ad1491fcae13c6e83948d8728363ecc09d66343a"
-=======
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a43b56df2c529fe44cb4d92bd64d0479883fb9608ff62daede4df5405381814"
->>>>>>> bc78c15 (feat: tx-indexer to store transactions to object storage (GCS))
+checksum = "2009a9733865d0ebf428a314440bbe357cc10d0c16d86a8e15d32e9b47c1e80e"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "http 0.2.12",
  "rustc_version 0.4.0",
  "tracing",
 ]
@@ -1034,16 +1018,16 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.71"
+version = "0.3.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
+checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
 dependencies = [
- "addr2line",
+ "addr2line 0.22.0",
  "cc",
  "cfg-if 1.0.0",
  "libc",
  "miniz_oxide",
- "object",
+ "object 0.36.1",
  "rustc-demangle",
 ]
 
@@ -1095,13 +1079,13 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bigdecimal"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9324c8014cd04590682b34f1e9448d38f0674d0f7b2dc553331016ef0e4e9ebc"
+checksum = "51d712318a27c7150326677b321a5fa91b55f6d9034ffd67f20319e147d40cee"
 dependencies = [
  "autocfg",
  "libm",
- "num-bigint 0.4.5",
+ "num-bigint 0.4.6",
  "num-integer",
  "num-traits",
 ]
@@ -1133,7 +1117,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.65",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -1144,9 +1128,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "bitmaps"
@@ -1226,11 +1210,11 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbe5b10e214954177fb1dc9fbd20a1a2608fe99e6c832033bdc7cea287a20d77"
+checksum = "a6362ed55def622cddc70a4746a68554d7b687713770de539e59a739b249f8ed"
 dependencies = [
- "borsh-derive 1.5.0",
+ "borsh-derive 1.5.1",
  "cfg_aliases",
 ]
 
@@ -1249,15 +1233,15 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a8646f94ab393e43e8b35a2558b1624bed28b97ee09c5d15456e3c9463f46d"
+checksum = "c3ef8005764f53cd4dca619f5bf64cafd4664dada50ece25e4d81de54c80cc0b"
 dependencies = [
  "once_cell",
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.68",
  "syn_derive",
 ]
 
@@ -1296,9 +1280,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "4.0.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6221fe77a248b9117d431ad93761222e1cf8ff282d9d1d5d9f53d6299a1cf76"
+checksum = "9a45bd2e4095a8b518033b128020dd4a55aab1c0a381ba4404a472630f4bc362"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -1407,9 +1391,9 @@ checksum = "a2698f953def977c68f935bb0dfa959375ad4638570e969e2f1e9f433cbf1af6"
 
 [[package]]
 name = "cc"
-version = "1.0.98"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41c270e7540d725e65ac7f1b212ac8ce349719624d7bcff99f8e2e488e8cf03f"
+checksum = "74b6a57f98764a267ff415d50a25e6e166f3831a5071af4995296ea97d210490"
 dependencies = [
  "jobserver",
  "libc",
@@ -1439,9 +1423,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.1.1"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -1469,9 +1453,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "1.7.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67523a3b4be3ce1989d607a828d036249522dd9c1c8de7f4dd2dae43a37369d1"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
 dependencies = [
  "glob",
  "libc",
@@ -1480,9 +1464,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.4"
+version = "4.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
+checksum = "84b3edb18336f4df585bc9aa31dd99c036dfa5dc5e9a2939a722a188f3a8970d"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1490,9 +1474,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.2"
+version = "4.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
+checksum = "c1c09dd5ada6c6c78075d6fd0da3f90d8080651e2d6cc8eb2f1aaa4034ced708"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1502,21 +1486,21 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.4"
+version = "4.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
+checksum = "2bac35c6dafb060fd4d275d9a4ffae97917c13a6327903a8be2153cd964f7085"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.68",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
 
 [[package]]
 name = "cloud-storage"
@@ -1596,7 +1580,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "toml 0.8.13",
+ "toml 0.8.14",
  "tracing",
  "tracing-opentelemetry 0.19.0",
  "tracing-stackdriver",
@@ -1702,7 +1686,7 @@ dependencies = [
  "cranelift-control",
  "cranelift-entity",
  "cranelift-isle",
- "gimli",
+ "gimli 0.28.1",
  "hashbrown 0.14.5",
  "log",
  "regalloc2",
@@ -1806,9 +1790,9 @@ checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
 name = "crc32c"
-version = "0.6.5"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89254598aa9b9fa608de44b3ae54c810f0f06d755e24c50177f1f8f31ff50ce2"
+checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
 dependencies = [
  "rustc_version 0.4.0",
 ]
@@ -1964,9 +1948,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.72+curl-8.6.0"
+version = "0.4.73+curl-8.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29cbdc8314c447d11e8fd156dcdd031d9e02a7a976163e396b548c03153bc9ea"
+checksum = "450ab250ecf17227c39afb9a2dd9261dc0035cb80f2612472fc0c4aac2dcb84d"
 dependencies = [
  "cc",
  "libc",
@@ -1979,16 +1963,15 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.2"
+version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a677b8922c94e01bdbb12126b0bc852f00447528dee1782229af9c720c3f348"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto",
- "platforms",
  "rand_core 0.6.4",
  "rustc_version 0.4.0",
  "subtle",
@@ -2003,7 +1986,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -2051,7 +2034,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.65",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -2073,7 +2056,7 @@ checksum = "733cabb43482b1a1b53eee8583c2b9e8684d592215ea83efd305dd31bc2f0178"
 dependencies = [
  "darling_core 0.20.9",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -2096,7 +2079,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bigdecimal",
- "borsh 1.5.0",
+ "borsh 1.5.1",
  "bytes",
  "configuration",
  "diesel",
@@ -2109,7 +2092,7 @@ dependencies = [
  "near-crypto 1.40.0",
  "near-indexer-primitives",
  "near-primitives 1.40.0",
- "num-bigint 0.4.5",
+ "num-bigint 0.4.6",
  "num-traits",
  "prettytable-rs",
  "prometheus",
@@ -2179,7 +2162,7 @@ checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -2215,15 +2198,15 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "0.99.17"
+version = "0.99.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
+checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
 dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
  "rustc_version 0.4.0",
- "syn 1.0.109",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -2233,11 +2216,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff236accb9a5069572099f0b350a92e9560e8e63a9b8d546162f4a5e03026bb2"
 dependencies = [
  "bigdecimal",
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "byteorder",
  "diesel_derives",
  "itoa",
- "num-bigint 0.4.5",
+ "num-bigint 0.4.6",
  "num-integer",
  "num-traits",
  "pq-sys",
@@ -2268,7 +2251,7 @@ dependencies = [
  "diesel_table_macro_syntax",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -2288,7 +2271,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc5557efc453706fed5e4fa85006fe9817c224c3f480a34c7e5959fd700921c5"
 dependencies = [
- "syn 2.0.65",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -2474,9 +2457,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "elastic-array"
@@ -2545,7 +2528,7 @@ checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -2566,7 +2549,7 @@ dependencies = [
  "darling 0.20.9",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -2707,12 +2690,6 @@ dependencies = [
  "wasmparser 0.105.0",
  "wasmprinter",
 ]
-
-[[package]]
-name = "finl_unicode"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fcfdc7a0362c9f4444381a9e697c79d435fe65b52a37466fc2c1184cee9edc6"
 
 [[package]]
 name = "fixed-hash"
@@ -2867,7 +2844,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -2915,7 +2892,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27d12c0aed7f1e24276a241aadc4cb8ea9f83000f34bc062b7cc2d51e3b0fabd"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "debugid",
  "fxhash",
  "serde",
@@ -2973,6 +2950,12 @@ dependencies = [
  "indexmap 2.2.6",
  "stable_deref_trait",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
 name = "glob"
@@ -3161,12 +3144,12 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
 dependencies = [
  "bytes",
- "futures-core",
+ "futures-util",
  "http 1.1.0",
  "http-body 1.0.0",
  "pin-project-lite",
@@ -3174,9 +3157,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.8.0"
+version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
 
 [[package]]
 name = "httpdate"
@@ -3192,9 +3175,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.28"
+version = "0.14.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
+checksum = "f361cde2f109281a220d4307746cdfd5ee3f410da58a70377762396775634b33"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -3431,6 +3414,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3507,11 +3499,11 @@ checksum = "d4345964bb142484797b161f473a503a434de77149dd8c7427788c6e13379388"
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin 0.5.2",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -3534,9 +3526,9 @@ checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libloading"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
+checksum = "e310b3a6b5907f99202fcdb4960ff45b93735d7c7d96b760fcff8db2dc0e103d"
 dependencies = [
  "cfg-if 1.0.0",
  "windows-targets 0.52.5",
@@ -3550,9 +3542,9 @@ checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "libmimalloc-sys"
-version = "0.1.38"
+version = "0.1.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7bb23d733dfcc8af652a78b7bf232f0e967710d044732185e561e47c0336b6"
+checksum = "23aa6811d3bd4deb8a84dde645f943476d13b248d818edcf8ce0b2f37f036b44"
 dependencies = [
  "cc",
  "libc",
@@ -3564,7 +3556,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "libc",
 ]
 
@@ -3587,9 +3579,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.16"
+version = "1.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e143b5e666b2695d28f6bca6497720813f699c9602dd7f5cac91008b8ada7f9"
+checksum = "c15da26e5af7e25c90b37a2d75cdbf940cf4a55316de9d84c679c9b8bfabf82e"
 dependencies = [
  "cc",
  "libc",
@@ -3641,9 +3633,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.21"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "lru"
@@ -3665,9 +3657,9 @@ dependencies = [
 
 [[package]]
 name = "lz4-sys"
-version = "1.9.4"
+version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d27b317e207b10f69f5e75494119e391a96f48861ae870d1da6edac98ca900"
+checksum = "e9764018d143cc854c9f17f0b907de70f14393b1f502da6375dce70f00514eb3"
 dependencies = [
  "cc",
  "libc",
@@ -3734,7 +3726,7 @@ checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -3755,9 +3747,9 @@ checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
-version = "2.7.2"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "memfd"
@@ -3837,9 +3829,9 @@ dependencies = [
 
 [[package]]
 name = "mimalloc"
-version = "0.1.42"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9186d86b79b52f4a77af65604b51225e8db1d6ee7e3f41aec1e40829c71a176"
+checksum = "68914350ae34959d83f732418d51e2427a794055d0b9529f48259ac07af65633"
 dependencies = [
  "libmimalloc-sys",
 ]
@@ -3852,9 +3844,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mime_guess"
-version = "2.0.4"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
 dependencies = [
  "mime",
  "unicase",
@@ -3877,9 +3869,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87dfd01fe195c66b572b37921ad8803d010623c0aca821bea2302239d155cdae"
+checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
 dependencies = [
  "adler",
 ]
@@ -3916,11 +3908,10 @@ checksum = "6d02c0b00610773bb7fc61d85e13d86c7858cbdf00e1a120bfc41bc055dbaa0e"
 
 [[package]]
 name = "native-tls"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
 dependencies = [
- "lazy_static",
  "libc",
  "log",
  "openssl",
@@ -3938,7 +3929,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35cbb989542587b47205e608324ddd391f0cee1c22b4b64ae49f458334b95907"
 dependencies = [
- "borsh 1.5.0",
+ "borsh 1.5.1",
  "serde",
 ]
 
@@ -3967,7 +3958,7 @@ source = "git+https://github.com/kobayurii/nearcore.git?branch=1.40.0-fork#866de
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -3985,7 +3976,7 @@ source = "git+https://github.com/kobayurii/nearcore.git?branch=1.40.0-fork#866de
 dependencies = [
  "actix",
  "assert_matches",
- "borsh 1.5.0",
+ "borsh 1.5.1",
  "bytesize",
  "chrono",
  "crossbeam-channel",
@@ -4091,7 +4082,7 @@ version = "1.40.0"
 source = "git+https://github.com/kobayurii/nearcore.git?branch=1.40.0-fork#866de3aab2f87bd4d947d6954fb10f29adb5cb1a"
 dependencies = [
  "actix",
- "borsh 1.5.0",
+ "borsh 1.5.1",
  "chrono",
  "derive_more",
  "futures",
@@ -4136,7 +4127,7 @@ dependencies = [
  "actix-rt",
  "anyhow",
  "async-trait",
- "borsh 1.5.0",
+ "borsh 1.5.1",
  "bytesize",
  "chrono",
  "cloud-storage",
@@ -4236,7 +4227,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2991d2912218a80ec0733ac87f84fa803accea105611eea209d4419271957667"
 dependencies = [
  "blake2",
- "borsh 1.5.0",
+ "borsh 1.5.1",
  "bs58",
  "c2-chacha",
  "curve25519-dalek",
@@ -4262,7 +4253,7 @@ version = "1.40.0"
 source = "git+https://github.com/kobayurii/nearcore.git?branch=1.40.0-fork#866de3aab2f87bd4d947d6954fb10f29adb5cb1a"
 dependencies = [
  "blake2",
- "borsh 1.5.0",
+ "borsh 1.5.1",
  "bs58",
  "curve25519-dalek",
  "derive_more",
@@ -4304,7 +4295,7 @@ name = "near-epoch-manager"
 version = "1.40.0"
 source = "git+https://github.com/kobayurii/nearcore.git?branch=1.40.0-fork#866de3aab2f87bd4d947d6954fb10f29adb5cb1a"
 dependencies = [
- "borsh 1.5.0",
+ "borsh 1.5.1",
  "itertools 0.10.5",
  "near-cache",
  "near-chain-configs 1.40.0",
@@ -4416,7 +4407,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18ad81e015f7aced8925d5b9ba3f369b36da9575c15812cfd0786bc1213284ca"
 dependencies = [
- "borsh 1.5.0",
+ "borsh 1.5.1",
  "lazy_static",
  "log",
  "near-chain-configs 0.20.1",
@@ -4434,7 +4425,7 @@ name = "near-jsonrpc-client"
 version = "0.9.0"
 source = "git+https://github.com/kobayurii/near-jsonrpc-client-rs.git?branch=0.10.0#77ece899657045362e7dbfcad3c409e2ee9a5ef5"
 dependencies = [
- "borsh 1.5.0",
+ "borsh 1.5.1",
  "lazy_static",
  "log",
  "near-chain-configs 1.40.0",
@@ -4538,7 +4529,7 @@ dependencies = [
  "anyhow",
  "arc-swap",
  "async-trait",
- "borsh 1.5.0",
+ "borsh 1.5.1",
  "bytes",
  "bytesize",
  "chrono",
@@ -4559,9 +4550,9 @@ dependencies = [
  "near-store",
  "once_cell",
  "opentelemetry 0.22.0",
- "parking_lot 0.12.2",
+ "parking_lot 0.12.3",
  "pin-project",
- "protobuf 3.4.0",
+ "protobuf 3.5.0",
  "protobuf-codegen",
  "rand 0.8.5",
  "rayon",
@@ -4639,7 +4630,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9f16a59b6c3e69b0585be951af6fe42a0ba86c0e207cb8c63badd19efd16680"
 dependencies = [
  "assert_matches",
- "borsh 1.5.0",
+ "borsh 1.5.1",
  "enum-map",
  "near-account-id",
  "near-primitives-core 0.20.1",
@@ -4656,7 +4647,7 @@ name = "near-parameters"
 version = "1.40.0"
 source = "git+https://github.com/kobayurii/nearcore.git?branch=1.40.0-fork#866de3aab2f87bd4d947d6954fb10f29adb5cb1a"
 dependencies = [
- "borsh 1.5.0",
+ "borsh 1.5.1",
  "enum-map",
  "near-account-id",
  "near-primitives-core 1.40.0",
@@ -4690,7 +4681,7 @@ version = "1.40.0"
 source = "git+https://github.com/kobayurii/nearcore.git?branch=1.40.0-fork#866de3aab2f87bd4d947d6954fb10f29adb5cb1a"
 dependencies = [
  "quote",
- "syn 2.0.65",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -4698,7 +4689,7 @@ name = "near-pool"
 version = "1.40.0"
 source = "git+https://github.com/kobayurii/nearcore.git?branch=1.40.0-fork#866de3aab2f87bd4d947d6954fb10f29adb5cb1a"
 dependencies = [
- "borsh 1.5.0",
+ "borsh 1.5.1",
  "near-crypto 1.40.0",
  "near-o11y 1.40.0",
  "near-primitives 1.40.0",
@@ -4714,7 +4705,7 @@ checksum = "0462b067732132babcc89d5577db3bfcb0a1bcfbaaed3f2db4c11cd033666314"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
- "borsh 1.5.0",
+ "borsh 1.5.1",
  "bytesize",
  "cfg-if 1.0.0",
  "chrono",
@@ -4755,7 +4746,7 @@ source = "git+https://github.com/kobayurii/nearcore.git?branch=1.40.0-fork#866de
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
- "borsh 1.5.0",
+ "borsh 1.5.1",
  "bytes",
  "bytesize",
  "cfg-if 1.0.0",
@@ -4799,7 +4790,7 @@ checksum = "8443eb718606f572c438be6321a097a8ebd69f8e48d953885b4f16601af88225"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
- "borsh 1.5.0",
+ "borsh 1.5.1",
  "bs58",
  "derive_more",
  "enum-map",
@@ -4820,7 +4811,7 @@ source = "git+https://github.com/kobayurii/nearcore.git?branch=1.40.0-fork#866de
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
- "borsh 1.5.0",
+ "borsh 1.5.1",
  "bs58",
  "derive_more",
  "enum-map",
@@ -4871,7 +4862,7 @@ checksum = "80fca203c51edd9595ec14db1d13359fb9ede32314990bf296b6c5c4502f6ab7"
 dependencies = [
  "quote",
  "serde",
- "syn 2.0.65",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -4881,7 +4872,7 @@ source = "git+https://github.com/kobayurii/nearcore.git?branch=1.40.0-fork#866de
 dependencies = [
  "quote",
  "serde",
- "syn 2.0.65",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -4893,7 +4884,7 @@ dependencies = [
  "fs2",
  "near-rpc-error-core 0.20.1",
  "serde",
- "syn 2.0.65",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -4903,7 +4894,7 @@ source = "git+https://github.com/kobayurii/nearcore.git?branch=1.40.0-fork#866de
 dependencies = [
  "near-rpc-error-core 1.40.0",
  "serde",
- "syn 2.0.65",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -4913,7 +4904,7 @@ dependencies = [
  "actix",
  "actix-web",
  "anyhow",
- "borsh 1.5.0",
+ "borsh 1.5.1",
  "clap",
  "configuration",
  "database",
@@ -4953,7 +4944,7 @@ dependencies = [
  "actix",
  "actix-rt",
  "anyhow",
- "borsh 1.5.0",
+ "borsh 1.5.1",
  "bytesize",
  "crossbeam",
  "derive_more",
@@ -5073,7 +5064,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c56c80bdb1954808f59bd36a9112377197b38d424991383bf05f52d0fe2e0da5"
 dependencies = [
  "base64 0.21.7",
- "borsh 1.5.0",
+ "borsh 1.5.1",
  "ed25519-dalek",
  "enum-map",
  "memoffset 0.8.0",
@@ -5103,7 +5094,7 @@ source = "git+https://github.com/kobayurii/nearcore.git?branch=1.40.0-fork#866de
 dependencies = [
  "anyhow",
  "base64 0.21.7",
- "borsh 1.5.0",
+ "borsh 1.5.1",
  "ed25519-dalek",
  "enum-map",
  "finite-wasm",
@@ -5200,7 +5191,7 @@ dependencies = [
  "actix-web",
  "anyhow",
  "awc",
- "borsh 1.5.0",
+ "borsh 1.5.1",
  "bytesize",
  "chrono",
  "cloud-storage",
@@ -5285,7 +5276,7 @@ name = "node-runtime"
 version = "1.40.0"
 source = "git+https://github.com/kobayurii/nearcore.git?branch=1.40.0-fork#866de3aab2f87bd4d947d6954fb10f29adb5cb1a"
 dependencies = [
- "borsh 1.5.0",
+ "borsh 1.5.1",
  "hex",
  "near-chain-configs 1.40.0",
  "near-crypto 1.40.0",
@@ -5371,9 +5362,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c165a9ab64cf766f73521c0dd2cfdff64f488b8f0b3e621face3462d3db536d7"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -5444,7 +5435,7 @@ dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -5466,6 +5457,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "081b846d1d56ddfc18fdf1a922e4f6e07a11768ea1b92dec44e42b72712ccfce"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5483,7 +5483,7 @@ version = "0.10.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "cfg-if 1.0.0",
  "foreign-types",
  "libc",
@@ -5500,7 +5500,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -5511,9 +5511,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "300.2.3+3.2.1"
+version = "300.3.1+3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cff92b6f71555b61bb9315f7c64da3ca43d87531622120fea0195fc761b4843"
+checksum = "7259953d42a81bf137fbbd73bd30a8e1914d6dce43c2b90ed575783a22608b91"
 dependencies = [
  "cc",
 ]
@@ -5735,7 +5735,7 @@ dependencies = [
  "glob",
  "once_cell",
  "opentelemetry 0.22.0",
- "ordered-float 4.2.0",
+ "ordered-float 4.2.1",
  "percent-encoding",
  "rand 0.8.5",
  "thiserror",
@@ -5754,9 +5754,9 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a76df7075c7d4d01fdcb46c912dd17fba5b60c78ea480b475f2b6ab6f666584e"
+checksum = "19ff2cf528c6c03d9ed653d6c4ce1dc0582dc4af309790ad92f07c1cd551b0be"
 dependencies = [
  "num-traits",
 ]
@@ -5907,9 +5907,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e4af0ca4f6caed20e900d564c242b8e5d4903fdacf31d3daf527b66fe6f42fb"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
 dependencies = [
  "lock_api 0.4.12",
  "parking_lot_core 0.9.10",
@@ -5937,7 +5937,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "redox_syscall 0.5.1",
+ "redox_syscall 0.5.2",
  "smallvec",
  "windows-targets 0.52.5",
 ]
@@ -6035,7 +6035,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -6065,12 +6065,6 @@ name = "pkg-config"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
-
-[[package]]
-name = "platforms"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db23d408679286588f4d4644f965003d056e3dd5abcaaa938116871d7ce2fee7"
 
 [[package]]
 name = "polling"
@@ -6151,7 +6145,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
 dependencies = [
  "proc-macro2",
- "syn 2.0.65",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -6232,9 +6226,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.83"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b33eb56c327dec362a9e55b3ad14f9d2f0904fb5a5b03b513ab5465399e9f43"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
@@ -6249,7 +6243,7 @@ dependencies = [
  "fnv",
  "lazy_static",
  "memchr",
- "parking_lot 0.12.2",
+ "parking_lot 0.12.3",
  "protobuf 2.28.0",
  "thiserror",
 ]
@@ -6314,10 +6308,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -6338,9 +6332,9 @@ checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "protobuf"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58678a64de2fced2bdec6bca052a6716a0efe692d6e3f53d1bda6a1def64cfc0"
+checksum = "df67496db1a89596beaced1579212e9b7c53c22dca1d9745de00ead76573d514"
 dependencies = [
  "once_cell",
  "protobuf-support",
@@ -6349,13 +6343,13 @@ dependencies = [
 
 [[package]]
 name = "protobuf-codegen"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32777b0b3f6538d9d2e012b3fad85c7e4b9244b5958d04a6415f4333782b7a77"
+checksum = "eab09155fad2d39333d3796f67845d43e29b266eea74f7bc93f153f707f126dc"
 dependencies = [
  "anyhow",
  "once_cell",
- "protobuf 3.4.0",
+ "protobuf 3.5.0",
  "protobuf-parse",
  "regex",
  "tempfile",
@@ -6364,14 +6358,14 @@ dependencies = [
 
 [[package]]
 name = "protobuf-parse"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96cb37955261126624a25b5e6bda40ae34cf3989d52a783087ca6091b29b5642"
+checksum = "1a16027030d4ec33e423385f73bb559821827e9ec18c50e7874e4d6de5a4e96f"
 dependencies = [
  "anyhow",
- "indexmap 1.9.3",
+ "indexmap 2.2.6",
  "log",
- "protobuf 3.4.0",
+ "protobuf 3.5.0",
  "protobuf-support",
  "tempfile",
  "thiserror",
@@ -6380,9 +6374,9 @@ dependencies = [
 
 [[package]]
 name = "protobuf-support"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1ed294a835b0f30810e13616b1cd34943c6d1e84a8f3b0dcfe466d256c3e7e7"
+checksum = "70e2d30ab1878b2e72d1e2fc23ff5517799c9929e2cf81a8516f9f4dcf2b9cf3"
 dependencies = [
  "thiserror",
 ]
@@ -6569,7 +6563,7 @@ dependencies = [
  "actix-web",
  "anyhow",
  "assert-json-diff",
- "borsh 1.5.0",
+ "borsh 1.5.1",
  "chrono",
  "configuration",
  "database",
@@ -6611,7 +6605,7 @@ name = "readnode-primitives"
 version = "0.2.10"
 dependencies = [
  "anyhow",
- "borsh 1.5.0",
+ "borsh 1.5.1",
  "near-chain-configs 1.40.0",
  "near-indexer-primitives",
  "num-traits",
@@ -6621,9 +6615,9 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "0.25.3"
+version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6472825949c09872e8f2c50bde59fcefc17748b6be5c90fd67cd8b4daca73bfd"
+checksum = "e0d7a6955c7511f60f3ba9e86c6d02b3c3f144f8c24b288d1f4e18074ab8bbec"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -6660,11 +6654,11 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
+checksum = "c82cf8cff14456045f55ec4241383baeff27af886adb72ffb2162f99911de0fd"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
 ]
 
 [[package]]
@@ -6702,14 +6696,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.4"
+version = "1.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
+checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.6",
- "regex-syntax 0.8.3",
+ "regex-automata 0.4.7",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
@@ -6723,20 +6717,20 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.3",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
 name = "regex-lite"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b661b2f27137bdbc16f00eda72866a92bb28af1753ffbd56744fb6e2e9cd8e"
+checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
 
 [[package]]
 name = "regex-syntax"
@@ -6746,9 +6740,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "region"
@@ -7001,7 +6995,7 @@ version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "errno 0.3.9",
  "libc",
  "linux-raw-sys",
@@ -7160,7 +7154,7 @@ dependencies = [
  "chrono",
  "lz4_flex",
  "num-bigint 0.3.3",
- "num-bigint 0.4.5",
+ "num-bigint 0.4.6",
  "num_enum",
  "scylla-macros",
  "secrecy",
@@ -7180,7 +7174,7 @@ dependencies = [
  "darling 0.20.9",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -7237,7 +7231,7 @@ version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c627723fd09706bacdb5cf41499e95098555af3c3c29d014dc3c458ef6be11c0"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -7277,9 +7271,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.202"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "226b61a0d411b2ba5ff6d7f73a476ac4f8bb900373459cd00fab8512828ba395"
+checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
 dependencies = [
  "serde_derive",
 ]
@@ -7308,22 +7302,22 @@ dependencies = [
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b8497c313fd43ab992087548117643f6fcd935cbf36f176ffda0aacf9591734"
+checksum = "387cc504cb06bb40a96c8e04e951fe01854cf6bc921053c954e4a606d9675c6a"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.202"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6048858004bcff69094cd972ed40a32500f153bd3be9f716b2eed2e8217c4838"
+checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -7337,9 +7331,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.117"
+version = "1.0.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
+checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
 dependencies = [
  "itoa",
  "ryu",
@@ -7354,7 +7348,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -7380,9 +7374,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.8.1"
+version = "3.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad483d2ab0149d5a5ebcd9972a3852711e0153d863bf5a5d0391d28883c4a20"
+checksum = "079f3a42cd87588d924ed95b533f8d30a483388c4e400ab736a7058e34f16169"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -7398,14 +7392,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.8.1"
+version = "3.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65569b702f41443e8bc8bbb1c5779bd0450bbe723b56198980e80ec45780bce2"
+checksum = "bc03aad67c1d26b7de277d51c86892e7d9a0110a2fe44bf6b26cc569fba302d6"
 dependencies = [
  "darling 0.20.9",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -7642,7 +7636,7 @@ version = "0.2.10"
 dependencies = [
  "actix-web",
  "anyhow",
- "borsh 1.5.0",
+ "borsh 1.5.1",
  "clap",
  "configuration",
  "database",
@@ -7670,13 +7664,13 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stringprep"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb41d74e231a107a1b4ee36bd1214b11285b77768d2e3824aedafa988fd36ee6"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
 dependencies = [
- "finl_unicode",
  "unicode-bidi",
  "unicode-normalization",
+ "unicode-properties",
 ]
 
 [[package]]
@@ -7753,9 +7747,9 @@ dependencies = [
 
 [[package]]
 name = "subtle"
-version = "2.5.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -7770,9 +7764,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.65"
+version = "2.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2863d96a84c6439701d7a38f9de935ec562c8832cc55d1dde0f513b52fad106"
+checksum = "901fa70d88b9d6c98022e23b4136f9f3e54e4662c3bc1bd1d84a42a9a0f0c1e9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7788,7 +7782,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -7906,7 +7900,7 @@ checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -7984,9 +7978,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+checksum = "c55115c6fbe2d2bef26eb09ad74bde02d8255476fc0c7b515ef09fbb35742d82"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -7999,16 +7993,16 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.37.0"
+version = "1.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
+checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
  "mio",
  "num_cpus",
- "parking_lot 0.12.2",
+ "parking_lot 0.12.3",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -8029,13 +8023,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -8073,7 +8067,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "log",
- "parking_lot 0.12.2",
+ "parking_lot 0.12.3",
  "percent-encoding",
  "phf",
  "pin-project-lite",
@@ -8168,14 +8162,14 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.13"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4e43f8cc456c9704c851ae29c67e17ef65d2c30017c17a9765b89c382dc8bba"
+checksum = "6f49eb2ab21d2f26bd6db7bf383edc527a7ebaee412d17af4d40fdccd442f335"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.13",
+ "toml_edit 0.22.14",
 ]
 
 [[package]]
@@ -8213,15 +8207,15 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.13"
+version = "0.22.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c127785850e8c20836d49732ae6abfa47616e60bf9d9f57c43c250361a9db96c"
+checksum = "f21c7aaf97f1bd9ca9d4f9e73b0a6c74bd5afef56f2bc931943a6e1c37e04e38"
 dependencies = [
  "indexmap 2.2.6",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.8",
+ "winnow 0.6.13",
 ]
 
 [[package]]
@@ -8340,9 +8334,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-actix-web"
-version = "0.7.10"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa069bd1503dd526ee793bb3fce408895136c95fc86d2edb2acf1c646d7f0684"
+checksum = "4ee9e39a66d9b615644893ffc1704d2a89b5b315b7fd0228ad3182ca9a306b19"
 dependencies = [
  "actix-web",
  "mutually_exclusive_features",
@@ -8371,7 +8365,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -8526,7 +8520,7 @@ dependencies = [
 
 [[package]]
 name = "tx-details-storage"
-version = "0.2.5"
+version = "0.2.10"
 dependencies = [
  "anyhow",
  "aws-credential-types",
@@ -8540,7 +8534,7 @@ version = "0.2.10"
 dependencies = [
  "actix-web",
  "anyhow",
- "borsh 1.5.0",
+ "borsh 1.5.1",
  "clap",
  "configuration",
  "database",
@@ -8614,6 +8608,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-properties"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4259d9d4425d9f0661581b804cb85fe66a4c631cadd8f490d1c13a35d5d9291"
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8621,9 +8621,9 @@ checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
+checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -8645,9 +8645,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.0"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
+checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -8662,15 +8662,15 @@ checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8parse"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.8.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
+checksum = "5de17fd2f7da591098415cff336e12965a28061ddace43b59cb3c430179c9439"
 dependencies = [
  "getrandom 0.2.15",
 ]
@@ -8759,7 +8759,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.68",
  "wasm-bindgen-shared",
 ]
 
@@ -8793,7 +8793,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.68",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -9069,7 +9069,7 @@ dependencies = [
  "indexmap 2.2.6",
  "libc",
  "log",
- "object",
+ "object 0.32.2",
  "once_cell",
  "paste",
  "psm",
@@ -9109,9 +9109,9 @@ dependencies = [
  "cranelift-frontend",
  "cranelift-native",
  "cranelift-wasm",
- "gimli",
+ "gimli 0.28.1",
  "log",
- "object",
+ "object 0.32.2",
  "target-lexicon 0.12.14",
  "thiserror",
  "wasmparser 0.115.0",
@@ -9130,8 +9130,8 @@ dependencies = [
  "cranelift-codegen",
  "cranelift-control",
  "cranelift-native",
- "gimli",
- "object",
+ "gimli 0.28.1",
+ "object 0.32.2",
  "target-lexicon 0.12.14",
  "wasmtime-environ",
 ]
@@ -9144,10 +9144,10 @@ checksum = "fb6a445ce2b2810127caee6c1b79b8da4ae57712b05556a674592c18b7500a14"
 dependencies = [
  "anyhow",
  "cranelift-entity",
- "gimli",
+ "gimli 0.28.1",
  "indexmap 2.2.6",
  "log",
- "object",
+ "object 0.32.2",
  "serde",
  "serde_derive",
  "target-lexicon 0.12.14",
@@ -9162,14 +9162,14 @@ version = "14.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f0f6586c61125fbfc13c3108c3dd565d21f314dd5bac823b9a5b7ab576d21f1"
 dependencies = [
- "addr2line",
+ "addr2line 0.21.0",
  "anyhow",
  "bincode",
  "cfg-if 1.0.0",
  "cpp_demangle",
- "gimli",
+ "gimli 0.28.1",
  "log",
- "object",
+ "object 0.32.2",
  "rustc-demangle",
  "rustix",
  "serde",
@@ -9251,7 +9251,7 @@ checksum = "09b5575a75e711ca6c36bb9ad647c93541cdc8e34218031acba5da3f35919dd3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -9326,9 +9326,9 @@ dependencies = [
 
 [[package]]
 name = "wildmatch"
-version = "2.3.3"
+version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "939e59c1bc731542357fdaad98b209ef78c8743d652bb61439d16b16a79eb025"
+checksum = "3928939971918220fed093266b809d1ee4ec6c1a2d72692ff6876898f3b16c19"
 
 [[package]]
 name = "winapi"
@@ -9521,9 +9521,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.6.8"
+version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c52e9c97a68071b23e836c9380edae937f17b9c4667bd021973efc689f618d"
+checksum = "59b5e5f6c299a3c7890b876a2a587f3115162487e704907d9b6cd29473052ba1"
 dependencies = [
  "memchr",
 ]
@@ -9576,29 +9576,29 @@ checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "zerocopy"
-version = "0.7.34"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae87e3fcd617500e5d106f0380cf7b77f3c6092aae37191433159dda23cfb087"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.34"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.68",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.7.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
 name = "zeropool-bn"
@@ -9633,9 +9633,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.10+zstd.1.5.6"
+version = "2.0.11+zstd.1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c253a4914af5bafc8fa8c86ee400827e83cf6ec01195ec1f1ed8441bf00d65aa"
+checksum = "75652c55c0b6f3e6f12eb786fe1bc960396bf05a1eb3bf1f3691c3610ac2e6d4"
 dependencies = [
  "cc",
  "pkg-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "readnode-primitives",
     "rpc-server",
     "state-indexer",
+    "tx-details-storage",
     "tx-indexer",
 ]
 
@@ -38,6 +39,7 @@ configuration = { path = "configuration" }
 database = { path = "database" }
 readnode-primitives = { path = "readnode-primitives" }
 epoch-indexer = { path = "epoch-indexer" }
+tx-details-storage = { path = "tx-details-storage" }
 
 # Please, update the supported nearcore version in .cargo/config.toml file
 near-async = { git = 'https://github.com/kobayurii/nearcore.git', branch = "1.40.0-fork" }

--- a/config.toml
+++ b/config.toml
@@ -42,6 +42,13 @@ aws_secret_access_key = "${AWS_SECRET_ACCESS_KEY}"
 aws_default_region = "${AWS_DEFAULT_REGION}"
 aws_bucket_name = "${AWS_BUCKET_NAME}"
 
+[tx_details_storage]
+aws_access_key_id = "${TX_AWS_ACCESS_KEY_ID}"
+aws_secret_access_key = "${TX_AWS_SECRET_ACCESS_KEY}"
+aws_default_region = "${TX_AWS_DEFAULT_REGION}"
+aws_bucket_name = "${TX_AWS_BUCKET_NAME}"
+aws_endpoint = "${TX_AWS_ENDPOINT}"
+
 [database]
 database_url = "${DATABASE_URL}"
 database_user = "${DATABASE_USER}"

--- a/configuration/example.config.toml
+++ b/configuration/example.config.toml
@@ -138,6 +138,27 @@ aws_default_region = "eu-central-1"
 ## Lake framework bucket name
 aws_bucket_name = "near-lake-data-mainnet"
 
+[tx_details_storage]
+## Transaction details are stored in the S3-compatibe object storage (Google Cloud Storage by default)
+## You can use any S3-compatible object storage
+## Storage Access Key ID
+aws_access_key_id = "${TX_AWS_ACCESS_KEY_ID}"
+
+# Storage Secret Access Key
+aws_secret_access_key = "${TX_AWS_SECRET_ACCESS_KEY}"
+
+# Storage Region
+aws_default_region = "eu-central-1"
+
+# Storage Bucket Name
+aws_bucket_name = "readrpc-tx-details"
+
+# Storage Endpoint
+# Default value is "https://storage.googleapis.com" pointing to Google Cloud Storage
+# You can use any S3-compatible object storage, e.g. "https://s3.amazonaws.com"
+# or MinIO "http://127.0.0.1:9000"
+aws_endpoint = "https://storage.googleapis.com"
+
 ## Database configuration
 [database]
 

--- a/configuration/src/configs/mod.rs
+++ b/configuration/src/configs/mod.rs
@@ -9,6 +9,7 @@ pub(crate) mod database;
 pub(crate) mod general;
 mod lake;
 mod rightsizing;
+mod tx_details_storage;
 
 lazy_static::lazy_static! {
     static ref RE_NAME_ENV: regex::Regex = regex::Regex::new(r"\$\{(?<env_name>\w+)}").unwrap();
@@ -80,6 +81,7 @@ pub struct CommonConfig {
     pub rightsizing: rightsizing::CommonRightsizingConfig,
     pub lake_config: lake::CommonLakeConfig,
     pub database: database::CommonDatabaseConfig,
+    pub tx_details_storage: tx_details_storage::CommonTxDetailStorageConfig,
 }
 
 pub trait Config {
@@ -109,6 +111,7 @@ pub struct TxIndexerConfig {
     pub rightsizing: rightsizing::RightsizingConfig,
     pub lake_config: lake::LakeConfig,
     pub database: database::DatabaseConfig,
+    pub tx_details_storage: tx_details_storage::TxDetailsStorageConfig,
 }
 
 impl TxIndexerConfig {
@@ -127,6 +130,9 @@ impl Config for TxIndexerConfig {
             rightsizing: common_config.rightsizing.into(),
             lake_config: common_config.lake_config.into(),
             database: database::DatabaseTxIndexerConfig::from(common_config.database).into(),
+            tx_details_storage: tx_details_storage::TxDetailsStorageConfig::from(
+                common_config.tx_details_storage,
+            ),
         }
     }
 }

--- a/configuration/src/configs/mod.rs
+++ b/configuration/src/configs/mod.rs
@@ -93,6 +93,7 @@ pub struct RpcServerConfig {
     pub general: general::GeneralRpcServerConfig,
     pub lake_config: lake::LakeConfig,
     pub database: database::DatabaseConfig,
+    pub tx_details_storage: tx_details_storage::TxDetailsStorageConfig,
 }
 
 impl Config for RpcServerConfig {
@@ -101,6 +102,9 @@ impl Config for RpcServerConfig {
             general: common_config.general.into(),
             lake_config: common_config.lake_config.into(),
             database: database::DatabaseRpcServerConfig::from(common_config.database).into(),
+            tx_details_storage: tx_details_storage::TxDetailsStorageConfig::from(
+                common_config.tx_details_storage,
+            ),
         }
     }
 }

--- a/configuration/src/configs/tx_details_storage.rs
+++ b/configuration/src/configs/tx_details_storage.rs
@@ -1,0 +1,80 @@
+use serde_derive::Deserialize;
+
+use crate::configs::{deserialize_optional_data_or_env, required_value_or_panic};
+
+const DEFAULT_GCP_ENDPOINT_URL: &str = "https://storage.googleapis.com";
+
+#[derive(Debug, Clone)]
+pub struct TxDetailsStorageConfig {
+    pub aws_access_key_id: String,
+    pub aws_secret_access_key: String,
+    pub aws_default_region: String,
+    pub aws_bucket_name: String,
+    pub aws_endpoint: Option<String>,
+}
+
+impl TxDetailsStorageConfig {
+    pub async fn s3_config(&self) -> aws_sdk_s3::Config {
+        let credentials = aws_credential_types::Credentials::new(
+            &self.aws_access_key_id,
+            &self.aws_secret_access_key,
+            None,
+            None,
+            "",
+        );
+        aws_sdk_s3::Config::builder()
+            .credentials_provider(credentials)
+            .endpoint_url(
+                self.aws_endpoint
+                    .clone()
+                    .unwrap_or_else(|| DEFAULT_GCP_ENDPOINT_URL.to_string()),
+            )
+            .region(aws_types::region::Region::new(
+                self.aws_default_region.clone(),
+            ))
+            .build()
+    }
+
+    pub async fn storage_client(&self) -> aws_sdk_s3::Client {
+        let s3_config = self.s3_config().await;
+        aws_sdk_s3::Client::from_conf(s3_config)
+    }
+}
+
+#[derive(Deserialize, Debug, Clone, Default)]
+pub struct CommonTxDetailStorageConfig {
+    #[serde(deserialize_with = "deserialize_optional_data_or_env", default)]
+    pub aws_access_key_id: Option<String>,
+    #[serde(deserialize_with = "deserialize_optional_data_or_env", default)]
+    pub aws_secret_access_key: Option<String>,
+    #[serde(deserialize_with = "deserialize_optional_data_or_env", default)]
+    pub aws_default_region: Option<String>,
+    #[serde(deserialize_with = "deserialize_optional_data_or_env", default)]
+    pub aws_bucket_name: Option<String>,
+    #[serde(deserialize_with = "deserialize_optional_data_or_env", default)]
+    pub aws_endpoint: Option<String>,
+}
+
+impl From<CommonTxDetailStorageConfig> for TxDetailsStorageConfig {
+    fn from(common_config: CommonTxDetailStorageConfig) -> Self {
+        Self {
+            aws_access_key_id: required_value_or_panic(
+                "aws_access_key_id",
+                common_config.aws_access_key_id,
+            ),
+            aws_secret_access_key: required_value_or_panic(
+                "aws_secret_access_key",
+                common_config.aws_secret_access_key,
+            ),
+            aws_default_region: required_value_or_panic(
+                "aws_default_region",
+                common_config.aws_default_region,
+            ),
+            aws_bucket_name: required_value_or_panic(
+                "aws_bucket_name",
+                common_config.aws_bucket_name,
+            ),
+            aws_endpoint: common_config.aws_endpoint,
+        }
+    }
+}

--- a/database/src/scylladb/tx_indexer.rs
+++ b/database/src/scylladb/tx_indexer.rs
@@ -415,7 +415,7 @@ impl crate::TxIndexerDbManager for ScyllaDBManager {
                     session,
                     prepared,
                     token_val_range_start,
-                    token_val_range_start + step - 1,
+                    token_val_range_start.saturating_add(step).saturating_sub(1),
                 )
                 .await;
                 let _permit = permit;

--- a/rpc-server/Cargo.toml
+++ b/rpc-server/Cargo.toml
@@ -42,6 +42,7 @@ sysinfo = "0.30.5"
 configuration.workspace = true
 database.workspace = true
 readnode-primitives.workspace = true
+tx-details-storage.workspace = true
 
 near-async.workspace = true
 near-chain-configs.workspace = true

--- a/rpc-server/src/metrics.rs
+++ b/rpc-server/src/metrics.rs
@@ -107,6 +107,13 @@ lazy_static! {
         "Optimistic updating status. 0: working, 1: not working",
     ).unwrap();
 
+    pub(crate) static ref LEGACY_DATABASE_TX_DETAILS: IntCounterVec = register_int_counter_vec(
+        "legacy_database_tx_details",
+        "Total number of calls to the legacy database for transaction details",
+        // This declares a label named `lookup_type` to differentiate "finished" and "in_progress" transaction lookups
+        &["lookup_type"]
+    ).unwrap();
+
     // Error metrics
     // 0: ReadRPC success, NEAR RPC success"
     // 1: ReadRPC success, NEAR RPC error"

--- a/rpc-server/src/modules/transactions/mod.rs
+++ b/rpc-server/src/modules/transactions/mod.rs
@@ -1,1 +1,34 @@
+use jsonrpc_v2::Data;
+
+use crate::config::ServerContext;
+
 pub mod methods;
+
+/// Helper method that tries to find the transaction in the object storage by its hash.
+/// If the transaction is not found in the storage it might be because it hasn't finished yet
+/// and can be retrieved from the database cache table.
+/// If the transaction is not found neither in the storage nor in the cache table this helper returns error.
+pub(crate) async fn try_get_transaction_details_by_hash(
+    data: &Data<ServerContext>,
+    tx_hash: &str,
+) -> anyhow::Result<readnode_primitives::TransactionDetails> {
+    match data.tx_details_storage.retrieve(tx_hash).await {
+        Ok(transaction_details_bytes) => {
+            let transaction_details = borsh::from_slice::<readnode_primitives::TransactionDetails>(
+                &transaction_details_bytes,
+            )?;
+            Ok(transaction_details)
+        }
+        Err(_) => {
+            tracing::debug!(
+                "Transaction with hash {} is not found in the object storage. Trying to find it in the cache table",
+                tx_hash
+            );
+            let transaction_details = data
+                .db_manager
+                .get_indexing_transaction_by_hash(tx_hash)
+                .await?;
+            Ok(transaction_details)
+        }
+    }
+}

--- a/rpc-server/src/modules/transactions/mod.rs
+++ b/rpc-server/src/modules/transactions/mod.rs
@@ -44,6 +44,10 @@ pub(crate) async fn try_get_transaction_details_by_hash(
                         tx_hash,
                     );
                     // TODO: Except this. The cache search should stay, though refactored to the new cache solution
+                    // increase legacy database transaction details lookup metrics for in_progress transactions
+                    crate::metrics::LEGACY_DATABASE_TX_DETAILS
+                        .with_label_values(&["in_progress"])
+                        .inc();
                     let (_, transaction_details) = data
                         .db_manager
                         .get_indexing_transaction_by_hash(&tx_hash.to_string(), method_name)
@@ -62,6 +66,10 @@ async fn legacy_try_get_transaction_details_by_hash(
     tx_hash: &str,
     method_name: &str,
 ) -> anyhow::Result<readnode_primitives::TransactionDetails> {
+    // increase legacy database transaction details lookup metrics for finished transactions
+    crate::metrics::LEGACY_DATABASE_TX_DETAILS
+        .with_label_values(&["finished"])
+        .inc();
     let (block_height, transaction_details) = data
         .db_manager
         .get_transaction_by_hash(tx_hash, method_name)

--- a/rpc-server/src/modules/transactions/mod.rs
+++ b/rpc-server/src/modules/transactions/mod.rs
@@ -4,15 +4,20 @@ use crate::config::ServerContext;
 
 pub mod methods;
 
+/// MIGRATION NOTE: Additionally this method will try to find the transaction
+/// in the legacy database table between object storage and cache table.
+/// REMOVE this comment after the migration to the new object storage is completely finished.
+///
 /// Helper method that tries to find the transaction in the object storage by its hash.
 /// If the transaction is not found in the storage it might be because it hasn't finished yet
 /// and can be retrieved from the database cache table.
 /// If the transaction is not found neither in the storage nor in the cache table this helper returns error.
 pub(crate) async fn try_get_transaction_details_by_hash(
     data: &Data<ServerContext>,
-    tx_hash: &str,
+    tx_hash: &near_indexer_primitives::CryptoHash,
+    method_name: &str,
 ) -> anyhow::Result<readnode_primitives::TransactionDetails> {
-    match data.tx_details_storage.retrieve(tx_hash).await {
+    match data.tx_details_storage.retrieve(&tx_hash.to_string()).await {
         Ok(transaction_details_bytes) => {
             let transaction_details = borsh::from_slice::<readnode_primitives::TransactionDetails>(
                 &transaction_details_bytes,
@@ -21,14 +26,57 @@ pub(crate) async fn try_get_transaction_details_by_hash(
         }
         Err(_) => {
             tracing::debug!(
-                "Transaction with hash {} is not found in the object storage. Trying to find it in the cache table",
+                "Transaction with hash {} is not found in the object storage. Trying to find it in the legacy database table.",
                 tx_hash
             );
-            let transaction_details = data
-                .db_manager
-                .get_indexing_transaction_by_hash(tx_hash)
-                .await?;
-            Ok(transaction_details)
+            // TODO: remove this logic after the migration to the new object storage is completely finished
+            match legacy_try_get_transaction_details_by_hash(
+                data,
+                &tx_hash.to_string(),
+                method_name,
+            )
+            .await
+            {
+                Ok(transaction_details) => Ok(transaction_details),
+                Err(_err) => {
+                    tracing::error!(
+                        "Transaction with hash {} is not found in the legacy database table. Last try to find it in the cache table of the database",
+                        tx_hash,
+                    );
+                    // TODO: Except this. The cache search should stay, though refactored to the new cache solution
+                    let (_, transaction_details) = data
+                        .db_manager
+                        .get_indexing_transaction_by_hash(&tx_hash.to_string(), method_name)
+                        .await?;
+                    Ok(transaction_details)
+                }
+            }
         }
     }
+}
+
+// TODO: remove this after the migration to the new object storage is completely finished
+/// Helper method that tries to find the transaction in the legacy database table by its hash.
+async fn legacy_try_get_transaction_details_by_hash(
+    data: &Data<ServerContext>,
+    tx_hash: &str,
+    method_name: &str,
+) -> anyhow::Result<readnode_primitives::TransactionDetails> {
+    let (block_height, transaction_details) = data
+        .db_manager
+        .get_transaction_by_hash(tx_hash, method_name)
+        .await?;
+
+    // increase block category metrics
+    crate::metrics::increase_request_category_metrics(
+        data,
+        &near_primitives::types::BlockReference::BlockId(near_primitives::types::BlockId::Height(
+            block_height,
+        )),
+        method_name,
+        Some(block_height),
+    )
+    .await;
+
+    Ok(transaction_details)
 }

--- a/tx-details-storage/Cargo.toml
+++ b/tx-details-storage/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "tx-details-storage"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+license.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+aws-credential-types = "1.1.4"
+anyhow = "1.0.70"
+aws-sdk-s3 = { version = "1.14.0", features = ["behavior-version-latest"] }
+aws-types = "1.1.4"

--- a/tx-details-storage/README.md
+++ b/tx-details-storage/README.md
@@ -1,0 +1,15 @@
+# tx-details-storage
+
+This is a small library that provides the interface to store and retrieve `TransactionDetails` to/from bucket. The functionality is extracted into this separate library to provide a common interface for all the components that need to store and retrieve `TransactionDetails` (e.g. `tx-indexer` and `rpc-server`).
+
+`TransactionDetails` is a data class defined in the `readnode-primitives` module, it contains all the details of the transactions:
+- `SignedTransactionView` itself
+- `ExecutionOutcomeWithIdView` of the transaction
+- All `ReceiptView`s of the transaction
+- All `ExecutionOutcomeWithIdView`s of the receipts
+- `FinalExecutionStatus` of the transaction
+
+This entire structuer is borsh-serialized and stored in the bucket.
+
+**This library doesn't handle the serialization/deserialization of the `TransactionDetails` struct. It is the responsibility of the caller to serialize/deserialize the struct before storing/retrieving it from the bucket.**
+

--- a/tx-details-storage/src/lib.rs
+++ b/tx-details-storage/src/lib.rs
@@ -1,0 +1,47 @@
+use anyhow::Context;
+use aws_sdk_s3::primitives::ByteStream;
+
+pub struct TxDetailsStorage {
+    client: aws_sdk_s3::Client,
+    bucket_name: String,
+}
+
+impl TxDetailsStorage {
+    /// Create a new instance of the `TxDetailsStorage` struct.
+    pub fn new(client: aws_sdk_s3::Client, bucket_name: String) -> Self {
+        Self {
+            client,
+            bucket_name,
+        }
+    }
+
+    pub async fn store(&self, key: &str, data: Vec<u8>) -> anyhow::Result<()> {
+        self.client
+            .put_object()
+            .bucket(self.bucket_name.clone())
+            .key(key)
+            .body(ByteStream::from(data))
+            .send()
+            .await
+            .map(|_| ())
+            .context("Failed to store the data")
+    }
+
+    pub async fn retrieve(&self, key: &str) -> anyhow::Result<Vec<u8>> {
+        let response = self
+            .client
+            .get_object()
+            .bucket(self.bucket_name.clone())
+            .key(key)
+            .send()
+            .await
+            .context("Failed to retrieve the data")?;
+
+        let body = response
+            .body
+            .collect()
+            .await
+            .context("Failed to read the body")?;
+        Ok(body.to_vec())
+    }
+}

--- a/tx-indexer/Cargo.toml
+++ b/tx-indexer/Cargo.toml
@@ -29,6 +29,7 @@ tracing = "0.1.34"
 configuration.workspace = true
 database.workspace = true
 readnode-primitives.workspace = true
+tx-details-storage.workspace = true
 
 near-indexer-primitives.workspace = true
 near-jsonrpc-client.workspace = true

--- a/tx-indexer/src/collector.rs
+++ b/tx-indexer/src/collector.rs
@@ -104,7 +104,7 @@ async fn new_transaction_details_to_collecting_pool(
     if !indexer_config.tx_should_be_indexed(transaction) {
         return Ok(());
     };
-
+    crate::metrics::TX_IN_MEMORY_CACHE.inc();
     let converted_into_receipt_id = transaction
         .outcome
         .execution_outcome
@@ -365,6 +365,7 @@ async fn save_transaction_details(
                 }
             }
             Err(err) => {
+                crate::metrics::TX_STORE_ERRORS_TOTAL.inc();
                 tracing::error!(
                     target: crate::INDEXER,
                     "Failed to save transaction {} \n{:#?}",

--- a/tx-indexer/src/metrics.rs
+++ b/tx-indexer/src/metrics.rs
@@ -29,6 +29,21 @@ lazy_static! {
         "Last seen block height by indexer"
     )
     .unwrap();
+    pub(crate) static ref TX_IN_MEMORY_CACHE: IntGauge = try_create_int_gauge(
+        "tx_in_memory_cache",
+        "Number of transactions in memory cache"
+    )
+    .unwrap();
+    pub(crate) static ref RECEIPTS_IN_MEMORY_CACHE: IntGauge = try_create_int_gauge(
+        "receipts_in_memory_cache",
+        "Number of receipts in memory cache"
+    )
+    .unwrap();
+    pub(crate) static ref TX_STORE_ERRORS_TOTAL: IntCounter = try_create_int_counter(
+        "total_tx_store_errors",
+        "Total number of errors while storing transactions"
+    )
+    .unwrap();
 }
 
 #[get("/metrics")]

--- a/tx-indexer/src/storage.rs
+++ b/tx-indexer/src/storage.rs
@@ -208,6 +208,7 @@ impl HashStorageWithDB {
         receipt_id: String,
         transaction_key: readnode_primitives::TransactionKey,
     ) -> anyhow::Result<()> {
+        crate::metrics::RECEIPTS_IN_MEMORY_CACHE.inc();
         self.receipts_counters
             .write()
             .await
@@ -239,6 +240,7 @@ impl HashStorageWithDB {
             {
                 *receipts_counter -= 1;
             }
+            crate::metrics::RECEIPTS_IN_MEMORY_CACHE.dec();
             tracing::debug!(
                 target: crate::storage::STORAGE,
                 "-R {} - {}",


### PR DESCRIPTION
## Rational 

We noticed that the `transaction_details` table in ScyllaDB takes ~2 TB of data, directly affecting the infra cost. We want to reduce the cost even more. Building on our successful experience of serving some data directly from the NEAR Lake AWS S3 storage, we propose to move the `TransactionDetails` data to object storage (GSC) to further offload ScyllaDB.

Since this structure is stored in bytes (borsh-serialized), it doesn't make any big difference to the performance (though some increase in latency, anyway, is expected, not that significant to overpay).

### What is done

1. I've introduced a small crate (lib) `tx-details-storage` that interacts with the provided S3-compatible object storage to store and retrieve raw bytes
2. Extended the `configuration` crate with the dedicated config section for `tx-details-storage`. Updated `config.example.toml` to reflect new accepted parameters
3. Refactored `tx-indexer` to store the finished `TransactionDetails` to the object storage using the `tx-details-storage` library. **The library doesn't handle serialization/deserialization to keep it as simple as possible**, this is left for the indexer and rpc-server.
4. Refactored `rpc-server` to retrieve `TransactionDetails` from the object storage using the newly introduced library.
5. Additionally, I've extended the `tx-indexer` with a few metrics to monitor what's happening there.

**Important note:** Recently, we've adjusted the `rpc-server` to return half-baked (not finished, in progress) transaction details from the database cache table. This logic is preserved.

### Next steps

We must wait to deliver this change. We have yet to get the data in an object storage.

I plan to make it in three phases:

1. ✅ Create a small script that will walk over each transaction present in NEAR Protocol and copy the `TransactionDetails` from ScyllaDB to GCS. **This has to be done for both testnet and mainnet**
2. Start the new `tx-indexer` (from this PR) to continue collecting the data into the object storage
3. Replace the `rpc-server` instances with the new ones that can read from the object storage
4. (cleanup phase) Stop old `tx-indexer`s, drop `transaction_details` table from ScyllaDB, downscale ScyllaDB

### Update from 2024-07-03

The table `transaction_details` is growing and reaching the limits of the database we have right now. We don't want to scale it, so we need to stop the growth in the short-term. I refactored code a bit by leaving the legacy way of searching for the transaction in the database (Scylla) while we migrate.

I've added an additional metric for this `legacy_database_tx_details` to monitor the migration period. We expect that counters to be null for some time before we can consider migration as finished.