### PR TITLE
feat: added support for a `version` flag

### DIFF
--- a/logic-state-indexer/src/configs.rs
+++ b/logic-state-indexer/src/configs.rs
@@ -3,7 +3,7 @@ pub use clap::{Parser, Subcommand};
 /// NEAR Indexer for Explorer
 /// Watches for stream of blocks from the chain
 #[derive(Parser, Debug)]
-#[command(version)]
+#[command(version = concat!(env!("CARGO_PKG_VERSION"), "\nnearcore ", env!("NEARCORE_VERSION")))]
 pub struct Opts {
     #[clap(subcommand)]
     pub start_options: StartOptions,

--- a/logic-state-indexer/src/configs.rs
+++ b/logic-state-indexer/src/configs.rs
@@ -3,6 +3,7 @@ pub use clap::{Parser, Subcommand};
 /// NEAR Indexer for Explorer
 /// Watches for stream of blocks from the chain
 #[derive(Parser, Debug)]
+#[command(version)]
 pub struct Opts {
     #[clap(subcommand)]
     pub start_options: StartOptions,

--- a/near-state-indexer/src/configs.rs
+++ b/near-state-indexer/src/configs.rs
@@ -1,6 +1,6 @@
 /// Watches for stream of blocks from the chain
 #[derive(clap::Parser, Debug)]
-#[command(version)]
+#[command(version = concat!(env!("CARGO_PKG_VERSION"), "\nnearcore ", env!("NEARCORE_VERSION")))]
 pub(crate) struct Opts {
     /// Sets a custom config dir. Defaults to ~/.near/
     #[clap(long)]

--- a/near-state-indexer/src/configs.rs
+++ b/near-state-indexer/src/configs.rs
@@ -1,8 +1,9 @@
 /// Watches for stream of blocks from the chain
 #[derive(clap::Parser, Debug)]
+#[command(version)]
 pub(crate) struct Opts {
     /// Sets a custom config dir. Defaults to ~/.near/
-    #[clap(short, long)]
+    #[clap(long)]
     pub home: Option<std::path::PathBuf>,
     #[clap(subcommand)]
     pub subcmd: SubCommand,

--- a/near-state-indexer/src/main.rs
+++ b/near-state-indexer/src/main.rs
@@ -13,6 +13,12 @@ mod utils;
 #[actix_web::main]
 async fn main() -> anyhow::Result<()> {
     configuration::init_tracing(INDEXER).await?;
+    tracing::info!(
+        "Starting {} v{}",
+        env!("CARGO_PKG_NAME"),
+        env!("CARGO_PKG_VERSION"),
+    );
+
     // We use it to automatically search the for root certificates to perform HTTPS calls
     // (sending telemetry and downloading genesis)
     openssl_probe::init_ssl_cert_env_vars();

--- a/perf-testing/src/config.rs
+++ b/perf-testing/src/config.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 
 #[derive(Parser)]
-#[clap(author, version, about, long_about = None)]
+#[clap(author, version = concat!(env!("CARGO_PKG_VERSION"), "\nnearcore ", env!("NEARCORE_VERSION")), about, long_about = None)]
 pub struct Opts {
     #[clap(long, env = "NEAR_RPC_URL")]
     pub near_rpc_url: http::Uri,

--- a/rpc-server/src/main.rs
+++ b/rpc-server/src/main.rs
@@ -22,6 +22,12 @@ pub(crate) const RPC_SERVER: &str = "read_rpc_server";
 #[actix_web::main]
 async fn main() -> anyhow::Result<()> {
     configuration::init_tracing(RPC_SERVER).await?;
+    tracing::info!(
+        "Starting {} v{}",
+        env!("CARGO_PKG_NAME"),
+        env!("CARGO_PKG_VERSION"),
+    );
+
     let rpc_server_config =
         configuration::read_configuration::<configuration::RpcServerConfig>().await?;
 

--- a/state-indexer/src/main.rs
+++ b/state-indexer/src/main.rs
@@ -10,6 +10,8 @@ async fn main() -> anyhow::Result<()> {
     openssl_probe::init_ssl_cert_env_vars();
 
     configuration::init_tracing(INDEXER).await?;
+    tracing::info!("Starting {} v{}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
+
     let indexer_config = configuration::read_configuration::<configuration::StateIndexerConfig>().await?;
     let opts: configs::Opts = configs::Opts::parse();
 

--- a/tx-indexer/src/config.rs
+++ b/tx-indexer/src/config.rs
@@ -5,7 +5,7 @@ use near_jsonrpc_client::{methods, JsonRpcClient};
 /// NEAR Indexer for Explorer
 /// Watches for stream of blocks from the chain
 #[derive(Parser, Debug)]
-#[command(version)]
+#[command(version = concat!(env!("CARGO_PKG_VERSION"), "\nnearcore ", env!("NEARCORE_VERSION")))]
 pub(crate) struct Opts {
     #[clap(subcommand)]
     pub start_options: StartOptions,

--- a/tx-indexer/src/config.rs
+++ b/tx-indexer/src/config.rs
@@ -5,6 +5,7 @@ use near_jsonrpc_client::{methods, JsonRpcClient};
 /// NEAR Indexer for Explorer
 /// Watches for stream of blocks from the chain
 #[derive(Parser, Debug)]
+#[command(version)]
 pub(crate) struct Opts {
     #[clap(subcommand)]
     pub start_options: StartOptions,

--- a/tx-indexer/src/main.rs
+++ b/tx-indexer/src/main.rs
@@ -16,6 +16,12 @@ pub(crate) const INDEXER: &str = "tx_indexer";
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     configuration::init_tracing(INDEXER).await?;
+    tracing::info!(
+        "Starting {} v{}",
+        env!("CARGO_PKG_NAME"),
+        env!("CARGO_PKG_VERSION"),
+    );
+
     let indexer_config =
         configuration::read_configuration::<configuration::TxIndexerConfig>().await?;
 


### PR DESCRIPTION
I've added the version flag for all indexers. However, I didn't complete the part with a supported nearcore version. In order to print an information about nearcore version along with the indexer version, we need to store nearcore version in some env variable (or in .toml file). I'm not sure that this overhead is needed, but I'm more than happy to implement it, so please say if this small overhead worth it or not

closes #287 