### PR TITLE
fix: removed `try_join` to await futures

### DIFF
--- a/database/src/base/state_indexer.rs
+++ b/database/src/base/state_indexer.rs
@@ -48,8 +48,10 @@ pub trait StateIndexerDbManager {
         let add_block_future = self.save_block(block_height, block_hash);
         let add_chunks_future = self.save_chunks(block_height, chunks);
 
-        futures::try_join!(add_block_future, add_chunks_future)?;
-        Ok(())
+        futures::future::join_all([add_block_future, add_chunks_future])
+            .await
+            .into_iter()
+            .collect::<anyhow::Result<()>>()
     }
 
     async fn save_state_changes_data(

--- a/database/src/base/tx_indexer.rs
+++ b/database/src/base/tx_indexer.rs
@@ -20,8 +20,11 @@ pub trait TxIndexerDbManager {
     ) -> anyhow::Result<()> {
         let save_outcome_future = self.save_outcomes(shard_id, outcomes);
         let save_receipt_future = self.save_receipts(shard_id, receipts);
-        futures::try_join!(save_outcome_future, save_receipt_future)?;
-        Ok(())
+
+        futures::future::join_all([save_outcome_future, save_receipt_future])
+            .await
+            .into_iter()
+            .collect::<anyhow::Result<()>>()
     }
 
     async fn update_meta(&self, indexer_id: &str, block_height: u64) -> anyhow::Result<()>;

--- a/rpc-server/src/modules/blocks/methods.rs
+++ b/rpc-server/src/modules/blocks/methods.rs
@@ -562,8 +562,11 @@ async fn fetch_shards_by_cache_block(
                 shard_id,
             )
         });
-    futures::future::try_join_all(fetch_shards_futures)
+
+    futures::future::join_all(fetch_shards_futures)
         .await
