### PR TITLE
(state-indexer): config.toml provisioning

### DIFF
--- a/configuration/src/configs/mod.rs
+++ b/configuration/src/configs/mod.rs
@@ -81,6 +81,9 @@ pub struct CommonConfig {
     pub rightsizing: rightsizing::CommonRightsizingConfig,
     pub lake_config: lake::CommonLakeConfig,
     pub database: database::CommonDatabaseConfig,
+    // Set as default to avoid breaking changes
+    // This options needs only for tx_indexer and rpc_server
+    #[serde(default)]
     pub tx_details_storage: tx_details_storage::CommonTxDetailStorageConfig,
 }
 


### PR DESCRIPTION
`tx_details_storage` - is not required for state indexers
more details here: https://github.com/near/read-rpc/issues/304