### PR TITLE
fix(rpc-server): Fix of the returned transaction results associated with the transaction hash collisions.

### DIFF
--- a/database/src/scylladb/rpc_server.rs
+++ b/database/src/scylladb/rpc_server.rs
@@ -124,7 +124,7 @@ impl ScyllaStorageManager for ScyllaDBManager {
             // ref: https://github.com/near/near-indexer-for-explorer/issues/84
             get_transaction_by_hash: Self::prepare_read_query(
                 &scylla_db_session,
-                "SELECT transaction_details FROM tx_indexer.transactions_details WHERE transaction_hash = ? LIMIT 1",
+                "SELECT transaction_details FROM tx_indexer.transactions_details WHERE transaction_hash = ? ORDER BY block_height ASC LIMIT 1",
             ).await?,
             get_indexing_transaction_by_hash: Self::prepare_read_query(
                 &scylla_db_session,


### PR DESCRIPTION
We have identified an issue with transaction hash collisions in the NEAR protocol, as detailed in [issue #84](https://github.com/near/near-indexer-for-explorer/issues/84). Specifically, there is an inconsistency in how transactions with the same hash are handled by different RPC endpoints.

**Issue**
- _RPC Near Protocol:_ Returns the first transaction for a given hash.
- _Read-RPC Server:_ Returns the last transaction for a given hash.

This discrepancy can lead to confusion and potential errors in transaction processing and data retrieval.

**Solution**
This pull request aims to standardize the behavior across both RPC endpoints to ensure consistent and predictable results when querying transactions by hash.

**Changes**
- Modify the query in the Read-RPC server to the ScyllaDB to align with the behavior of the RPC Near protocol, ensuring it returns the first transaction for a given hash.

**Related Issue**
[Transaction hash collision issue](https://github.com/near/near-indexer-for-explorer/issues/84)