### PR TITLE
feat: added error metrics

### DIFF
--- a/rpc-server/src/main.rs
+++ b/rpc-server/src/main.rs
@@ -157,7 +157,10 @@ async fn main() -> anyhow::Result<()> {
         // custom requests methods
         .with_method(
             "view_state_paginated",
-            handle_rpc_method!(modules::state::methods::view_state_paginated, "view_state"),
+            handle_rpc_method!(
+                modules::state::methods::view_state_paginated,
+                "view_state_paginated"
+            ),
         )
         .with_method(
             "view_receipt_record",

--- a/rpc-server/src/metrics.rs
+++ b/rpc-server/src/metrics.rs
@@ -128,6 +128,12 @@ lazy_static! {
         &["method_name"] // This declares a label named `method name`
     ).unwrap();
 
+    pub(crate) static ref METHOD_ERRORS_TOTAL: IntCounterVec = register_int_counter_vec(
+        "method_errors_total",
+        "Total number of errors for method",
+        &["method_name", "error_type"] // This declares a label named `method_name` and `error_type`
+    ).unwrap();
+
     pub(crate) static ref TOTAL_REQUESTS_COUNTER: IntCounterVec = register_int_counter_vec(
         "total_requests_counter",
         "Total number of method requests by type",


### PR DESCRIPTION
This PR is adding more metrics based on the method name and returned error type (`ParseError`, `HandlerError` or `InternalError`)

Example:
<img width="679" alt="image" src="https://github.com/user-attachments/assets/7c4a8dbe-2f73-422b-ac3c-4d6c4e2fa3f0">

closes #314