### PR TITLE
feat: added config checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1610,6 +1610,7 @@ dependencies = [
  "tracing-stackdriver",
  "tracing-subscriber",
  "url",
+ "validator",
 ]
 
 [[package]]
@@ -8811,6 +8812,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
 dependencies = [
  "getrandom 0.2.15",
+]
+
+[[package]]
+name = "validator"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db79c75af171630a3148bd3e6d7c4f42b6a9a014c2945bc5ed0020cbb8d9478e"
+dependencies = [
+ "idna",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "url",
+ "validator_derive",
+]
+
+[[package]]
+name = "validator_derive"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55591299b7007f551ed1eb79a684af7672c19c3193fb9e0a31936987bb2438ec"
+dependencies = [
+ "darling 0.20.10",
+ "once_cell",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.71",
 ]
 
 [[package]]

--- a/config.toml
+++ b/config.toml
@@ -11,7 +11,7 @@ redis_url = "${REDIS_URL}"
 [general.rpc_server]
 server_port = "${SERVER_PORT}"
 max_gas_burnt = "${MAX_GAS_BURNT}"
-contract_code_cache_size = "${CONTRACT_CODE_CAHCE_SIZE}"
+contract_code_cache_size = "${CONTRACT_CODE_CACHE_SIZE}"
 block_cache_size = "${BLOCK_CACHE_SIZE}"
 shadow_data_consistency_rate = "${SHADOW_DATA_CONSISTENCY_RATE}"
 prefetch_state_size_limit = "${PREFETCH_STATE_SIZE_LIMIT}"

--- a/configuration/Cargo.toml
+++ b/configuration/Cargo.toml
@@ -19,6 +19,7 @@ regex = "1.10.2"
 serde = "1.0.145"
 serde_derive = "1.0.145"
 serde_json = "1.0.108"
