### PR TITLE
feat: added `view_receipt_record` rpc endpoint

### DIFF
--- a/docs/CUSTOM_RPC_METHODS.md
+++ b/docs/CUSTOM_RPC_METHODS.md
@@ -85,3 +85,34 @@ Next page response:
 ```
 In the last page response `next_page_token` field will be `null`.
 
+# view_receipt_record
+
+The `view_receipt_record` method is a custom method that allows you to view the record of the receipt by its ID.
+
+## How to use it
+### Example
+
+Request:
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "dontcare",
+  "method": "view_receipt_record",
+  "params": {
+    "receipt_id": "6aB1XxfnhuQ83FWHb5xyqssGnaD5CUQgxHpbAVJFRrPe"
+  }
+}
+```
+Response:
+```json
+{
+  "id": "dontcare",
+  "jsonrpc": "2.0",
+  "result": {
+    "block_height": 118875440,
+    "parent_transaction_hash": "6iJgcM5iZrWuhG4ZpUyX6ivtMQUho2S1JRdBYdY7Y7vX",
+    "receipt_id": "6aB1XxfnhuQ83FWHb5xyqssGnaD5CUQgxHpbAVJFRrPe",
+    "shard_id": 0
+  }
+}
+```

--- a/readnode-primitives/src/lib.rs
+++ b/readnode-primitives/src/lib.rs
@@ -177,7 +177,7 @@ pub struct QueryData<T: borsh::BorshDeserialize> {
     pub block_height: near_indexer_primitives::types::BlockHeight,
     pub block_hash: CryptoHash,
 }
-#[derive(serde::Serialize, serde::Deserialize, Debug)]
+
 pub struct ReceiptRecord {
     pub receipt_id: CryptoHash,
     pub parent_transaction_hash: CryptoHash,

--- a/readnode-primitives/src/lib.rs
+++ b/readnode-primitives/src/lib.rs
@@ -177,6 +177,7 @@ pub struct QueryData<T: borsh::BorshDeserialize> {
     pub block_height: near_indexer_primitives::types::BlockHeight,
     pub block_hash: CryptoHash,
 }
+#[derive(serde::Serialize, serde::Deserialize, Debug)]
 pub struct ReceiptRecord {
     pub receipt_id: CryptoHash,
     pub parent_transaction_hash: CryptoHash,

--- a/rpc-server/src/main.rs
+++ b/rpc-server/src/main.rs
@@ -91,6 +91,10 @@ async fn main() -> anyhow::Result<()> {
             "view_state_paginated",
             modules::state::methods::view_state_paginated,
         )
+        .with_method(
+            "view_receipt_record",
+            modules::receipts::methods::view_receipt_record,
+        )
         // requests methods
         .with_method("query", modules::queries::methods::query)
         // basic requests methods

--- a/rpc-server/src/modules/receipts/methods.rs
+++ b/rpc-server/src/modules/receipts/methods.rs
@@ -36,14 +36,16 @@ pub async fn receipt(
 pub async fn view_receipt_record(
     data: Data<ServerContext>,
     Params(params): Params<serde_json::Value>,
-) -> Result<readnode_primitives::ReceiptRecord, RPCError> {
+) -> Result<crate::modules::receipts::RpcReceiptRecordResponse, RPCError> {
     tracing::debug!("`view_receipt_record` call. Params: {:?}", params);
     let receipt_request =
         near_jsonrpc::primitives::types::receipts::RpcReceiptRequest::parse(params)?;
 
     let result = fetch_receipt_record(&data, &receipt_request, "view_receipt_record").await;
 
-    Ok(result.map_err(near_jsonrpc::primitives::errors::RpcError::from)?)
+    Ok(result
+        .map_err(near_jsonrpc::primitives::errors::RpcError::from)?
+        .into())
 }
 
 #[cfg_attr(feature = "tracing-instrumentation", tracing::instrument(skip(data)))]

--- a/rpc-server/src/modules/receipts/mod.rs
+++ b/rpc-server/src/modules/receipts/mod.rs
@@ -1,1 +1,20 @@
 pub mod methods;
+
+#[derive(serde::Serialize, serde::Deserialize, Debug)]
+pub struct RpcReceiptRecordResponse {
+    pub receipt_id: near_indexer_primitives::CryptoHash,
+    pub parent_transaction_hash: near_indexer_primitives::CryptoHash,
+    pub block_height: near_indexer_primitives::types::BlockHeight,
+    pub shard_id: near_indexer_primitives::types::ShardId,
+}
+
+impl From<readnode_primitives::ReceiptRecord> for RpcReceiptRecordResponse {
+    fn from(receipt: readnode_primitives::ReceiptRecord) -> Self {
+        Self {
+            receipt_id: receipt.receipt_id,
+            parent_transaction_hash: receipt.parent_transaction_hash,
+            block_height: receipt.block_height,
+            shard_id: receipt.shard_id,
+        }
+    }
+}


### PR DESCRIPTION
Here's an example of calling `view_receipt_record`:
<img width="1063" alt="image" src="https://github.com/near/read-rpc/assets/59515280/6209422d-e152-44e9-a482-c0bb23949647">

closes #264 