+        .into_iter()
+        .collect::<Result<_, _>>()
         .map_err(|err| {
             anyhow::anyhow!(
                 "Failed to fetch shards for block {} with error: {}",

--- a/rpc-server/src/modules/blocks/mod.rs
+++ b/rpc-server/src/modules/blocks/mod.rs
@@ -295,16 +295,31 @@ impl BlocksInfoByFinality {
         let final_block_future = crate::utils::get_final_block(near_rpc_client, false);
         let optimistic_block_future = crate::utils::get_final_block(near_rpc_client, true);
         let validators_future = crate::utils::get_current_validators(near_rpc_client);
-        let (final_block, optimistic_block, validators) = tokio::try_join!(
+        let (final_block, optimistic_block, validators) = futures::future::join3(
             final_block_future,
             optimistic_block_future,
             validators_future,
         )
-        .map_err(|err| {
-            tracing::error!("Error to fetch final block info: {:?}", err);
-            err
-        })
-        .expect("Error to get final block info");
+        .await;
+
+        let final_block = final_block
+            .map_err(|err| {
+                tracing::error!("Error to fetch final block info: {:?}", err);
+                err
+            })
+            .expect("Error to get final block info");
+        let optimistic_block = optimistic_block
+            .map_err(|err| {
+                tracing::error!("Error to fetch optimistic block info: {:?}", err);
+                err
+            })
+            .expect("Error to get optimistic block info");
+        let validators = validators
+            .map_err(|err| {
+                tracing::error!("Error to fetch validators info: {:?}", err);
+                err
+            })
+            .expect("Error to get validators info");
 
         blocks_cache
             .put(final_block.header.height, CacheBlock::from(&final_block))

--- a/rpc-server/src/modules/blocks/mod.rs
+++ b/rpc-server/src/modules/blocks/mod.rs
@@ -295,31 +295,17 @@ impl BlocksInfoByFinality {
         let final_block_future = crate::utils::get_final_block(near_rpc_client, false);
         let optimistic_block_future = crate::utils::get_final_block(near_rpc_client, true);
         let validators_future = crate::utils::get_current_validators(near_rpc_client);
-        let (final_block, optimistic_block, validators) = futures::future::join3(
+
+        let (final_block, optimistic_block, validators) = futures::try_join!(
             final_block_future,
             optimistic_block_future,
             validators_future,
         )
-        .await;
-
-        let final_block = final_block
-            .map_err(|err| {
-                tracing::error!("Error to fetch final block info: {:?}", err);
-                err
-            })
-            .expect("Error to get final block info");
-        let optimistic_block = optimistic_block
-            .map_err(|err| {
-                tracing::error!("Error to fetch optimistic block info: {:?}", err);
-                err
-            })
-            .expect("Error to get optimistic block info");
-        let validators = validators
-            .map_err(|err| {
-                tracing::error!("Error to fetch validators info: {:?}", err);
-                err
-            })
-            .expect("Error to get validators info");
+        .map_err(|err| {
+            tracing::error!("Error to fetch final block info: {:?}", err);
+            err
+        })
+        .expect("Error to get final block info");
 
         blocks_cache
             .put(final_block.header.height, CacheBlock::from(&final_block))

--- a/rpc-server/src/modules/gas/methods.rs
+++ b/rpc-server/src/modules/gas/methods.rs
@@ -29,7 +29,7 @@ pub async fn gas_price(
     {
         let result = match &cache_block {
             Ok(block) => {
-                if let None = gas_price_request.block_id {
+                if gas_price_request.block_id.is_none() {
                     gas_price_request.block_id =
                         Some(near_primitives::types::BlockId::Height(block.block_height));
                 };

--- a/rpc-server/src/modules/queries/methods.rs
+++ b/rpc-server/src/modules/queries/methods.rs
@@ -250,22 +250,24 @@ async fn view_code(
         is_optimistic
     );
     let (code, account) = if is_optimistic {
-        tokio::try_join!(
+        futures::future::join(
             optimistic_view_code(data, block, account_id, "query_view_code"),
             optimistic_view_account(data, block, account_id, "query_view_code"),
-        )?
+        )
+        .await
     } else {
-        tokio::try_join!(
+        futures::future::join(
             database_view_code(data, block, account_id, "query_view_code"),
             database_view_account(data, block, account_id, "query_view_code"),
-        )?
+        )
+        .await
     };
 
     Ok(near_jsonrpc::primitives::types::query::RpcQueryResponse {
         kind: near_jsonrpc::primitives::types::query::QueryResponseKind::ViewCode(
             near_primitives::views::ContractCodeView {
-                code,
-                hash: account.code_hash,
+                code: code?,
+                hash: account?.code_hash,
             },
         ),
         block_height: block.block_height,

--- a/rpc-server/src/modules/queries/methods.rs
+++ b/rpc-server/src/modules/queries/methods.rs
@@ -369,10 +369,9 @@ async fn function_call(
         maybe_optimistic_data,
         data.prefetch_state_size_limit,
     )
-    .await;
+    .await
+    .map_err(|err| err.to_rpc_query_error(block.block_height, block.block_hash))?;
 
-    let call_results =
-        call_results.map_err(|err| err.to_rpc_query_error(block.block_height, block.block_hash))?;
     Ok(near_jsonrpc::primitives::types::query::RpcQueryResponse {
         kind: near_jsonrpc::primitives::types::query::QueryResponseKind::CallResult(
             near_primitives::views::CallResult {
@@ -380,8 +379,8 @@ async fn function_call(
                 logs: call_results.logs,
             },
         ),
-        block_height: block.block_height,
-        block_hash: block.block_hash,
+        block_height: call_results.block_height,
+        block_hash: call_results.block_hash,
     })
 }
 

--- a/rpc-server/src/modules/queries/methods.rs
+++ b/rpc-server/src/modules/queries/methods.rs
@@ -250,24 +250,22 @@ async fn view_code(
         is_optimistic
     );
     let (code, account) = if is_optimistic {
-        futures::future::join(
+        futures::try_join!(
             optimistic_view_code(data, block, account_id, "query_view_code"),
             optimistic_view_account(data, block, account_id, "query_view_code"),
-        )
-        .await
+        )?
     } else {
-        futures::future::join(
+        futures::try_join!(
             database_view_code(data, block, account_id, "query_view_code"),
             database_view_account(data, block, account_id, "query_view_code"),
-        )
-        .await
+        )?
     };
 
     Ok(near_jsonrpc::primitives::types::query::RpcQueryResponse {
         kind: near_jsonrpc::primitives::types::query::QueryResponseKind::ViewCode(
             near_primitives::views::ContractCodeView {
-                code: code?,
-                hash: account?.code_hash,
+                code,
+                hash: account.code_hash,
             },
         ),
         block_height: block.block_height,

--- a/rpc-server/src/utils.rs
+++ b/rpc-server/src/utils.rs
@@ -533,7 +533,7 @@ where
             // both response objects included for future investigation
             ShadowDataConsistencyError::ResultsDontMatch {
                 error_message: "Success results don't match".to_string(),
-                reason: DataMismatchReason::ReadRpcSuccessNearRpcSuccess,
+                reason: DataMismatchReason::SuccessNearRpcSuccess,
                 read_rpc_response: read_rpc_json,
                 near_rpc_response: near_rpc_json,
             }
@@ -541,7 +541,7 @@ where
             // read_rpc service has error response and near_rpc has successful response
             ShadowDataConsistencyError::ResultsDontMatch {
                 error_message: "ReadRPC failed, NearRPC success".to_string(),
-                reason: DataMismatchReason::ReadRpcErrorNearRpcSuccess,
+                reason: DataMismatchReason::ErrorNearRpcSuccess,
                 read_rpc_response: read_rpc_json,
                 near_rpc_response: near_rpc_json,
             }
@@ -550,7 +550,7 @@ where
             // Expected that all error will be related with network issues.
             ShadowDataConsistencyError::ResultsDontMatch {
                 error_message: "ReadRPC success, NearRPC failed".to_string(),
-                reason: DataMismatchReason::ReadRpcSuccessNearRpcError,
+                reason: DataMismatchReason::SuccessNearRpcError,
                 read_rpc_response: read_rpc_json,
                 near_rpc_response: near_rpc_json,
             }
@@ -560,7 +560,7 @@ where
             // Expected we will only have a difference in the error text.
             ShadowDataConsistencyError::ResultsDontMatch {
                 error_message: "Both services failed, but results don't match".to_string(),
-                reason: DataMismatchReason::ReadRpcErrorNearRpcError,
+                reason: DataMismatchReason::ErrorNearRpcError,
                 read_rpc_response: read_rpc_json,
                 near_rpc_response: near_rpc_json,
             }
@@ -596,13 +596,13 @@ pub enum ShadowDataConsistencyError {
 #[derive(Debug)]
 pub enum DataMismatchReason {
     /// ReadRPC returns success result and NEAR RPC returns success result but the results mismatch
-    ReadRpcSuccessNearRpcSuccess,
+    SuccessNearRpcSuccess,
     /// ReadRPC returns success result and NEAR RPC returns error result
-    ReadRpcSuccessNearRpcError,
+    SuccessNearRpcError,
     /// ReadRPC returns error result and NEAR RPC returns success result
-    ReadRpcErrorNearRpcSuccess,
+    ErrorNearRpcSuccess,
     /// ReadRPC returns error result and NEAR RPC returns error result but the results mismatch
-    ReadRpcErrorNearRpcError,
+    ErrorNearRpcError,
 }
 
 #[cfg(feature = "shadow_data_consistency")]
@@ -611,10 +611,10 @@ impl DataMismatchReason {
     /// metrics like BLOCK_ERROR_0, BLOCK_ERROR_1, BLOCK_ERROR_2, BLOCK_ERROR_3 etc.
     pub fn code(&self) -> String {
         match self {
-            DataMismatchReason::ReadRpcSuccessNearRpcSuccess => "0".to_string(),
-            DataMismatchReason::ReadRpcSuccessNearRpcError => "1".to_string(),
-            DataMismatchReason::ReadRpcErrorNearRpcSuccess => "2".to_string(),
-            DataMismatchReason::ReadRpcErrorNearRpcError => "3".to_string(),
+            DataMismatchReason::SuccessNearRpcSuccess => "0".to_string(),
+            DataMismatchReason::SuccessNearRpcError => "1".to_string(),
+            DataMismatchReason::ErrorNearRpcSuccess => "2".to_string(),
+            DataMismatchReason::ErrorNearRpcError => "3".to_string(),
         }
     }
 
@@ -622,16 +622,10 @@ impl DataMismatchReason {
     /// human readable reason for the mismatch.
     pub fn reason(&self) -> &'static str {
         match self {
-            DataMismatchReason::ReadRpcSuccessNearRpcSuccess => {
-                "Read RPC success, and NEAR RPC success"
-            }
-            DataMismatchReason::ReadRpcSuccessNearRpcError => {
-                "Read RPC success, but NEAR RPC error"
-            }
-            DataMismatchReason::ReadRpcErrorNearRpcSuccess => {
-                "Read RPC error, but NEAR RPC success"
-            }
-            DataMismatchReason::ReadRpcErrorNearRpcError => "Read RPC error, and NEAR RPC error",
+            DataMismatchReason::SuccessNearRpcSuccess => "Read RPC success, and NEAR RPC success",
+            DataMismatchReason::SuccessNearRpcError => "Read RPC success, but NEAR RPC error",
+            DataMismatchReason::ErrorNearRpcSuccess => "Read RPC error, but NEAR RPC success",
+            DataMismatchReason::ErrorNearRpcError => "Read RPC error, and NEAR RPC error",
         }
     }
 }

--- a/tx-indexer/src/storage.rs
+++ b/tx-indexer/src/storage.rs
@@ -98,7 +98,10 @@ impl CacheStorage {
         let tx_futures = tx_in_process
             .iter()
             .map(|tx_key| self.restore_transaction_with_receipts(tx_key));
-        futures::future::try_join_all(tx_futures).await?;
+        futures::future::join_all(tx_futures)
+            .await
+            .into_iter()
+            .collect::<anyhow::Result<_>>()?;
         tracing::info!(
             target: STORAGE,
             "Restored {} transactions after interruption",


### PR DESCRIPTION
This PR fixes a misconception behind `try_join` method. It doesn't await until the finish state of all futures, but rather kills other futures if one one them returns an error. You can try it yourself:

```rust
use anyhow::Result;

async fn a() -> Result<()> {
    println!("Throwing an error");
    anyhow::bail!("This is an error");
}

async fn b() -> Result<()> {
    tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
    println!("Returning OK");
    Ok(())
}

#[tokio::main]
async fn main() -> Result<()> {
    futures::try_join!(a(), b())?;

    Ok(())
}
```
As you can see it doesn't print "Returning OK" to the stdout:
<img width="450" alt="image" src="https://github.com/user-attachments/assets/0f9eacc5-2dd2-4ed1-92f4-0f28554d8920">

Now let's modify our code to use regular `join_all` instead and handle possible errors afterwards:
```rust
use anyhow::Result;
use futures::FutureExt;

async fn a() -> Result<()> {
    println!("Throwing an error");
    anyhow::bail!("This is an error");
}

async fn b() -> Result<()> {
    tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
    println!("Returning OK");
    Ok(())
}

#[tokio::main]
async fn main() -> Result<()> {
    futures::future::join_all([a().boxed(), b().boxed()])
        .await
        .into_iter()
        .collect::<Result<_>>()?;

    Ok(())
}
```

And here's the new ouput which waits for both function to finish their execution before handling an error:
<img width="438" alt="image" src="https://github.com/user-attachments/assets/3367e836-3ee3-4088-96e1-debfff8c85e1">

