### PR TITLE
add read_only flag for database config

### DIFF
--- a/configuration/src/configs/database.rs
+++ b/configuration/src/configs/database.rs
@@ -18,6 +18,19 @@ pub struct DatabaseConfig {
     pub database_url: DatabaseConnectUrl,
     pub shards_config:
         std::collections::HashMap<near_primitives::types::ShardId, DatabaseConnectUrl>,
+    // Migrations cannot be applied to read-only replicas
+    // We should run rpc-server only on read-only replicas
+    pub read_only: bool,
+}
+
+impl DatabaseConfig {
+    pub fn to_read_only(&self) -> Self {
+        Self {
+            database_url: self.database_url.clone(),
+            shards_config: self.shards_config.clone(),
+            read_only: true,
+        }
+    }
 }
 
 #[derive(serde_derive::Deserialize, Debug, Clone, Default)]
@@ -37,6 +50,7 @@ impl From<CommonDatabaseConfig> for DatabaseConfig {
                 .into_iter()
                 .map(|shard| (shard.shard_id, shard.database_url))
                 .collect(),
+            read_only: false,
         }
     }
 }

--- a/configuration/src/configs/mod.rs
+++ b/configuration/src/configs/mod.rs
@@ -124,7 +124,7 @@ impl Config for RpcServerConfig {
         Self {
             general: common_config.general.into(),
             lake_config: common_config.lake_config.into(),
-            database: database::DatabaseConfig::from(common_config.database),
+            database: database::DatabaseConfig::from(common_config.database).to_read_only(),
             tx_details_storage: tx_details_storage::TxDetailsStorageConfig::from(
                 common_config.tx_details_storage,
             ),


### PR DESCRIPTION
Migrations cannot be applied to read-only replicas