### PR TITLE
(tx-indexer): Fix restore tx in cache after interruption

### DIFF
--- a/tx-indexer/src/main.rs
+++ b/tx-indexer/src/main.rs
@@ -66,7 +66,7 @@ async fn main() -> anyhow::Result<()> {
         .lake_config(start_block_height)
         .await?;
 
-    tracing::info!(target: INDEXER, "Creating hash storage...");
+    tracing::info!(target: INDEXER, "Creating cache storage...");
     let tx_collecting_storage = std::sync::Arc::new(
         storage::CacheStorage::init_with_restore(
             indexer_config.general.redis_url.to_string(),


### PR DESCRIPTION
The indexers work pretty fast. 
We use the KEYS method to get the list of transactions, which is relatively slow. 
And sometimes we get into a situation where the indexer already running has time to save the transaction 
and we get an error `Unexpected length of input`. 
This hook will help to avoid such situations when launching several indexers.