### PR TITLE
fix: clarified Redis connection errors and added Redis dependency to docker-compose files

### DIFF
--- a/examples/postgres-compose.yml
+++ b/examples/postgres-compose.yml
@@ -2,6 +2,7 @@ version: '3.7'
 
 x-common-variables: &common-variables
   CHAIN_ID: mainnet
+  REDIS_URL: redis://redis:6379/
   DATABASE_URL: postgres:5432
   DATABASE_USER: postgres
   DATABASE_PASSWORD: password
@@ -29,6 +30,7 @@ services:
       - 8000:8000
     depends_on:
       - postgres
+      - redis
     restart: on-failure
 
   state-indexer:
@@ -45,6 +47,7 @@ services:
       - 8080:8080
     depends_on:
       - postgres
+      - redis
     restart: on-failure
 
   tx-indexer:
@@ -61,6 +64,7 @@ services:
       - 8081:8081
     depends_on:
       - postgres
+      - redis
     restart: on-failure
 
   postgres:
@@ -72,3 +76,9 @@ services:
       POSTGRES_PASSWORD: password
     ports:
       - 5432:5432
+
+  redis:
+    image: redis/redis-stack-server:latest
+    restart: always
+    ports:
+      - 6379:6379

--- a/examples/rightsizing-compose.yml
+++ b/examples/rightsizing-compose.yml
@@ -2,6 +2,7 @@ version: '3.7'
 
 x-common-variables: &common-variables
   CHAIN_ID: mainnet
+  REDIS_URL: redis://redis:6379/
   DATABASE_URL: postgres:5432
   DATABASE_USER: postgres
   DATABASE_PASSWORD: password
@@ -31,6 +32,7 @@ services:
       - 8000:8000
     depends_on:
       - postgres
+      - redis
 
   state-indexer:
     build:
@@ -46,6 +48,7 @@ services:
       - 8080:8080
     depends_on:
       - postgres
+      - redis
     restart: on-failure
 
   tx-indexer:
@@ -57,12 +60,12 @@ services:
     environment:
       <<: *common-variables
       TX_INDEXER_ID: tx-indexer-local
-
     command: [ "from-interruption" ]
     ports:
       - 8081:8081
     depends_on:
       - postgres
+      - redis
     restart: on-failure
 
   postgres:
@@ -74,3 +77,10 @@ services:
       POSTGRES_PASSWORD: password
     ports:
       - 5432:5432
+
+  redis:
+    image: redis/redis-stack-server:latest
+    container_name: redis-stack-server
+    ports:
+      - 6379:6379
+    restart: always

--- a/rpc-server/README.md
+++ b/rpc-server/README.md
@@ -89,6 +89,10 @@ This feature flag enables the shadow data consistency checks. With this feature 
 
 We encountered a problem with the design of the table `account_access_keys` and overall design of the logic around it. We had to disable the table and proxy the calls of the `query.access_key_list` method to the real NEAR RPC. However, we still aren't ready to get rid of the code and that's why we hid it under the feature flag. We are planning to remove the code in the future and remove the feature flag.
 
+## Redis (Optional)
+
+Redis is used as an optional dependency when paired with the near_state_indexer feature. To use Redis, you need to specify the REDIS_URL in the .env file and set up a server using docker or `redis-server` command. Redis can be used to cache the state data indexed by the near_state_indexer for faster retrieval and reduced load on the database.
+
 ## Metrics (Prometheus)
 
 The read-rpc-server exposes Prometheus-compatible metrics at the `/metrics` endpoint.

--- a/rpc-server/src/main.rs
+++ b/rpc-server/src/main.rs
@@ -49,6 +49,7 @@ async fn main() -> anyhow::Result<()> {
         .get_connection_manager()
         .await
         .map_err(|err| {
+            crate::metrics::OPTIMISTIC_UPDATING.set_not_working();
             tracing::warn!("Failed to connect to Redis: {:?}", err);
         })
         .ok();

--- a/rpc-server/src/main.rs
+++ b/rpc-server/src/main.rs
@@ -44,9 +44,14 @@ async fn main() -> anyhow::Result<()> {
     let blocks_info_by_finality_clone =
         std::sync::Arc::clone(&server_context.blocks_info_by_finality);
     let near_rpc_client_clone = near_rpc_client.clone();
+
     let redis_client = redis::Client::open(rpc_server_config.general.redis_url.clone())?
         .get_connection_manager()
-        .await?;
+        .await
+        .map_err(|err| {
+            tracing::error!("Failed to connect to Redis: {:?}", err);
+            err
+        })?;
     let redis_client_clone = redis_client.clone();
 
     // We need to update final block from Redis and Lake

--- a/rpc-server/src/utils.rs
+++ b/rpc-server/src/utils.rs
@@ -278,7 +278,7 @@ pub async fn update_final_block_regularly_from_redis(
                 }
             }
             Err(err) => {
-                tracing::error!("Error to get final block from redis: {:?}", err);
+                tracing::warn!("Error to get final block from redis: {:?}", err);
             }
         }
     }
@@ -319,7 +319,7 @@ pub async fn update_optimistic_block_regularly(
                 }
             }
             Err(err) => {
-                tracing::error!("Error to get optimistic block from redis: {:?}", err);
+                tracing::warn!("Error to get optimistic block from redis: {:?}", err);
             }
         }
 


### PR DESCRIPTION
- [x] Improve the error to make it less ambiguous, we need a clear message identifying it is related to connection to Redis

  Before: 
  <img width="591" alt="image" src="https://github.com/near/read-rpc/assets/59515280/4f1a963f-5139-4591-9475-b563463f34bb">

  After:
  <img width="785" alt="image" src="https://github.com/near/read-rpc/assets/59515280/ec3e4446-3ef3-4639-926e-bb552e0fa647">

- [x] Update the `docker-compose.yml` to ensure it is always in a working condition to `docker-compose up` from `main`

  To complete this, I've added redis dependency to postgres and rightsizing docker-compose files

- [x] Decide how to proceed with having Redis as a mandatory dependency and whether the `rpc-server` can work without it even with limited capabilities

  In any case we can merge these minor fixes now and later (@kobayurii @khorolets) will decide wether Redis is required or not

closes #274 
closes #279 