+validator = { version = "0.18.1", features = ["derive"] }
 opentelemetry = { version = "0.19", features = ["rt-tokio-current-thread"] }
 opentelemetry-jaeger = { version = "0.18", features = [
     "rt-tokio-current-thread",

--- a/configuration/src/configs/database.rs
+++ b/configuration/src/configs/database.rs
@@ -1,15 +1,18 @@
-use crate::configs::{deserialize_data_or_env, deserialize_url_or_env};
+use crate::configs::deserialize_data_or_env;
+use validator::Validate;
+
 use near_lake_framework::near_indexer_primitives::near_primitives;
 
 // Database connection URL
 // Example: "postgres://user:password@localhost:5432/dbname"
 type DatabaseConnectUrl = String;
 
-#[derive(serde_derive::Deserialize, Debug, Clone, Default)]
+#[derive(Validate, serde_derive::Deserialize, Debug, Clone, Default)]
 pub struct ShardDatabaseConfig {
     #[serde(deserialize_with = "deserialize_data_or_env")]
     pub shard_id: u64,
-    #[serde(deserialize_with = "deserialize_url_or_env")]
+    #[validate(url(message = "Invalid database shard URL"))]
+    #[serde(deserialize_with = "deserialize_data_or_env")]
     pub database_url: DatabaseConnectUrl,
 }
 
@@ -33,10 +36,12 @@ impl DatabaseConfig {
     }
 }
 
-#[derive(serde_derive::Deserialize, Debug, Clone, Default)]
+#[derive(Validate, serde_derive::Deserialize, Debug, Clone, Default)]
 pub struct CommonDatabaseConfig {
-    #[serde(deserialize_with = "deserialize_url_or_env")]
+    #[validate(url(message = "Invalid database URL"))]
+    #[serde(deserialize_with = "deserialize_data_or_env")]
     pub database_url: DatabaseConnectUrl,
+    #[validate(nested)]
     #[serde(default)]
     pub shards: Vec<ShardDatabaseConfig>,
 }

--- a/configuration/src/configs/database.rs
+++ b/configuration/src/configs/database.rs
@@ -1,7 +1,7 @@
-use crate::configs::deserialize_data_or_env;
+use near_lake_framework::near_indexer_primitives::near_primitives;
 use validator::Validate;
 
-use near_lake_framework::near_indexer_primitives::near_primitives;
+use crate::configs::deserialize_data_or_env;
 
 // Database connection URL
 // Example: "postgres://user:password@localhost:5432/dbname"

--- a/configuration/src/configs/database.rs
+++ b/configuration/src/configs/database.rs
@@ -1,4 +1,4 @@
-use crate::configs::deserialize_data_or_env;
+use crate::configs::{deserialize_data_or_env, deserialize_url_or_env};
 use near_lake_framework::near_indexer_primitives::near_primitives;
 
 // Database connection URL
@@ -9,7 +9,7 @@ type DatabaseConnectUrl = String;
 pub struct ShardDatabaseConfig {
     #[serde(deserialize_with = "deserialize_data_or_env")]
     pub shard_id: u64,
-    #[serde(deserialize_with = "deserialize_data_or_env")]
+    #[serde(deserialize_with = "deserialize_url_or_env")]
     pub database_url: DatabaseConnectUrl,
 }
 
@@ -35,7 +35,7 @@ impl DatabaseConfig {
 
 #[derive(serde_derive::Deserialize, Debug, Clone, Default)]
 pub struct CommonDatabaseConfig {
-    #[serde(deserialize_with = "deserialize_data_or_env")]
+    #[serde(deserialize_with = "deserialize_url_or_env")]
     pub database_url: DatabaseConnectUrl,
     #[serde(default)]
     pub shards: Vec<ShardDatabaseConfig>,

--- a/configuration/src/configs/general.rs
+++ b/configuration/src/configs/general.rs
@@ -3,7 +3,10 @@ use std::str::FromStr;
 use serde_derive::Deserialize;
 
 use crate::configs::{
-    deserialize_data_or_env, deserialize_optional_data_or_env, required_value_or_panic,
+    deserialize_data_or_env, deserialize_optional_block_cache_size_or_env,
+    deserialize_optional_contract_code_cache_size_or_env, deserialize_optional_data_or_env,
+    deserialize_optional_shadow_data_consistency_rate_or_env, deserialize_optional_url_or_env,
+    required_value_or_panic,
 };
 
 #[derive(Debug, Clone)]
@@ -53,13 +56,13 @@ pub struct GeneralNearStateIndexerConfig {
 pub struct CommonGeneralConfig {
     #[serde(deserialize_with = "deserialize_data_or_env")]
     pub chain_id: ChainId,
-    #[serde(deserialize_with = "deserialize_optional_data_or_env", default)]
+    #[serde(deserialize_with = "deserialize_optional_url_or_env", default)]
     pub near_rpc_url: Option<String>,
-    #[serde(deserialize_with = "deserialize_optional_data_or_env", default)]
+    #[serde(deserialize_with = "deserialize_optional_url_or_env", default)]
     pub near_archival_rpc_url: Option<String>,
-    #[serde(deserialize_with = "deserialize_optional_data_or_env", default)]
+    #[serde(deserialize_with = "deserialize_optional_url_or_env", default)]
     pub referer_header_value: Option<String>,
-    #[serde(deserialize_with = "deserialize_optional_data_or_env", default)]
+    #[serde(deserialize_with = "deserialize_optional_url_or_env", default)]
     pub redis_url: Option<String>,
     #[serde(default)]
     pub rpc_server: CommonGeneralRpcServerConfig,
@@ -101,11 +104,20 @@ pub struct CommonGeneralRpcServerConfig {
     pub server_port: Option<u16>,
     #[serde(deserialize_with = "deserialize_optional_data_or_env", default)]
     pub max_gas_burnt: Option<u64>,
-    #[serde(deserialize_with = "deserialize_optional_data_or_env", default)]
+    #[serde(
+        deserialize_with = "deserialize_optional_contract_code_cache_size_or_env",
+        default
+    )]
     pub contract_code_cache_size: Option<f64>,
-    #[serde(deserialize_with = "deserialize_optional_data_or_env", default)]
+    #[serde(
+        deserialize_with = "deserialize_optional_block_cache_size_or_env",
+        default
+    )]
     pub block_cache_size: Option<f64>,
-    #[serde(deserialize_with = "deserialize_optional_data_or_env", default)]
+    #[serde(
+        deserialize_with = "deserialize_optional_shadow_data_consistency_rate_or_env",
+        default
+    )]
     pub shadow_data_consistency_rate: Option<f64>,
     #[serde(deserialize_with = "deserialize_optional_data_or_env", default)]
     pub prefetch_state_size_limit: Option<u64>,

--- a/configuration/src/configs/general.rs
+++ b/configuration/src/configs/general.rs
@@ -1,12 +1,10 @@
 use std::str::FromStr;
 
 use serde_derive::Deserialize;
+use validator::Validate;
 
 use crate::configs::{
-    deserialize_data_or_env, deserialize_optional_block_cache_size_or_env,
-    deserialize_optional_contract_code_cache_size_or_env, deserialize_optional_data_or_env,
-    deserialize_optional_shadow_data_consistency_rate_or_env, deserialize_optional_url_or_env,
-    required_value_or_panic,
+    deserialize_data_or_env, deserialize_optional_data_or_env, required_value_or_panic,
 };
 
 #[derive(Debug, Clone)]
@@ -52,18 +50,23 @@ pub struct GeneralNearStateIndexerConfig {
     pub concurrency: usize,
 }
 
