### PR TITLE
fix: view state unknown account error

### DIFF
--- a/rpc-server/src/modules/queries/methods.rs
+++ b/rpc-server/src/modules/queries/methods.rs
@@ -401,6 +401,17 @@ async fn view_state(
         is_optimistic,
     );
 
+    data.db_manager
+        .get_account(account_id, block.block_height, "query_view_state")
+        .await
+        .map_err(
+            |_err| near_jsonrpc::primitives::types::query::RpcQueryError::UnknownAccount {
+                requested_account_id: account_id.clone(),
+                block_height: block.block_height,
+                block_hash: block.block_hash,
+            },
+        )?;
+
     let state_item = if is_optimistic {
         optimistic_view_state(data, block, account_id, prefix).await?
     } else {
@@ -429,17 +440,6 @@ async fn optimistic_view_state(
     Vec<near_primitives::views::StateItem>,
     near_jsonrpc::primitives::types::query::RpcQueryError,
 > {
-    data.db_manager
-        .get_account(account_id, block.block_height, "query_view_state")
-        .await
-        .map_err(
-            |_err| near_jsonrpc::primitives::types::query::RpcQueryError::UnknownAccount {
-                requested_account_id: account_id.clone(),
-                block_height: block.block_height,
-                block_hash: block.block_hash,
-            },
-        )?;
-
     let mut optimistic_data = data
         .blocks_info_by_finality
         .optimistic_state_changes_in_block(account_id, prefix)
@@ -500,17 +500,6 @@ async fn database_view_state(
     Vec<near_primitives::views::StateItem>,
     near_jsonrpc::primitives::types::query::RpcQueryError,
 > {
-    data.db_manager
-        .get_account(account_id, block.block_height, "query_view_state")
-        .await
-        .map_err(
-            |_err| near_jsonrpc::primitives::types::query::RpcQueryError::UnknownAccount {
-                requested_account_id: account_id.clone(),
-                block_height: block.block_height,
-                block_hash: block.block_hash,
-            },
-        )?;
-
     let state_from_db = get_state_from_db_with_timeout(
         &data.db_manager,
         account_id,

--- a/rpc-server/src/modules/queries/methods.rs
+++ b/rpc-server/src/modules/queries/methods.rs
@@ -429,6 +429,17 @@ async fn optimistic_view_state(
     Vec<near_primitives::views::StateItem>,
     near_jsonrpc::primitives::types::query::RpcQueryError,
 > {
+    data.db_manager
+        .get_account(account_id, block.block_height, "query_view_state")
+        .await
+        .map_err(
+            |_err| near_jsonrpc::primitives::types::query::RpcQueryError::UnknownAccount {
+                requested_account_id: account_id.clone(),
+                block_height: block.block_height,
+                block_hash: block.block_hash,
+            },
+        )?;
+
     let mut optimistic_data = data
         .blocks_info_by_finality
         .optimistic_state_changes_in_block(account_id, prefix)
@@ -449,43 +460,34 @@ async fn optimistic_view_state(
             block_hash: block.block_hash,
         }
     })?;
-    if state_from_db.is_empty() && optimistic_data.is_empty() {
-        Err(
-            near_jsonrpc::primitives::types::query::RpcQueryError::UnknownAccount {
-                requested_account_id: account_id.clone(),
-                block_height: block.block_height,
-                block_hash: block.block_hash,
-            },
-        )
-    } else {
-        let mut values: Vec<near_primitives::views::StateItem> = state_from_db
-            .into_iter()
-            .filter_map(|(key, value)| {
-                let value = if let Some(value) = optimistic_data.remove(&key) {
-                    value.clone()
-                } else {
-                    Some(value)
-                };
-                value.map(|value| near_primitives::views::StateItem {
-                    key: key.into(),
-                    value: value.into(),
+
+    let mut values: Vec<near_primitives::views::StateItem> = state_from_db
+        .into_iter()
+        .filter_map(|(key, value)| {
+            let value = if let Some(value) = optimistic_data.remove(&key) {
+                value.clone()
+            } else {
+                Some(value)
+            };
+            value.map(|value| near_primitives::views::StateItem {
+                key: key.into(),
+                value: value.into(),
+            })
+        })
+        .collect();
+    let optimistic_items: Vec<near_primitives::views::StateItem> = optimistic_data
+        .iter()
+        .filter_map(|(key, value)| {
+            value
+                .clone()
+                .map(|value| near_primitives::views::StateItem {
+                    key: key.clone().into(),
+                    value: value.clone().into(),
                 })
-            })
-            .collect();
-        let optimistic_items: Vec<near_primitives::views::StateItem> = optimistic_data
-            .iter()
-            .filter_map(|(key, value)| {
-                value
-                    .clone()
-                    .map(|value| near_primitives::views::StateItem {
-                        key: key.clone().into(),
-                        value: value.clone().into(),
-                    })
-            })
-            .collect();
-        values.extend(optimistic_items);
-        Ok(values)
-    }
+        })
+        .collect();
+    values.extend(optimistic_items);
+    Ok(values)
 }
 
 #[cfg_attr(feature = "tracing-instrumentation", tracing::instrument(skip(data)))]
@@ -498,6 +500,17 @@ async fn database_view_state(
     Vec<near_primitives::views::StateItem>,
     near_jsonrpc::primitives::types::query::RpcQueryError,
 > {
+    data.db_manager
+        .get_account(account_id, block.block_height, "query_view_state")
+        .await
+        .map_err(
+            |_err| near_jsonrpc::primitives::types::query::RpcQueryError::UnknownAccount {
+                requested_account_id: account_id.clone(),
+                block_height: block.block_height,
+                block_hash: block.block_hash,
+            },
+        )?;
+
     let state_from_db = get_state_from_db_with_timeout(
         &data.db_manager,
         account_id,
@@ -514,24 +527,15 @@ async fn database_view_state(
             block_hash: block.block_hash,
         }
     })?;
-    if state_from_db.is_empty() {
-        Err(
-            near_jsonrpc::primitives::types::query::RpcQueryError::UnknownAccount {
-                requested_account_id: account_id.clone(),
-                block_height: block.block_height,
-                block_hash: block.block_hash,
-            },
-        )
-    } else {
-        let values: Vec<near_primitives::views::StateItem> = state_from_db
-            .into_iter()
-            .map(|(key, value)| near_primitives::views::StateItem {
-                key: key.into(),
-                value: value.into(),
-            })
-            .collect();
-        Ok(values)
-    }
+
+    let values: Vec<near_primitives::views::StateItem> = state_from_db
+        .into_iter()
+        .map(|(key, value)| near_primitives::views::StateItem {
+            key: key.into(),
+            value: value.into(),
+        })
+        .collect();
+    Ok(values)
 }
 
 #[cfg_attr(feature = "tracing-instrumentation", tracing::instrument(skip(data)))]


### PR DESCRIPTION
This PR closes #302. Basically current fix is very straightforward, therefore it might not be very optimal. We simply check whether an account exists in our DB and handle "Unknown account" error before fetching the state. If we didn't exit function during the check, then we print the state no matter of its value (even if the state is empty). I also thought about the approach that would require to change the raw sql statement of getting the state from DB, maybe by utilizing join command on `state_changes_account` and `state_changes_data`, but this would be also an extra call to db and it will be quite heavy, so I decided to stick to this approach. I guess that in order to come up with the most optimal solution we need to change the way how we store `state_changes_data`

Before:
![image](https://github.com/user-attachments/assets/7f260cf1-00bd-4f11-a21a-bdf12d781108)

After:
![image](https://github.com/user-attachments/assets/86b1445a-9ce1-440f-929c-9ec020ae9285)
