### PR TITLE
(rpc_server): Extend metrics

### DIFF
--- a/database/src/base/rpc_server.rs
+++ b/database/src/base/rpc_server.rs
@@ -90,18 +90,21 @@ pub trait ReaderDbManager {
     ) -> anyhow::Result<readnode_primitives::ReceiptRecord>;
 
     /// Returns the readnode_primitives::TransactionDetails at the given transaction hash
+    /// TODO: rewrite this method to return a Result like a struct with block_height and transaction_details instead of a tuple
     async fn get_transaction_by_hash(
         &self,
         transaction_hash: &str,
         method_name: &str,
     ) -> anyhow::Result<(u64, readnode_primitives::TransactionDetails)>;
     /// Returns the readnode_primitives::TransactionDetails at the given transaction hash
+    /// TODO: rewrite this method to return a Result like a struct with block_height and transaction_details instead of a tuple
     async fn get_indexed_transaction_by_hash(
         &self,
         transaction_hash: &str,
         method_name: &str,
     ) -> anyhow::Result<(u64, readnode_primitives::TransactionDetails)>;
     /// Returns the readnode_primitives::TransactionDetails at the given transaction hash
+    /// TODO: rewrite this method to return a Result like a struct with block_height and transaction_details instead of a tuple
     async fn get_indexing_transaction_by_hash(
         &self,
         transaction_hash: &str,

--- a/database/src/base/rpc_server.rs
+++ b/database/src/base/rpc_server.rs
@@ -94,19 +94,19 @@ pub trait ReaderDbManager {
         &self,
         transaction_hash: &str,
         method_name: &str,
-    ) -> anyhow::Result<readnode_primitives::TransactionDetails>;
+    ) -> anyhow::Result<(u64, readnode_primitives::TransactionDetails)>;
     /// Returns the readnode_primitives::TransactionDetails at the given transaction hash
     async fn get_indexed_transaction_by_hash(
         &self,
         transaction_hash: &str,
         method_name: &str,
-    ) -> anyhow::Result<readnode_primitives::TransactionDetails>;
+    ) -> anyhow::Result<(u64, readnode_primitives::TransactionDetails)>;
     /// Returns the readnode_primitives::TransactionDetails at the given transaction hash
     async fn get_indexing_transaction_by_hash(
         &self,
         transaction_hash: &str,
         method_name: &str,
-    ) -> anyhow::Result<readnode_primitives::TransactionDetails>;
+    ) -> anyhow::Result<(u64, readnode_primitives::TransactionDetails)>;
 
     /// Returns the block height and shard id by the given block height
     async fn get_block_by_height_and_shard_id(

--- a/database/src/postgres/models.rs
+++ b/database/src/postgres/models.rs
@@ -433,14 +433,14 @@ impl TransactionDetail {
     pub async fn get_transaction_by_hash(
         mut conn: crate::postgres::PgAsyncConn,
         transaction_hash: &str,
-    ) -> anyhow::Result<Vec<u8>> {
+    ) -> anyhow::Result<(bigdecimal::BigDecimal, Vec<u8>)> {
         let response = transaction_detail::table
             .filter(transaction_detail::transaction_hash.eq(transaction_hash))
             .select(Self::as_select())
             .first(&mut conn)
             .await?;
 
-        Ok(response.transaction_details)
+        Ok((response.block_height, response.transaction_details))
     }
 }
 

--- a/rpc-server/src/config.rs
+++ b/rpc-server/src/config.rs
@@ -26,6 +26,7 @@ impl GenesisInfo {
         let genesis_config = near_rpc_client
             .call(
                 near_jsonrpc_client::methods::EXPERIMENTAL_genesis_config::RpcGenesisConfigRequest,
+                None,
             )
             .await
             .expect("Error to get genesis config");

--- a/rpc-server/src/metrics.rs
+++ b/rpc-server/src/metrics.rs
@@ -96,10 +96,16 @@ lazy_static! {
         &["method_name"] // This declares a label named `method name`
     ).unwrap();
 
-    pub(crate) static ref REQUESTS_COUNTER: IntCounterVec = register_int_counter_vec(
-        "requests_counter",
+    pub(crate) static ref TOTAL_REQUESTS_COUNTER: IntCounterVec = register_int_counter_vec(
+        "total_requests_counter",
         "Total number of requests",
         &["request_type"] // This declares a label named `request_type`
+    ).unwrap();
+
+    pub(crate) static ref TIMELINE_METHOD_REQUESTS_COUNTER: IntCounterVec = register_int_counter_vec(
+        "timeline_method_requests_counter",
+        "Total number of method requests by timeline",
+        &["method_name", "timeline"] // This declares a label named `timeline` and `method_name`
     ).unwrap();
 
     pub(crate) static ref OPTIMISTIC_STATUS: IntGauge = try_create_int_gauge(
@@ -128,6 +134,7 @@ lazy_static! {
 pub async fn increase_request_category_metrics(
     data: &jsonrpc_v2::Data<crate::config::ServerContext>,
     block_reference: &near_primitives::types::BlockReference,
+    method_name: &str,
     block_height: Option<u64>,
 ) {
     match block_reference {
@@ -135,38 +142,58 @@ pub async fn increase_request_category_metrics(
             let final_block = data.blocks_info_by_finality.final_cache_block().await;
             let expected_earliest_available_block =
                 final_block.block_height - 5 * data.genesis_info.genesis_config.epoch_length;
-            if block_height.unwrap_or_default() > expected_earliest_available_block {
+            // By default, all requests should be historical, therefore
+            // if block_height is None we use `genesis.block_height` by default
+            if block_height.unwrap_or(data.genesis_info.genesis_block_cache.block_height)
+                > expected_earliest_available_block
+            {
                 // This is request to regular nodes which includes 5 last epochs
-                REQUESTS_COUNTER.with_label_values(&["regular"]).inc();
+                TOTAL_REQUESTS_COUNTER.with_label_values(&["regular"]).inc();
+                TIMELINE_METHOD_REQUESTS_COUNTER
+                    .with_label_values(&[method_name, "regular"])
+                    .inc();
             } else {
                 // This is a request to archival nodes which include blocks from genesis (later than 5 epochs ago)
-                REQUESTS_COUNTER.with_label_values(&["historical"]).inc();
+                TOTAL_REQUESTS_COUNTER
+                    .with_label_values(&["historical"])
+                    .inc();
+                TIMELINE_METHOD_REQUESTS_COUNTER
+                    .with_label_values(&[method_name, "historical"])
+                    .inc();
             }
         }
         near_primitives::types::BlockReference::Finality(finality) => {
+            // All Finality is requests to regular nodes which includes 5 last epochs
+            TOTAL_REQUESTS_COUNTER.with_label_values(&["regular"]).inc();
             match finality {
-                // Increase the REQUESTS_COUNTER `final` metric
+                // Increase the TOTAL_REQUESTS_COUNTER `final` metric
                 // if the request has final finality
                 near_primitives::types::Finality::DoomSlug
                 | near_primitives::types::Finality::Final => {
-                    REQUESTS_COUNTER.with_label_values(&["final"]).inc();
+                    TOTAL_REQUESTS_COUNTER.with_label_values(&["final"]).inc();
+                    TIMELINE_METHOD_REQUESTS_COUNTER
+                        .with_label_values(&[method_name, "final"])
+                        .inc();
                 }
-                // Increase the REQUESTS_COUNTER `optimistic` metric
+                // Increase the TOTAL_REQUESTS_COUNTER `optimistic` metric
                 // if the request has optimistic finality
                 near_primitives::types::Finality::None => {
-                    REQUESTS_COUNTER.with_label_values(&["optimistic"]).inc();
-                    // Increase the REQUESTS_COUNTER `proxy_optimistic` metric
-                    // if the optimistic is not updating and proxy to native JSON-RPC
-                    if crate::metrics::OPTIMISTIC_UPDATING.is_not_working() {
-                        REQUESTS_COUNTER
-                            .with_label_values(&["proxy_optimistic"])
-                            .inc();
-                    }
+                    TOTAL_REQUESTS_COUNTER
+                        .with_label_values(&["optimistic"])
+                        .inc();
+                    TIMELINE_METHOD_REQUESTS_COUNTER
+                        .with_label_values(&[method_name, "optimistic"])
+                        .inc();
                 }
             }
         }
         near_primitives::types::BlockReference::SyncCheckpoint(_) => {
-            REQUESTS_COUNTER.with_label_values(&["historical"]).inc();
+            TOTAL_REQUESTS_COUNTER
+                .with_label_values(&["historical"])
+                .inc();
+            TIMELINE_METHOD_REQUESTS_COUNTER
+                .with_label_values(&[method_name, "historical"])
+                .inc();
         }
     }
 }

--- a/rpc-server/src/middlewares.rs
+++ b/rpc-server/src/middlewares.rs
@@ -1,4 +1,4 @@
-use crate::metrics::{METHOD_CALLS_COUNTER, TOTAL_REQUESTS_COUNTER};
+use crate::metrics::METHOD_CALLS_COUNTER;
 use actix_web::dev::{forward_ready, Service, ServiceRequest, ServiceResponse, Transform};
 use futures::future::LocalBoxFuture;
 use futures::StreamExt;
@@ -52,8 +52,6 @@ where
             if request.path() != "/" {
                 return service_clone.call(request).await;
             }
-
-            TOTAL_REQUESTS_COUNTER.with_label_values(&["total"]).inc();
 
             let (req, mut payload) = request.into_parts();
             let mut body = actix_web::web::BytesMut::new();

--- a/rpc-server/src/middlewares.rs
+++ b/rpc-server/src/middlewares.rs
@@ -1,4 +1,4 @@
-use crate::metrics::{METHOD_CALLS_COUNTER, REQUESTS_COUNTER};
+use crate::metrics::{METHOD_CALLS_COUNTER, TOTAL_REQUESTS_COUNTER};
 use actix_web::dev::{forward_ready, Service, ServiceRequest, ServiceResponse, Transform};
 use futures::future::LocalBoxFuture;
 use futures::StreamExt;
@@ -53,7 +53,7 @@ where
                 return service_clone.call(request).await;
             }
 
-            REQUESTS_COUNTER.with_label_values(&["total"]).inc();
+            TOTAL_REQUESTS_COUNTER.with_label_values(&["total"]).inc();
 
             let (req, mut payload) = request.into_parts();
             let mut body = actix_web::web::BytesMut::new();

--- a/rpc-server/src/modules/clients/methods.rs
+++ b/rpc-server/src/modules/clients/methods.rs
@@ -14,10 +14,10 @@ pub async fn light_client_proof(
         near_jsonrpc::primitives::types::light_client::RpcLightClientExecutionProofRequest::parse(
             params,
         )?;
-    crate::metrics::REQUESTS_COUNTER
-        .with_label_values(&["archive_proxy_light_client_proof"])
-        .inc();
-    Ok(data.near_rpc_client.archival_call(request).await?)
+    Ok(data
+        .near_rpc_client
+        .archival_call(request, Some("light_client_proof"))
+        .await?)
 }
 
 pub async fn next_light_client_block(
@@ -29,7 +29,11 @@ pub async fn next_light_client_block(
         near_jsonrpc::primitives::types::light_client::RpcLightClientNextBlockRequest::parse(
             params,
         )?;
-    match data.near_rpc_client.call(request).await? {
+    match data
+        .near_rpc_client
+        .call(request, Some("next_light_client_block"))
+        .await?
+    {
         Some(light_client_block) => Ok(
             near_jsonrpc::primitives::types::light_client::RpcLightClientNextBlockResponse {
                 light_client_block: Some(std::sync::Arc::new(light_client_block)),

--- a/rpc-server/src/utils.rs
+++ b/rpc-server/src/utils.rs
@@ -69,10 +69,7 @@ impl JsonRpcClient {
         tracing::debug!("PROXY call. {:?}", params);
         if let Some(method_name) = method_name {
             crate::metrics::TOTAL_REQUESTS_COUNTER
-                .with_label_values(&["total_regular_proxy"])
-                .inc();
-            crate::metrics::TOTAL_REQUESTS_COUNTER
-                .with_label_values(&[&format!("proxy_{}", method_name)])
+                .with_label_values(&[method_name, "proxy"])
                 .inc();
         }
         self.rpc_call(params, false).await
@@ -90,10 +87,7 @@ impl JsonRpcClient {
         tracing::debug!("ARCHIVAL PROXY call. {:?}", params);
         if let Some(method_name) = method_name {
             crate::metrics::TOTAL_REQUESTS_COUNTER
-                .with_label_values(&["total_archive_proxy"])
-                .inc();
-            crate::metrics::TOTAL_REQUESTS_COUNTER
-                .with_label_values(&[&format!("archive_proxy_{}", method_name)])
+                .with_label_values(&[method_name, "archive_proxy"])
                 .inc();
         }
         self.rpc_call(params, true).await

--- a/rpc-server/src/utils.rs
+++ b/rpc-server/src/utils.rs
@@ -61,14 +61,20 @@ impl JsonRpcClient {
     pub async fn call<M>(
         &self,
         params: M,
+        method_name: Option<&str>,
     ) -> near_jsonrpc_client::MethodCallResult<M::Response, M::Error>
     where
         M: near_jsonrpc_client::methods::RpcMethod + std::fmt::Debug,
     {
         tracing::debug!("PROXY call. {:?}", params);
-        crate::metrics::REQUESTS_COUNTER
-            .with_label_values(&["regular_proxy"])
-            .inc();
+        if let Some(method_name) = method_name {
+            crate::metrics::TOTAL_REQUESTS_COUNTER
+                .with_label_values(&["total_regular_proxy"])
+                .inc();
+            crate::metrics::TOTAL_REQUESTS_COUNTER
+                .with_label_values(&[&format!("proxy_{}", method_name)])
+                .inc();
+        }
         self.rpc_call(params, false).await
     }
 
@@ -76,14 +82,20 @@ impl JsonRpcClient {
     pub async fn archival_call<M>(
         &self,
         params: M,
+        method_name: Option<&str>,
     ) -> near_jsonrpc_client::MethodCallResult<M::Response, M::Error>
     where
         M: near_jsonrpc_client::methods::RpcMethod + std::fmt::Debug,
     {
         tracing::debug!("ARCHIVAL PROXY call. {:?}", params);
-        crate::metrics::REQUESTS_COUNTER
-            .with_label_values(&["archive_proxy"])
-            .inc();
+        if let Some(method_name) = method_name {
+            crate::metrics::TOTAL_REQUESTS_COUNTER
+                .with_label_values(&["total_archive_proxy"])
+                .inc();
+            crate::metrics::TOTAL_REQUESTS_COUNTER
+                .with_label_values(&[&format!("archive_proxy_{}", method_name)])
+                .inc();
+        }
         self.rpc_call(params, true).await
     }
 
@@ -112,7 +124,7 @@ pub async fn get_final_block(
             near_primitives::types::Finality::Final
         }),
     };
-    let block_view = near_rpc_client.call(block_request_method).await?;
+    let block_view = near_rpc_client.call(block_request_method, None).await?;
 
     // Updating the metric to expose the block height considered as final by the server
     // this metric can be used to calculate the lag between the server and the network
@@ -138,7 +150,7 @@ pub async fn get_current_validators(
     let params = near_jsonrpc_client::methods::validators::RpcValidatorRequest {
         epoch_reference: near_primitives::types::EpochReference::Latest,
     };
-    Ok(near_rpc_client.call(params).await?)
+    Ok(near_rpc_client.call(params, None).await?)
 }
 
 pub async fn get_current_epoch_config(
@@ -150,7 +162,7 @@ pub async fn get_current_epoch_config(
                 near_primitives::types::Finality::Final,
             ),
         };
-    let protocol_config_view = near_rpc_client.call(params).await?;
+    let protocol_config_view = near_rpc_client.call(params, None).await?;
     Ok(epoch_config_from_protocol_config_view(protocol_config_view).await)
 }
 


### PR DESCRIPTION
In this PR Historical/regular counter is extended and broken down by method.
This metric should to help to analyze the block_references for methods 
to see the most common pattern is it specific block or final/optimistic.

- final
- optimistic
- block_id:
     - regular - includes 5 last epochs
     - historical - later than 5 epochs ago