-#[derive(Deserialize, Debug, Clone, Default)]
+#[derive(Validate, Deserialize, Debug, Clone, Default)]
 pub struct CommonGeneralConfig {
     #[serde(deserialize_with = "deserialize_data_or_env")]
     pub chain_id: ChainId,
-    #[serde(deserialize_with = "deserialize_optional_url_or_env", default)]
+    #[validate(url(message = "Invalid NEAR RPC URL"))]
+    #[serde(deserialize_with = "deserialize_optional_data_or_env", default)]
     pub near_rpc_url: Option<String>,
-    #[serde(deserialize_with = "deserialize_optional_url_or_env", default)]
+    #[validate(url(message = "Invalid NEAR Archival RPC URL"))]
+    #[serde(deserialize_with = "deserialize_optional_data_or_env", default)]
     pub near_archival_rpc_url: Option<String>,
-    #[serde(deserialize_with = "deserialize_optional_url_or_env", default)]
+    #[validate(url(message = "Invalid referer header value"))]
+    #[serde(deserialize_with = "deserialize_optional_data_or_env", default)]
     pub referer_header_value: Option<String>,
-    #[serde(deserialize_with = "deserialize_optional_url_or_env", default)]
+    #[validate(url(message = "Invalid Redis URL"))]
+    #[serde(deserialize_with = "deserialize_optional_data_or_env", default)]
     pub redis_url: Option<String>,
+    #[validate(nested)]
     #[serde(default)]
     pub rpc_server: CommonGeneralRpcServerConfig,
     #[serde(default)]
@@ -98,26 +101,24 @@ impl FromStr for ChainId {
     }
 }
 
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Validate, Deserialize, Debug, Clone)]
 pub struct CommonGeneralRpcServerConfig {
     #[serde(deserialize_with = "deserialize_optional_data_or_env", default)]
     pub server_port: Option<u16>,
     #[serde(deserialize_with = "deserialize_optional_data_or_env", default)]
     pub max_gas_burnt: Option<u64>,
-    #[serde(
-        deserialize_with = "deserialize_optional_contract_code_cache_size_or_env",
-        default
-    )]
+    #[validate(range(min = 0.0, message = "Contract code cache size must be greater than 0"))]
+    #[serde(deserialize_with = "deserialize_optional_data_or_env", default)]
     pub contract_code_cache_size: Option<f64>,
-    #[serde(
-        deserialize_with = "deserialize_optional_block_cache_size_or_env",
-        default
-    )]
+    #[validate(range(min = 0.0, message = "Block cache size must be greater than 0"))]
+    #[serde(deserialize_with = "deserialize_optional_data_or_env", default)]
     pub block_cache_size: Option<f64>,
-    #[serde(
-        deserialize_with = "deserialize_optional_shadow_data_consistency_rate_or_env",
-        default
-    )]
+    #[validate(range(
+        min = 0.0,
+        max = 100.0,
+        message = "Shadow data consistency rate must be between 0 and 100"
+    ))]
+    #[serde(deserialize_with = "deserialize_optional_data_or_env", default)]
     pub shadow_data_consistency_rate: Option<f64>,
     #[serde(deserialize_with = "deserialize_optional_data_or_env", default)]
     pub prefetch_state_size_limit: Option<u64>,

--- a/configuration/src/configs/general.rs
+++ b/configuration/src/configs/general.rs
@@ -107,10 +107,16 @@ pub struct CommonGeneralRpcServerConfig {
     pub server_port: Option<u16>,
     #[serde(deserialize_with = "deserialize_optional_data_or_env", default)]
     pub max_gas_burnt: Option<u64>,
-    #[validate(range(min = 0.0, message = "Contract code cache size must be greater than 0"))]
+    #[validate(range(
+        min = 0.0,
+        message = "Contract code cache size must be greater than or equal to 0"
+    ))]
     #[serde(deserialize_with = "deserialize_optional_data_or_env", default)]
     pub contract_code_cache_size: Option<f64>,
-    #[validate(range(min = 0.0, message = "Block cache size must be greater than 0"))]
+    #[validate(range(
+        min = 0.0,
+        message = "Block cache size must be greater than or equal to 0"
+    ))]
     #[serde(deserialize_with = "deserialize_optional_data_or_env", default)]
     pub block_cache_size: Option<f64>,
     #[validate(range(

--- a/configuration/src/configs/mod.rs
+++ b/configuration/src/configs/mod.rs
@@ -59,6 +59,35 @@ where
     serde_json::from_value::<T>(value).map_err(serde::de::Error::custom)
 }
 
