### PR TITLE
feat: saving outcomes and receipts

### DIFF
--- a/tx-indexer/src/collector.rs
+++ b/tx-indexer/src/collector.rs
@@ -91,11 +91,13 @@ async fn save_outcomes_and_receipts(
 
     if !receipts_and_outcomes_to_save.is_empty() {
         let db_manager_clone = db_manager.clone();
+        let tx_collecting_storage_clone = tx_collecting_storage.clone();
         tokio::spawn(async move {
             let save_receipts_and_outcomes_futures = receipts_and_outcomes_to_save.into_iter().map(
                 |(shard_id, receipts_and_outcomes)| {
-                    save_outcome_and_receipt_to_shard(
+                    save_receipts_and_outcomes_details(
                         &db_manager_clone,
+                        &tx_collecting_storage_clone,
                         shard_id,
                         receipts_and_outcomes.receipts,
                         receipts_and_outcomes.outcomes,
@@ -109,23 +111,92 @@ async fn save_outcomes_and_receipts(
     Ok(())
 }
 
+#[cfg_attr(feature = "tracing-instrumentation", tracing::instrument(skip_all))]
+async fn save_receipts_and_outcomes_details(
+    db_manager: &std::sync::Arc<Box<dyn database::TxIndexerDbManager + Sync + Send + 'static>>,
+    tx_collecting_storage: &std::sync::Arc<crate::storage::CacheStorage>,
+    shard_id: database::primitives::ShardId,
+    receipts: Vec<readnode_primitives::ReceiptRecord>,
+    outcomes: Vec<readnode_primitives::OutcomeRecord>,
+) {
+    match save_outcome_and_receipt_to_shard(
+        db_manager,
+        shard_id,
+        receipts.clone(),
+        outcomes.clone(),
+    )
+    .await
+    {
+        Ok(_) => {
+            for receipt in receipts {
+                tx_collecting_storage
+                    .remove_receipt_from_watching_list(&receipt.receipt_id.to_string())
+                    .await
+                    .map_err(|err| {
+                        tracing::error!(
+                            target: crate::INDEXER,
+                            "Failed to remove receipt from watching list {}: Error {}",
+                            receipt.receipt_id.to_string(),
+                            err
+                        );
+                        err
+                    })
+                    .ok();
+            }
+        }
+        Err(err) => {
+            tracing::error!(
+                target: crate::INDEXER,
+                "Failed to save receipts and outcomes for shard {}: Error {}",
+                shard_id,
+                err
+            );
+
+            for (receipt, outcome) in receipts.into_iter().zip(outcomes) {
+                tx_collecting_storage
+                    .push_outcome_and_receipt_to_save(
+                        &outcome.outcome_id,
+                        &receipt.receipt_id,
+                        &outcome.parent_transaction_hash,
+                        &receipt.receiver_id,
+                        readnode_primitives::BlockRecord {
+                            height: outcome.block_height,
+                            hash: outcome.block_hash,
+                        },
+                        shard_id,
+                    )
+                    .await
+                    .map_err(|err| {
+                        tracing::error!(
+                            target: crate::INDEXER,
+                            "Failed to push outcome_and_receipt to save ({}, {}): Error {}",
+                            receipt.receipt_id.to_string(),
+                            outcome.outcome_id.to_string(),
+                            err
+                        );
+                        err
+                    })
+                    .ok();
+            }
+        }
+    }
+}
+
 async fn save_outcome_and_receipt_to_shard(
     db_manager: &std::sync::Arc<Box<dyn database::TxIndexerDbManager + Sync + Send + 'static>>,
     shard_id: database::primitives::ShardId,
     receipts: Vec<readnode_primitives::ReceiptRecord>,
     outcomes: Vec<readnode_primitives::OutcomeRecord>,
-) {
+) -> anyhow::Result<()> {
     let mut save_attempts = 0;
     'retry: loop {
         save_attempts += 1;
         if save_attempts >= SAVE_ATTEMPTS {
-            tracing::error!(
-                target: crate::INDEXER,
+            anyhow::bail!(
                 "Failed to save receipts and outcomes for shard {} after {} attempts",
                 shard_id,
                 save_attempts,
             );
-            break 'retry;
         }
         match db_manager
             .save_outcome_and_receipt(shard_id, receipts.clone(), outcomes.clone())
@@ -142,7 +213,7 @@ async fn save_outcome_and_receipt_to_shard(
                         save_attempts,
                     );
                 }
-                break 'retry;
+                break 'retry Ok(());
             }
             Err(err) => {
                 tracing::warn!(

--- a/tx-indexer/src/collector.rs
+++ b/tx-indexer/src/collector.rs
@@ -143,10 +143,10 @@ async fn save_receipts_and_outcomes_details(
             );
 
             tx_collecting_storage
-                .return_outcomes_to_save(outcomes)
+                .return_outcomes_to_save(shard_id, outcomes)
                 .await;
             tx_collecting_storage
-                .return_receipts_to_save(receipts)
+                .return_receipts_to_save(shard_id, receipts)
                 .await;
         }
     }

--- a/tx-indexer/src/storage.rs
+++ b/tx-indexer/src/storage.rs
@@ -223,7 +223,10 @@ impl CacheStorage {
     }
 
     #[cfg_attr(feature = "tracing-instrumentation", tracing::instrument(skip_all))]
-    async fn remove_receipt_from_watching_list(&self, receipt_id: &str) -> anyhow::Result<()> {
+    pub(crate) async fn remove_receipt_from_watching_list(
+        &self,
+        receipt_id: &str,
+    ) -> anyhow::Result<()> {
         if let Some(transaction_key) = self.receipts_watching_list.write().await.remove(receipt_id)
         {
             if let Some(receipts_counter) = self

--- a/tx-indexer/src/storage.rs
+++ b/tx-indexer/src/storage.rs
@@ -459,6 +459,40 @@ impl CacheStorage {
         Ok(())
     }
 
+    pub(crate) async fn return_outcomes_to_save(
+        &self,
+        outcomes: Vec<readnode_primitives::OutcomeRecord>,
+    ) {
+        for outcome in outcomes {
+            self.outcomes_and_receipts_to_save
+                .write()
+                .await
+                .entry(outcome.shard_id)
+                .and_modify(|receipts_and_outcomes| {
+                    receipts_and_outcomes
+                        .outcomes
+                        .insert(outcome.outcome_id.to_string(), outcome);
+                });
+        }
+    }
+
+    pub(crate) async fn return_receipts_to_save(
+        &self,
+        receipts: Vec<readnode_primitives::ReceiptRecord>,
+    ) {
+        for receipt in receipts {
+            self.outcomes_and_receipts_to_save
+                .write()
+                .await
+                .entry(receipt.shard_id)
+                .and_modify(|receipts_and_outcomes| {
+                    receipts_and_outcomes
+                        .receipts
+                        .insert(receipt.receipt_id.to_string(), receipt);
+                });
+        }
+    }
+
     #[cfg_attr(feature = "tracing-instrumentation", tracing::instrument(skip_all))]
     pub(crate) async fn push_outcome_and_receipt(
         &self,


### PR DESCRIPTION
Now `save_outcomes_and_receipts` function manages data just like `save_finished_transaction_details`:
In case of successful saving outcome and receipt to shard it removes receipt from the watchlist. Otherwise, it pushes data back to the queue