### PR TITLE
(tx-indexer): Drop `validator` feature along with code, add `save_receipts_outcomes` feature [by default]

### DIFF
--- a/tx-indexer/Cargo.toml
+++ b/tx-indexer/Cargo.toml
@@ -41,6 +41,7 @@ near-jsonrpc-client.workspace = true
 near-lake-framework.workspace = true
 
 [features]
-default = []
-validator = []
+default = ["save_receipts_outcomes"]
+# this feature enables storing receipt and outcome data to DB
+save_receipts_outcomes = []
 tracing-instrumentation = ["configuration/tracing-instrumentation"]

--- a/tx-indexer/src/storage.rs
+++ b/tx-indexer/src/storage.rs
@@ -370,6 +370,7 @@ impl CacheStorage {
         Ok(transactions)
     }
 
+    #[cfg(feature = "save_outcomes_and_receipts")]
     #[cfg_attr(feature = "tracing-instrumentation", tracing::instrument(skip_all))]
     pub(crate) async fn outcomes_and_receipts_to_save(
         &self,
@@ -459,6 +460,7 @@ impl CacheStorage {
         Ok(())
     }
 
+    #[cfg(feature = "save_outcomes_and_receipts")]
     pub(crate) async fn return_outcomes_to_save(
         &self,
         shard_id: u64,
@@ -478,6 +480,7 @@ impl CacheStorage {
             });
     }
 
+    #[cfg(feature = "save_outcomes_and_receipts")]
     pub(crate) async fn return_receipts_to_save(
         &self,
         shard_id: u64,


### PR DESCRIPTION
This PR affects `tx-indexer` for V2 only.

* Dropped the feature `validator` since we figured we don't need it anyway
* Added another feature `save_receipts_outcomes`. I made it default. When enabled, it saves data about receipts and outcomes to the database. 

The main idea behind a new feature is that we want to index/reindex only transaction details data stored in the bucket and don't want to do extra work related to storing receipt/outcome data in the DB. The feature is required in the "tip of the network" mode.