### PR TITLE
feat: prefetch optimization

### DIFF
--- a/configuration/example.config.toml
+++ b/configuration/example.config.toml
@@ -53,6 +53,11 @@ near_rpc_url = "https://beta.rpc.mainnet.near.org"
 ## thet means for every method calls will be checked every 100th request
 #shadow_data_consistency_rate = 100
 
+## Max size (in bytes) for state prefetch during a view_call
+## Limits the amount of data prefetched to speed up the view_call
+## By default, it is set to 1MB (1_000_000 bytes).
+#prefetch_state_size_limit = 1_000_000
+
 ### Tx indexer general configuration
 [general.tx_indexer]
 

--- a/configuration/src/configs/general.rs
+++ b/configuration/src/configs/general.rs
@@ -18,7 +18,7 @@ pub struct GeneralRpcServerConfig {
     pub contract_code_cache_size: f64,
     pub block_cache_size: f64,
     pub shadow_data_consistency_rate: f64,
-    pub prefetch_storage_limit: u64,
+    pub prefetch_state_size_limit: u64,
 }
 
 #[derive(Debug, Clone)]
@@ -108,7 +108,7 @@ pub struct CommonGeneralRpcServerConfig {
     #[serde(deserialize_with = "deserialize_optional_data_or_env", default)]
     pub shadow_data_consistency_rate: Option<f64>,
     #[serde(deserialize_with = "deserialize_optional_data_or_env", default)]
-    pub prefetch_storage_limit: Option<u64>,
+    pub prefetch_state_size_limit: Option<u64>,
 }
 
 impl CommonGeneralRpcServerConfig {
@@ -132,7 +132,7 @@ impl CommonGeneralRpcServerConfig {
         100.0
     }
 
-    pub fn default_prefetch_storage_limit() -> u64 {
+    pub fn default_prefetch_state_size_limit() -> u64 {
         1_000_000
     }
 }
@@ -145,7 +145,7 @@ impl Default for CommonGeneralRpcServerConfig {
             contract_code_cache_size: Some(Self::default_contract_code_cache_size()),
             block_cache_size: Some(Self::default_block_cache_size()),
             shadow_data_consistency_rate: Some(Self::default_shadow_data_consistency_rate()),
-            prefetch_storage_limit: Some(Self::default_prefetch_storage_limit()),
+            prefetch_state_size_limit: Some(Self::default_prefetch_state_size_limit()),
         }
     }
 }
@@ -266,10 +266,10 @@ impl From<CommonGeneralConfig> for GeneralRpcServerConfig {
                 .rpc_server
                 .shadow_data_consistency_rate
                 .unwrap_or_else(CommonGeneralRpcServerConfig::default_shadow_data_consistency_rate),
-            prefetch_storage_limit: common_config
+            prefetch_state_size_limit: common_config
                 .rpc_server
-                .prefetch_storage_limit
-                .unwrap_or_else(CommonGeneralRpcServerConfig::default_prefetch_storage_limit),
+                .prefetch_state_size_limit
+                .unwrap_or_else(CommonGeneralRpcServerConfig::default_prefetch_state_size_limit),
         }
     }
 }

--- a/configuration/src/configs/general.rs
+++ b/configuration/src/configs/general.rs
@@ -18,6 +18,7 @@ pub struct GeneralRpcServerConfig {
     pub contract_code_cache_size: f64,
     pub block_cache_size: f64,
     pub shadow_data_consistency_rate: f64,
+    pub prefetch_storage_limit: u64,
 }
 
 #[derive(Debug, Clone)]
@@ -106,6 +107,8 @@ pub struct CommonGeneralRpcServerConfig {
     pub block_cache_size: Option<f64>,
     #[serde(deserialize_with = "deserialize_optional_data_or_env", default)]
     pub shadow_data_consistency_rate: Option<f64>,
+    #[serde(deserialize_with = "deserialize_optional_data_or_env", default)]
+    pub prefetch_storage_limit: Option<u64>,
 }
 
 impl CommonGeneralRpcServerConfig {
@@ -128,6 +131,10 @@ impl CommonGeneralRpcServerConfig {
     pub fn default_shadow_data_consistency_rate() -> f64 {
         100.0
     }
+
+    pub fn default_prefetch_storage_limit() -> u64 {
+        1_000_000
+    }
 }
 
 impl Default for CommonGeneralRpcServerConfig {
@@ -138,6 +145,7 @@ impl Default for CommonGeneralRpcServerConfig {
             contract_code_cache_size: Some(Self::default_contract_code_cache_size()),
             block_cache_size: Some(Self::default_block_cache_size()),
             shadow_data_consistency_rate: Some(Self::default_shadow_data_consistency_rate()),
+            prefetch_storage_limit: Some(Self::default_prefetch_storage_limit()),
         }
     }
 }
