### PR TITLE
Metrics(rpc-server): Extend metrics

### DIFF
--- a/rpc-server/src/metrics.rs
+++ b/rpc-server/src/metrics.rs
@@ -125,7 +125,7 @@ lazy_static! {
 /// Main idea is to have a single place to increment metrics
 /// It should help to analyze the most popular requests
 /// And build s better caching strategy
-pub async fn increase_block_category_metrics(
+pub async fn increase_request_category_metrics(
     data: &jsonrpc_v2::Data<crate::config::ServerContext>,
     block_reference: &near_primitives::types::BlockReference,
     block_height: Option<u64>,
@@ -137,26 +137,26 @@ pub async fn increase_block_category_metrics(
                 final_block.block_height - 5 * data.genesis_info.genesis_config.epoch_length;
             if block_height.unwrap_or_default() > expected_earliest_available_block {
                 // This is request to regular nodes which includes 5 last epochs
-                REQUESTS_COUNTER.with_label_values(&["regula_block"]).inc();
+                REQUESTS_COUNTER.with_label_values(&["regular"]).inc();
             } else {
-                // This is request to archive nodes which includes oldest blocks than 5 last epochs
-                REQUESTS_COUNTER.with_label_values(&["archive_block"]).inc();
+                // This is a request to archival nodes which include blocks from genesis (later than 5 epochs ago)
+                REQUESTS_COUNTER.with_label_values(&["historical"]).inc();
             }
         }
         near_primitives::types::BlockReference::Finality(finality) => {
             match finality {
-                // Increase the FINAL_REQUESTS_TOTAL metric
+                // Increase the REQUESTS_COUNTER `final` metric
                 // if the request has final finality
                 near_primitives::types::Finality::DoomSlug
                 | near_primitives::types::Finality::Final => {
                     REQUESTS_COUNTER.with_label_values(&["final"]).inc();
                 }
-                // Increase the OPTIMISTIC_REQUESTS_TOTAL metric
+                // Increase the REQUESTS_COUNTER `optimistic` metric
                 // if the request has optimistic finality
                 near_primitives::types::Finality::None => {
                     REQUESTS_COUNTER.with_label_values(&["optimistic"]).inc();
-                    // Increase the PROXY_OPTIMISTIC_REQUESTS_TOTAL metric
-                    // if optimistic not updating and proxy to near-rpc
+                    // Increase the REQUESTS_COUNTER `proxy_optimistic` metric
+                    // if the optimistic is not updating and proxy to native JSON-RPC
                     if crate::metrics::OPTIMISTIC_UPDATING.is_not_working() {
                         REQUESTS_COUNTER
                             .with_label_values(&["proxy_optimistic"])
@@ -166,7 +166,7 @@ pub async fn increase_block_category_metrics(
             }
         }
         near_primitives::types::BlockReference::SyncCheckpoint(_) => {
-            REQUESTS_COUNTER.with_label_values(&["archive_block"]).inc();
+            REQUESTS_COUNTER.with_label_values(&["historical"]).inc();
         }
     }
 }

--- a/rpc-server/src/metrics.rs
+++ b/rpc-server/src/metrics.rs
@@ -1,6 +1,4 @@
-use crate::config::ServerContext;
 use actix_web::{get, Responder};
-use jsonrpc_v2::Data;
 use prometheus::{Encoder, IntCounterVec, IntGauge, IntGaugeVec, Opts};
 
 type Result<T, E> = std::result::Result<T, E>;
@@ -128,7 +126,7 @@ lazy_static! {
 /// It should help to analyze the most popular requests
 /// And build s better caching strategy
 pub async fn increase_block_category_metrics(
-    data: &Data<ServerContext>,
+    data: &jsonrpc_v2::Data<crate::config::ServerContext>,
     block_reference: &near_primitives::types::BlockReference,
     block_height: Option<u64>,
 ) {

--- a/rpc-server/src/modules/blocks/methods.rs
+++ b/rpc-server/src/modules/blocks/methods.rs
@@ -25,7 +25,7 @@ pub async fn block(
     {
         if crate::metrics::OPTIMISTIC_UPDATING.is_not_working() {
             // increase metrics before proxy request
-            crate::metrics::increase_block_category_metrics(
+            crate::metrics::increase_request_category_metrics(
                 &data,
                 &block_request.block_reference,
                 None,
@@ -82,7 +82,7 @@ pub async fn changes_in_block_by_type(
     {
         if crate::metrics::OPTIMISTIC_UPDATING.is_not_working() {
             // increase metrics before proxy request
-            crate::metrics::increase_block_category_metrics(
+            crate::metrics::increase_request_category_metrics(
                 &data,
                 &changes_in_block_request.block_reference,
                 None,
@@ -115,7 +115,7 @@ pub async fn changes_in_block(
     {
         if crate::metrics::OPTIMISTIC_UPDATING.is_not_working() {
             // increase metrics before proxy request
-            crate::metrics::increase_block_category_metrics(
+            crate::metrics::increase_request_category_metrics(
                 &data,
                 &changes_in_block_request.block_reference,
                 None,
@@ -140,7 +140,7 @@ async fn block_call(
     let result = match fetch_block(&data, &block_request.block_reference, "block").await {
         Ok(block) => {
             // increase block category metrics
-            crate::metrics::increase_block_category_metrics(
+            crate::metrics::increase_request_category_metrics(
                 &data,
                 &block_request.block_reference,
                 Some(block.block_view.header.height),
@@ -193,7 +193,7 @@ async fn changes_in_block_call(
     .map_err(near_jsonrpc::primitives::errors::RpcError::from)?;
 
     // increase block category metrics
-    crate::metrics::increase_block_category_metrics(
+    crate::metrics::increase_request_category_metrics(
         &data,
         &params.block_reference,
         Some(cache_block.block_height),
@@ -234,7 +234,7 @@ async fn changes_in_block_by_type_call(
             .map_err(near_jsonrpc::primitives::errors::RpcError::from)?;
 
     // increase block category metrics
-    crate::metrics::increase_block_category_metrics(
+    crate::metrics::increase_request_category_metrics(
         &data,
         &params.block_reference,
         Some(cache_block.block_height),

--- a/rpc-server/src/modules/blocks/methods.rs
+++ b/rpc-server/src/modules/blocks/methods.rs
@@ -191,7 +191,7 @@ async fn changes_in_block_call(
     )
     .await
     .map_err(near_jsonrpc::primitives::errors::RpcError::from)?;
-    
+
     // increase block category metrics
     crate::metrics::increase_block_category_metrics(
         &data,

--- a/rpc-server/src/modules/blocks/methods.rs
+++ b/rpc-server/src/modules/blocks/methods.rs
@@ -23,17 +23,15 @@ pub async fn block(
         near_primitives::types::Finality::None,
     ) = &block_request.block_reference
     {
-        // Increase the OPTIMISTIC_REQUESTS_TOTAL metric
-        // if the request has optimistic finality
-        crate::metrics::REQUESTS_COUNTER
-            .with_label_values(&["optimistic"])
-            .inc();
         if crate::metrics::OPTIMISTIC_UPDATING.is_not_working() {
-            // Increase the PROXY_OPTIMISTIC_REQUESTS_TOTAL metric
-            // if optimistic not updating and proxy to near-rpc
-            crate::metrics::REQUESTS_COUNTER
-                .with_label_values(&["proxy_optimistic"])
-                .inc();
+            // increase metrics before proxy request
+            crate::metrics::increase_block_category_metrics(
+                &data,
+                &block_request.block_reference,
+                None,
+            )
+            .await;
+            // Proxy if the optimistic updating is not working
             let block_view = data.near_rpc_client.call(block_request).await?;
             return Ok(near_jsonrpc::primitives::types::blocks::RpcBlockResponse { block_view });
         }
@@ -82,17 +80,15 @@ pub async fn changes_in_block_by_type(
         near_primitives::types::Finality::None,
     ) = &changes_in_block_request.block_reference
     {
-        // Increase the OPTIMISTIC_REQUESTS_TOTAL metric
-        // if the request has optimistic finality
-        crate::metrics::REQUESTS_COUNTER
-            .with_label_values(&["optimistic"])
-            .inc();
         if crate::metrics::OPTIMISTIC_UPDATING.is_not_working() {
-            // Increase the PROXY_OPTIMISTIC_REQUESTS_TOTAL metric
-            // if optimistic not updating and proxy to near-rpc
-            crate::metrics::REQUESTS_COUNTER
-                .with_label_values(&["proxy_optimistic"])
-                .inc();
+            // increase metrics before proxy request
+            crate::metrics::increase_block_category_metrics(
+                &data,
+                &changes_in_block_request.block_reference,
+                None,
+            )
+            .await;
+            // Proxy if the optimistic updating is not working
             return Ok(data.near_rpc_client.call(changes_in_block_request).await?);
         }
     };
@@ -117,17 +113,15 @@ pub async fn changes_in_block(
         near_primitives::types::Finality::None,
     ) = &changes_in_block_request.block_reference
     {
-        // Increase the OPTIMISTIC_REQUESTS_TOTAL metric
-        // if the request has optimistic finality
-        crate::metrics::REQUESTS_COUNTER
-            .with_label_values(&["optimistic"])
-            .inc();
         if crate::metrics::OPTIMISTIC_UPDATING.is_not_working() {
-            // Increase the PROXY_OPTIMISTIC_REQUESTS_TOTAL metric
-            // if optimistic not updating and proxy to near-rpc
-            crate::metrics::REQUESTS_COUNTER
-                .with_label_values(&["proxy_optimistic"])
-                .inc();
+            // increase metrics before proxy request
+            crate::metrics::increase_block_category_metrics(
+                &data,
+                &changes_in_block_request.block_reference,
+                None,
+            )
+            .await;
+            // Proxy if the optimistic updating is not working
             return Ok(data.near_rpc_client.call(changes_in_block_request).await?);
         }
     };
@@ -143,7 +137,19 @@ async fn block_call(
     mut block_request: near_jsonrpc::primitives::types::blocks::RpcBlockRequest,
 ) -> Result<near_jsonrpc::primitives::types::blocks::RpcBlockResponse, RPCError> {
     tracing::debug!("`block` called with parameters: {:?}", block_request);
-    let result = fetch_block(&data, &block_request.block_reference, "block").await;
+    let result = match fetch_block(&data, &block_request.block_reference, "block").await {
+        Ok(block) => {
+            // increase block category metrics
+            crate::metrics::increase_block_category_metrics(
+                &data,
+                &block_request.block_reference,
+                Some(block.block_view.header.height),
+            )
+            .await;
+            Ok(block)
+        }
+        Err(err) => Err(err),
+    };
 
     #[cfg(feature = "shadow_data_consistency")]
     {
@@ -185,6 +191,15 @@ async fn changes_in_block_call(
     )
     .await
     .map_err(near_jsonrpc::primitives::errors::RpcError::from)?;
+    
+    // increase block category metrics
+    crate::metrics::increase_block_category_metrics(
+        &data,
+        &params.block_reference,
+        Some(cache_block.block_height),
+    )
+    .await;
+
     let result = fetch_changes_in_block(&data, cache_block, &params.block_reference).await;
     #[cfg(feature = "shadow_data_consistency")]
     {
@@ -217,6 +232,15 @@ async fn changes_in_block_by_type_call(
         fetch_block_from_cache_or_get(&data, &params.block_reference, "EXPERIMENTAL_changes")
             .await
             .map_err(near_jsonrpc::primitives::errors::RpcError::from)?;
+
+    // increase block category metrics
+    crate::metrics::increase_block_category_metrics(
+        &data,
+        &params.block_reference,
+        Some(cache_block.block_height),
+    )
+    .await;
+
     let result = fetch_changes_in_block_by_type(
         &data,
         cache_block,

--- a/rpc-server/src/modules/queries/methods.rs
+++ b/rpc-server/src/modules/queries/methods.rs
@@ -27,7 +27,7 @@ pub async fn query(
     {
         return if crate::metrics::OPTIMISTIC_UPDATING.is_not_working() {
             // increase metrics before proxy request
-            crate::metrics::increase_block_category_metrics(
+            crate::metrics::increase_request_category_metrics(
                 &data,
                 &query_request.block_reference,
                 None,
@@ -59,7 +59,7 @@ async fn query_call(
         .map_err(near_jsonrpc::primitives::errors::RpcError::from)?;
 
     // increase block category metrics
-    crate::metrics::increase_block_category_metrics(
+    crate::metrics::increase_request_category_metrics(
         data,
         &query_request.block_reference,
         Some(block.block_height),

--- a/rpc-server/src/modules/queries/methods.rs
+++ b/rpc-server/src/modules/queries/methods.rs
@@ -57,7 +57,7 @@ async fn query_call(
     let block = fetch_block_from_cache_or_get(data, &query_request.block_reference, "query")
         .await
         .map_err(near_jsonrpc::primitives::errors::RpcError::from)?;
-    
+
     // increase block category metrics
     crate::metrics::increase_block_category_metrics(
         data,


### PR DESCRIPTION
This pull request introduces new metrics for categorizing blocks based on their age and relevance. 
The categories added are:

- optimistic
- final
- regular (5 epochs)
- historical (more than 5 epochs)

These new metrics will enable us to track and analyze the frequency and distribution of different block queries. Understanding the usage patterns will help us to optimize our caching strategy, improving performance and efficiency.