### PR TITLE
fix(configuration): AWS ThroughPutBelowMinimum errors and timeouts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -667,9 +667,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.34.0"
+version = "1.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "724119d8fd2d2638b9979673f3b5c2979fa388c9ca27815e3cb5ad6234fac3f5"
+checksum = "8bf0ff573cd2ca6c250526ce550dc6a98d4d8f91605cc8409650e7a3bb3b5045"
 dependencies = [
  "ahash 0.8.11",
  "aws-credential-types",
@@ -881,9 +881,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.5.5"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0d3965f6417a92a6d1009c5958a67042f57e46342afb37ca58f9ad26744ec73"
+checksum = "db83b08939838d18e33b5dbaf1a0f048f28c10bd28071ab7ce6f245451855414"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -895,6 +895,7 @@ dependencies = [
  "http 0.2.12",
  "http-body 0.4.6",
  "http-body 1.0.0",
+ "httparse",
  "hyper",
  "hyper-rustls",
  "once_cell",
@@ -3157,9 +3158,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.9.4"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
+checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
 
 [[package]]
 name = "httpdate"

--- a/configuration/src/configs/lake.rs
+++ b/configuration/src/configs/lake.rs
@@ -1,3 +1,4 @@
+use aws_sdk_s3::config::StalledStreamProtectionConfig;
 use near_lake_framework::near_indexer_primitives::near_primitives;
 use serde_derive::Deserialize;
 
@@ -21,6 +22,7 @@ impl LakeConfig {
             "",
         );
         aws_sdk_s3::Config::builder()
+            .stalled_stream_protection(StalledStreamProtectionConfig::disabled())
             .credentials_provider(credentials)
             .region(aws_types::region::Region::new(
                 self.aws_default_region.clone(),

--- a/configuration/src/configs/tx_details_storage.rs
+++ b/configuration/src/configs/tx_details_storage.rs
@@ -1,3 +1,4 @@
+use aws_sdk_s3::config::StalledStreamProtectionConfig;
 use serde_derive::Deserialize;
 
 use crate::configs::{deserialize_optional_data_or_env, required_value_or_panic};
@@ -23,6 +24,7 @@ impl TxDetailsStorageConfig {
             "",
         );
         aws_sdk_s3::Config::builder()
+            .stalled_stream_protection(StalledStreamProtectionConfig::disabled())
             .credentials_provider(credentials)
             .endpoint_url(
                 self.aws_endpoint


### PR DESCRIPTION
In my investigations about the abnormal amount of the error messages from AWS client I've encountered this issue.

Following the advice to disable the newly introduced `StalledStreamProtection` which seemed to be the root cause led me to the results I was aiming for.

This fix should resolve the problem of storing `tx_details` to GCS. I tested it locally to prove it helps.