@@ -258,6 +266,10 @@ impl From<CommonGeneralConfig> for GeneralRpcServerConfig {
                 .rpc_server
                 .shadow_data_consistency_rate
                 .unwrap_or_else(CommonGeneralRpcServerConfig::default_shadow_data_consistency_rate),
+            prefetch_storage_limit: common_config
+                .rpc_server
+                .prefetch_storage_limit
+                .unwrap_or_else(CommonGeneralRpcServerConfig::default_prefetch_storage_limit),
         }
     }
 }

--- a/rpc-server/src/config.rs
+++ b/rpc-server/src/config.rs
@@ -77,6 +77,8 @@ pub struct ServerContext {
     pub max_gas_burnt: near_primitives::types::Gas,
     /// How many requests we should check for data consistency
     pub shadow_data_consistency_rate: f64,
+    /// Max size of the storage for the prefetch
+    pub prefetch_storage_limit: u64,
     /// Port of the server.
     pub server_port: u16,
     /// Timestamp of starting server.
@@ -164,6 +166,7 @@ impl ServerContext {
             contract_code_cache,
             max_gas_burnt: rpc_server_config.general.max_gas_burnt,
             shadow_data_consistency_rate: rpc_server_config.general.shadow_data_consistency_rate,
+            prefetch_storage_limit: rpc_server_config.general.prefetch_storage_limit,
             server_port: rpc_server_config.general.server_port,
             boot_time_seconds: chrono::Utc::now().timestamp(),
             version: near_primitives::version::Version {

--- a/rpc-server/src/config.rs
+++ b/rpc-server/src/config.rs
@@ -77,8 +77,8 @@ pub struct ServerContext {
     pub max_gas_burnt: near_primitives::types::Gas,
     /// How many requests we should check for data consistency
     pub shadow_data_consistency_rate: f64,
-    /// Max size of the storage for the prefetch
-    pub prefetch_storage_limit: u64,
+    /// Max size for state prefetch during a view_call
+    pub prefetch_state_size_limit: u64,
     /// Port of the server.
     pub server_port: u16,
     /// Timestamp of starting server.
@@ -166,7 +166,7 @@ impl ServerContext {
             contract_code_cache,
             max_gas_burnt: rpc_server_config.general.max_gas_burnt,
             shadow_data_consistency_rate: rpc_server_config.general.shadow_data_consistency_rate,
-            prefetch_storage_limit: rpc_server_config.general.prefetch_storage_limit,
+            prefetch_state_size_limit: rpc_server_config.general.prefetch_state_size_limit,
             server_port: rpc_server_config.general.server_port,
             boot_time_seconds: chrono::Utc::now().timestamp(),
             version: near_primitives::version::Version {

--- a/rpc-server/src/modules/queries/contract_runner/code_storage.rs
+++ b/rpc-server/src/modules/queries/contract_runner/code_storage.rs
@@ -46,24 +46,20 @@ impl CodeStorage {
             readnode_primitives::StateKey,
             Option<readnode_primitives::StateValue>,
         >,
-        prefetch_storage_limit: u64,
+        storage_usage: u64,
+        prefetch_state_size_limit: u64,
     ) -> Self {
         let mut prefetch_state_data = HashMap::new();
 
-        if let Ok(account) = db_manager
-            .get_account(&account_id, block_height, "query_call_function")
-            .await
-        {
-            if account.data.storage_usage() < prefetch_storage_limit {
-                prefetch_state_data = utils::get_state_from_db(
-                    &db_manager,
-                    &account_id,
-                    block_height,
-                    &[],
-                    "query_call_function",
-                )
-                .await;
-            }
+        if storage_usage < prefetch_state_size_limit {
+            prefetch_state_data = utils::get_state_from_db(
+                &db_manager,
+                &account_id,
+                block_height,
+                &[],
+                "query_call_function",
+            )
+            .await;
         }
 
         Self {

--- a/rpc-server/src/modules/queries/contract_runner/code_storage.rs
+++ b/rpc-server/src/modules/queries/contract_runner/code_storage.rs
@@ -46,6 +46,7 @@ impl CodeStorage {
             readnode_primitives::StateKey,
             Option<readnode_primitives::StateValue>,
         >,
+        prefetch_storage_limit: u64,
     ) -> Self {
         let mut prefetch_state_data = HashMap::new();
 
@@ -53,7 +54,7 @@ impl CodeStorage {
             .get_account(&account_id, block_height, "query_call_function")
             .await
         {
-            if account.data.storage_usage() < 1_000_000 {
+            if account.data.storage_usage() < prefetch_storage_limit {
                 prefetch_state_data = utils::get_state_from_db(
                     &db_manager,
                     &account_id,

--- a/rpc-server/src/modules/queries/contract_runner/code_storage.rs
+++ b/rpc-server/src/modules/queries/contract_runner/code_storage.rs
@@ -49,18 +49,18 @@ impl CodeStorage {
         storage_usage: u64,
         prefetch_state_size_limit: u64,
     ) -> Self {
-        let mut prefetch_state_data = HashMap::new();
-
-        if storage_usage < prefetch_state_size_limit {
-            prefetch_state_data = utils::get_state_from_db(
+        let prefetch_state_data = if storage_usage < prefetch_state_size_limit {
+            utils::get_state_from_db(
                 &db_manager,
                 &account_id,
                 block_height,
                 &[],
                 "query_call_function",
             )
-            .await;
-        }
+            .await
+        } else {
+            HashMap::new()
+        };
 
         Self {
             db_manager,

--- a/rpc-server/src/modules/queries/contract_runner/mod.rs
+++ b/rpc-server/src/modules/queries/contract_runner/mod.rs
@@ -38,7 +38,7 @@ pub async fn run_contract(
         readnode_primitives::StateKey,
         Option<readnode_primitives::StateValue>,
     >,
-    prefetch_storage_limit: u64,
+    prefetch_state_size_limit: u64,
 ) -> Result<RunContractResponse, FunctionCallError> {
     let contract = db_manager
         .get_account(account_id, block.block_height, "query_call_function")
@@ -118,7 +118,8 @@ pub async fn run_contract(
         block.block_height,
         validators,
         optimistic_data,
-        prefetch_storage_limit,
+        contract.data.storage_usage(),
+        prefetch_state_size_limit,
     )
     .await;
 

--- a/rpc-server/src/modules/queries/contract_runner/mod.rs
+++ b/rpc-server/src/modules/queries/contract_runner/mod.rs
@@ -38,6 +38,7 @@ pub async fn run_contract(
         readnode_primitives::StateKey,
         Option<readnode_primitives::StateValue>,
     >,
+    prefetch_storage_limit: u64,
 ) -> Result<RunContractResponse, FunctionCallError> {
     let contract = db_manager
         .get_account(account_id, block.block_height, "query_call_function")
@@ -117,6 +118,7 @@ pub async fn run_contract(
         block.block_height,
         validators,
         optimistic_data,
+        prefetch_storage_limit,
     )
     .await;
 

--- a/rpc-server/src/modules/queries/methods.rs
+++ b/rpc-server/src/modules/queries/methods.rs
@@ -365,7 +365,7 @@ async fn function_call(
         block,
         data.max_gas_burnt,
         maybe_optimistic_data,
-        data.prefetch_storage_limit,
+        data.prefetch_state_size_limit,
     )
     .await;
 

--- a/rpc-server/src/modules/queries/methods.rs
+++ b/rpc-server/src/modules/queries/methods.rs
@@ -365,6 +365,7 @@ async fn function_call(
         block,
         data.max_gas_burnt,
         maybe_optimistic_data,
+        data.prefetch_storage_limit,
     )
     .await;
 


### PR DESCRIPTION
This PR introduces a configuration option to control the maximum size of storage used for state prefetching during a `view_call`. Prefetching helps to speed up the `view_call` by loading data in advance, but it can consume more time if state size is too big. To prevent excessive time usage during a `view_call`, we set a default limit of 1MB (1_000_000 bytes) for the prefetch storage. Prefetching will only be an option if the state storage usage is below this given threshold