+fn deserialize_url_or_env<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = serde_json::Value::deserialize(deserializer)?;
+    if let serde_json::Value::String(value) = &value {
+        if let Some(caps) = RE_NAME_ENV.captures(value) {
+            let env_value =
+                get_env_var::<String>(&caps["env_name"]).map_err(serde::de::Error::custom)?;
+            if url::Url::parse(&env_value).is_ok() {
+                return Ok(env_value);
+            } else {
+                tracing::warn!("Failed to deserialize_url_or_env: Environment variable value should be a valid URL");
+                return Err(serde::de::Error::custom(
+                    "Environment variable value should be a valid URL",
+                ));
+            }
+        }
+    }
+
+    let value = serde_json::from_value::<String>(value).map_err(serde::de::Error::custom)?;
+    if url::Url::parse(&value).is_ok() {
+        Ok(value)
+    } else {
+        tracing::warn!("Failed to deserialize_url_or_env: Value should be a valid URL");
+        Err(serde::de::Error::custom("Value should be a valid URL"))
+    }
+}
+
 fn deserialize_optional_data_or_env<'de, D, T>(data: D) -> Result<Option<T>, D::Error>
 where
     D: serde::Deserializer<'de>,
@@ -67,6 +96,92 @@ where
 {
     Ok(match deserialize_data_or_env(data) {
         Ok(value) => Some(value),
+        Err(err) => {
+            tracing::warn!("Failed to deserialize_optional_data_or_env: {:?}", err);
+            None
+        }
+    })
+}
+
+fn deserialize_optional_url_or_env<'de, D>(data: D) -> Result<Option<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Ok(match deserialize_data_or_env::<D, String>(data) {
+        Ok(value) => {
+            if url::Url::parse(&value).is_ok() {
+                Some(value.to_string())
+            } else {
+                tracing::warn!(
+                    "Failed to deserialize_optional_url_or_env: Value should be a valid URL"
+                );
+                None
+            }
+        }
+        Err(err) => {
+            tracing::warn!("Failed to deserialize_optional_url_or_env: {:?}", err);
+            None
+        }
+    })
+}
+
+fn deserialize_optional_contract_code_cache_size_or_env<'de, D>(
+    data: D,
+) -> Result<Option<f64>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Ok(match deserialize_data_or_env(data) {
+        Ok(value) => {
+            if value >= 0.0 {
+                Some(value)
+            } else {
+                tracing::warn!("Failed to deserialize_optional_contract_code_cache_size_or_env: Value should be greater than or equal to 0");
+                None
+            }
+        }
+        Err(err) => {
+            tracing::warn!("Failed to deserialize_optional_data_or_env: {:?}", err);
+            None
+        }
+    })
+}
+
+fn deserialize_optional_block_cache_size_or_env<'de, D>(data: D) -> Result<Option<f64>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Ok(match deserialize_data_or_env(data) {
+        Ok(value) => {
+            if value >= 0.0 {
+                Some(value)
+            } else {
+                tracing::warn!("Failed to deserialize_optional_block_cache_size_or_env: Value should be greater than or equal to 0");
+                None
+            }
+        }
+        Err(err) => {
+            tracing::warn!("Failed to deserialize_optional_data_or_env: {:?}", err);
+            None
+        }
+    })
+}
+
+fn deserialize_optional_shadow_data_consistency_rate_or_env<'de, D>(
+    data: D,
+) -> Result<Option<f64>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Ok(match deserialize_data_or_env(data) {
+        Ok(value) => {
+            if (0.0..=100.0).contains(&value) {
+                Some(value)
+            } else {
+                tracing::warn!("Failed to deserialize_optional_shadow_data_consistency_rate_or_env: Value should be in range 0.0..100.0");
+                None
+            }
+        }
         Err(err) => {
             tracing::warn!("Failed to deserialize_optional_data_or_env: {:?}", err);
             None

--- a/configuration/src/lib.rs
+++ b/configuration/src/lib.rs
@@ -22,9 +22,7 @@ where
     let common_config = read_toml_file(path_root).await?;
 
     if let Err(validation_errors) = common_config.validate() {
-        for error in validation_errors.0.values() {
-            tracing::warn!("Failed to validate config: {error:?}");
-        }
+        tracing::warn!("Failed to validate config: {validation_errors}");
     }
 
     Ok(T::from_common_config(common_config))

--- a/configuration/src/lib.rs
+++ b/configuration/src/lib.rs
@@ -22,7 +22,7 @@ where
     let common_config = read_toml_file(path_root).await?;
 
     if let Err(validation_errors) = common_config.validate() {
-        tracing::warn!("Failed to validate config: {validation_errors}");
+        panic!("Failed to validate config: {validation_errors}");
     }
 
     Ok(T::from_common_config(common_config))


### PR DESCRIPTION
This PR introduces additional validation checks for certain configuration variables. Specifically, it ensures that all URLs and `f64` values adhere to their expected formats and constraints

Here's an example of running rpc-server with invalid env variables:
![image](https://github.com/user-attachments/assets/b64332fe-8f5c-44f0-a265-65d45d2e4ddd)
