### PR TITLE
feat: migration from `jsonrpc-v2` to `actix`

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -23,6 +23,24 @@ jobs:
       - name: Set up Rust
         uses: actions-rs/toolchain@v1
 
+      - name: Cargo update
+        run: cargo update
+
+      - name: Git log
+        run: git log
+
+      - name: Print mod
+        run: cat rpc-server/src/modules/network/mod.rs
+
+      - name: Print method
+        run: cat rpc-server/src/modules/network/method.rs
+
+      - name: Search for jsonrpc_v2 references
+        run: grep -R "jsonrpc_v2" .
+
+      - name: Print Cargo.toml
+        run: cat Cargo.toml
+
       - name: Cargo check
         run: cargo check --all-features
 
@@ -52,6 +70,9 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           components: clippy
+
+      - name: Cargo update
+        run: cargo update
 
       - name: Cargo clippy
         run: cargo clippy --all -- -D warnings

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -23,24 +23,6 @@ jobs:
       - name: Set up Rust
         uses: actions-rs/toolchain@v1
 
-      - name: Cargo update
-        run: cargo update
-
-      - name: Git log
-        run: git log
-
-      - name: Print mod
-        run: cat rpc-server/src/modules/network/mod.rs
-
-      - name: Print method
-        run: cat rpc-server/src/modules/network/method.rs
-
-      - name: Search for jsonrpc_v2 references
-        run: grep -R "jsonrpc_v2" .
-
-      - name: Print Cargo.toml
-        run: cat Cargo.toml
-
       - name: Cargo check
         run: cargo check --all-features
 
@@ -70,9 +52,6 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           components: clippy
-
-      - name: Cargo update
-        run: cargo update
 
       - name: Cargo clippy
         run: cargo clippy --all -- -D warnings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2528,15 +2528,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
-name = "extensions"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258f70bd2b060d448403a66d420e81dcac3e5247a4928a887404a5e03715e2e0"
-dependencies = [
- "fxhash",
-]
-
-[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3498,22 +3489,6 @@ name = "json_comments"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9dbbfed4e59ba9750e15ba154fdfd9329cee16ff3df539c2666b70f58cc32105"
-
-[[package]]
-name = "jsonrpc-v2"
-version = "0.11.0"
-source = "git+https://github.com/kobayurii/jsonrpc-v2?branch=rpc-fork#04ffc3acf990dc35acd7c292bc82834b7a85c6c7"
-dependencies = [
- "actix-service",
- "actix-web",
- "async-trait",
- "bytes",
- "erased-serde",
- "extensions",
- "futures",
- "serde",
- "serde_json",
-]
 
 [[package]]
 name = "jsonwebtoken"
@@ -6641,7 +6616,6 @@ dependencies = [
  "futures",
  "futures-locks",
  "hex",
- "jsonrpc-v2",
  "lazy_static",
  "lru 0.12.4",
  "mimalloc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2345,12 +2345,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53aff6fdc1b181225acdcb5b14c47106726fd8e486707315b1b138baed68ee31"
 
 [[package]]
-name = "easy-ext"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc5d6d6a8504f8caedd7de14576464383900cd3840b7033a7a3dce5ac00121ca"
-
-[[package]]
 name = "ecdsa"
 version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4058,7 +4052,7 @@ dependencies = [
  "bytesize",
  "chrono",
  "crossbeam-channel",
- "easy-ext 0.2.9",
+ "easy-ext",
  "enum-map",
  "itertools 0.10.5",
  "itoa",
@@ -4460,7 +4454,7 @@ dependencies = [
  "actix-web",
  "bs58",
  "derive_more",
- "easy-ext 0.2.9",
+ "easy-ext",
  "futures",
  "hex",
  "near-async",
@@ -4793,7 +4787,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "chrono",
  "derive_more",
- "easy-ext 0.2.9",
+ "easy-ext",
  "enum-map",
  "hex",
  "near-crypto 0.20.1",
@@ -4835,7 +4829,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "chrono",
  "derive_more",
- "easy-ext 0.2.9",
+ "easy-ext",
  "hex",
  "itertools 0.10.5",
  "near-crypto 2.0.0",
@@ -5292,7 +5286,7 @@ dependencies = [
  "chrono",
  "cloud-storage",
  "dirs",
- "easy-ext 0.2.9",
+ "easy-ext",
  "futures",
  "hex",
  "hyper 0.14.30",
@@ -6643,7 +6637,6 @@ dependencies = [
  "chrono",
  "configuration",
  "database",
- "easy-ext 1.0.2",
  "erased-serde",
  "futures",
  "futures-locks",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,9 +86,9 @@ dependencies = [
 
 [[package]]
 name = "actix-http"
-version = "3.8.0"
+version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae682f693a9cd7b058f2b0b5d9a6d7728a8555779bedbbc35dd88528611d020"
+checksum = "d48f96fc3003717aeb9856ca3d02a8c7de502667ad76eeacd830b48d2e91fac4"
 dependencies = [
  "actix-codec",
  "actix-rt",
@@ -130,7 +130,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
 dependencies = [
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -220,9 +220,9 @@ dependencies = [
 
 [[package]]
 name = "actix-web"
-version = "4.8.0"
+version = "4.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1988c02af8d2b718c05bc4aeb6a66395b7cdf32858c2c71131e5637a8c05a9ff"
+checksum = "9180d76e5cc7ccbc4d60a506f2c727730b154010262df5b910eb17dbe4b8cb38"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -242,6 +242,7 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
+ "impl-more",
  "itoa",
  "language-tags",
  "log",
@@ -268,7 +269,7 @@ dependencies = [
  "actix-router",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -279,7 +280,7 @@ checksum = "7c7db3d5a9718568e4cf4a537cfd7070e6e6ff7481510d0237fb529ac850f6d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -305,6 +306,12 @@ name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
+name = "adler2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "ahash"
@@ -503,7 +510,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -514,7 +521,7 @@ checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -550,9 +557,9 @@ checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "awc"
-version = "3.5.0"
+version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe6b67e44fb95d1dc9467e3930383e115f9b4ed60ca689db41409284e967a12d"
+checksum = "79049b2461279b886e46f1107efc347ebecc7b88d74d023dda010551a124967b"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -584,9 +591,9 @@ dependencies = [
 
 [[package]]
 name = "aws-config"
-version = "1.5.4"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf6cfe2881cb1fcbba9ae946fb9a6480d3b7a714ca84c74925014a89ef3387a"
+checksum = "4e95816a168520d72c0e7680c405a5a8c1fb6a035b4bc4b9d7b0de8e1a941697"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -604,7 +611,6 @@ dependencies = [
  "fastrand 2.1.0",
  "hex",
  "http 0.2.12",
- "hyper 0.14.30",
  "ring 0.17.8",
  "time",
  "tokio",
@@ -652,9 +658,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87c5f920ffd1e0526ec9e70e50bf444db50b204395a0fa7016bbf9e31ea1698f"
+checksum = "f42c2d4218de4dcd890a109461e2f799a1a2ba3bcd2cde9af88360f5df9266c6"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -668,6 +674,7 @@ dependencies = [
  "fastrand 2.1.0",
  "http 0.2.12",
  "http-body 0.4.6",
+ "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "tracing",
@@ -676,9 +683,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.42.0"
+version = "1.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "558bbcec8db82a1a8af1610afcb3b10d00652d25ad366a0558eecdff2400a1d1"
+checksum = "4abf69a87be33b6f125a93d5046b5f7395c26d1f449bf8d3927f5577463b6de0"
 dependencies = [
  "ahash 0.8.11",
  "aws-credential-types",
@@ -711,9 +718,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.36.0"
+version = "1.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6acca681c53374bf1d9af0e317a41d12a44902ca0f2d1e10e5cb5bb98ed74f35"
+checksum = "11822090cf501c316c6f75711d77b96fba30658e3867a7762e5e2f5d32d31e81"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -733,9 +740,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.37.0"
+version = "1.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b79c6bdfe612503a526059c05c9ccccbf6bd9530b003673cb863e547fd7c0c9a"
+checksum = "78a2a06ff89176123945d1bbe865603c4d7101bea216a550bb4d2e4e9ba74d74"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -755,9 +762,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.36.0"
+version = "1.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e6ecdb2bd756f3b2383e6f0588dc10a4e65f5d551e70a56e0bfe0c884673ce"
+checksum = "a20a91795850826a6f456f4a48eff1dfa59a0e69bdbf5b8c50518fd372106574"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -818,9 +825,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.60.11"
+version = "0.60.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c4134cf3adaeacff34d588dbe814200357b0c466d730cf1c0d8054384a2de4"
+checksum = "598b1689d001c4d4dc3cb386adb07d37786783aee3ac4b324bcadac116bf3d23"
 dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",
@@ -890,9 +897,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.6.2"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce87155eba55e11768b8c1afa607f3e864ae82f03caf63258b37455b0ad02537"
+checksum = "0abbf454960d0db2ad12684a1640120e7557294b0ff8e2f11236290a1b293225"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -917,9 +924,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30819352ed0a04ecf6a2f3477e344d2d1ba33d43e0f09ad9047c12e0d923616f"
+checksum = "e086682a53d3aa241192aa110fa8dfce98f2f5ac2ead0de84d41582c7e8fdb96"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-types",
@@ -934,9 +941,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.2.0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe321a6b21f5d8eabd0ade9c55d3d0335f3c3157fc2b3e87f05f34b539e4df5"
+checksum = "6cee7cadb433c781d3299b916fbf620fea813bf38f49db282fb6858141a05cc8"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -1036,7 +1043,7 @@ dependencies = [
  "cc",
  "cfg-if 1.0.0",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.7.4",
  "object 0.36.3",
  "rustc-demangle",
 ]
@@ -1125,7 +1132,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -1261,7 +1268,7 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
  "syn_derive",
 ]
 
@@ -1424,12 +1431,13 @@ checksum = "a2698f953def977c68f935bb0dfa959375ad4638570e969e2f1e9f433cbf1af6"
 
 [[package]]
 name = "cc"
-version = "1.1.8"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "504bdec147f2cc13c8b57ed9401fd8a147cc66b67ad5cb241394244f2c947549"
+checksum = "72db2f7947ecee9b03b510377e8bb9077afa27176fdbff55c51027e976fdcc48"
 dependencies = [
  "jobserver",
  "libc",
+ "shlex",
 ]
 
 [[package]]
@@ -1496,9 +1504,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.13"
+version = "4.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fbb260a053428790f3de475e304ff84cdbc4face759ea7a3e64c1edd938a7fc"
+checksum = "ed6719fffa43d0d87e5fd8caeab59be1554fb028cd30edc88fc4369b17971019"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1506,9 +1514,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.13"
+version = "4.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64b17d7ea74e9f833c7dbf2cbe4fb12ff26783eda4782a8975b72f895c9b4d99"
+checksum = "216aec2b177652e3846684cbfe25c9964d18ec45234f0f5da5157b207ed1aab6"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1525,7 +1533,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -1676,9 +1684,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpp_demangle"
@@ -1691,9 +1699,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
+checksum = "51e852e6dc9a5bed1fae92dd2375037bf2b768725bf3be87811edee3249d09ad"
 dependencies = [
  "libc",
 ]
@@ -1999,7 +2007,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -2047,7 +2055,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -2069,7 +2077,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core 0.20.10",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -2153,7 +2161,7 @@ checksum = "62d671cc41a825ebabc75757b62d3d168c577f9149b2d49ece1dad1f72119d25"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -2164,7 +2172,7 @@ checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -2208,7 +2216,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version 0.4.0",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -2439,7 +2447,7 @@ checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -2460,7 +2468,7 @@ dependencies = [
  "darling 0.20.10",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -2597,12 +2605,12 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.0.31"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f211bbe8e69bbd0cfdea405084f128ae8b4aaa6b0b522fc8f2b009084797920"
+checksum = "9c0596c1eac1f9e04ed902702e9878208b336edc9d6fddc8a48387349bab3666"
 dependencies = [
  "crc32fast",
- "miniz_oxide",
+ "miniz_oxide 0.8.0",
 ]
 
 [[package]]
@@ -2755,7 +2763,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -2860,7 +2868,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 dependencies = [
  "fallible-iterator",
- "indexmap 2.3.0",
+ "indexmap 2.4.0",
  "stable_deref_trait",
 ]
 
@@ -2888,7 +2896,7 @@ dependencies = [
  "google-cloud-token",
  "home",
  "jsonwebtoken 9.3.0",
- "reqwest 0.12.5",
+ "reqwest 0.12.7",
  "serde",
  "serde_json",
  "thiserror",
@@ -2904,7 +2912,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04f945a208886a13d07636f38fb978da371d0abc3e34bad338124b9f8c135a8f"
 dependencies = [
- "reqwest 0.12.5",
+ "reqwest 0.12.7",
  "thiserror",
  "tokio",
 ]
@@ -2929,7 +2937,7 @@ dependencies = [
  "percent-encoding",
  "pkcs8 0.10.2",
  "regex",
- "reqwest 0.12.5",
+ "reqwest 0.12.7",
  "reqwest-middleware",
  "ring 0.17.8",
  "serde",
@@ -2974,7 +2982,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.3.0",
+ "indexmap 2.4.0",
  "slab",
  "tokio",
  "tokio-util 0.7.11",
@@ -3359,9 +3367,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3fc2e30ba82dd1b3911c8de1ffc143c74a914a14e99514d7637e3099df5ea0"
+checksum = "93ead53efc7ea8ed3cfb0c79fc8023fbb782a5432b52830b6518941cebe6505c"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.5",
@@ -3477,9 +3485,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.69"
+version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -3557,9 +3565,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
 name = "libloading"
@@ -3627,9 +3635,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.18"
+version = "1.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c15da26e5af7e25c90b37a2d75cdbf940cf4a55316de9d84c679c9b8bfabf82e"
+checksum = "fdc53a7799a7496ebc9fd29f31f7df80e83c9bda5299768af5f9e59eeea74647"
 dependencies = [
  "cc",
  "libc",
@@ -3791,7 +3799,7 @@ checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -3921,10 +3929,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "mio"
-version = "1.0.1"
+name = "miniz_oxide"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4569e456d394deccd22ce1c1913e6ea0e54519f577285001215d33557431afe4"
+checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
+name = "mio"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
  "hermit-abi",
  "libc",
@@ -4005,7 +4022,7 @@ source = "git+https://github.com/kobayurii/nearcore.git?branch=2.0.0-fork1#dee62
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -4482,7 +4499,7 @@ dependencies = [
  "near-crypto 2.0.0",
  "near-jsonrpc-primitives 2.0.0",
  "near-primitives 2.0.0",
- "reqwest 0.12.5",
+ "reqwest 0.12.7",
  "serde",
  "serde_json",
  "thiserror",
@@ -4603,7 +4620,7 @@ dependencies = [
  "opentelemetry 0.22.0",
  "parking_lot 0.12.3",
  "pin-project",
- "protobuf 3.5.0",
+ "protobuf 3.5.1",
  "protobuf-codegen",
  "rand 0.8.5",
  "rayon",
@@ -4733,7 +4750,7 @@ version = "2.0.0"
 source = "git+https://github.com/kobayurii/nearcore.git?branch=2.0.0-fork1#dee6256d011b1e2ed5cf83c7ad06308a128259da"
 dependencies = [
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -4913,7 +4930,7 @@ checksum = "80fca203c51edd9595ec14db1d13359fb9ede32314990bf296b6c5c4502f6ab7"
 dependencies = [
  "quote",
  "serde",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -4923,7 +4940,7 @@ source = "git+https://github.com/kobayurii/nearcore.git?branch=2.0.0-fork1#dee62
 dependencies = [
  "quote",
  "serde",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -4935,7 +4952,7 @@ dependencies = [
  "fs2",
  "near-rpc-error-core 0.20.1",
  "serde",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -4945,7 +4962,7 @@ source = "git+https://github.com/kobayurii/nearcore.git?branch=2.0.0-fork1#dee62
 dependencies = [
  "near-rpc-error-core 2.0.0",
  "serde",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -5512,7 +5529,7 @@ checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
 dependencies = [
  "crc32fast",
  "hashbrown 0.14.5",
- "indexmap 2.3.0",
+ "indexmap 2.4.0",
  "memchr",
 ]
 
@@ -5560,7 +5577,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -6104,7 +6121,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.3.0",
+ "indexmap 2.4.0",
 ]
 
 [[package]]
@@ -6124,7 +6141,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -6220,7 +6237,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
 dependencies = [
  "proc-macro2",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -6362,7 +6379,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -6383,9 +6400,9 @@ checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "protobuf"
-version = "3.5.0"
+version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df67496db1a89596beaced1579212e9b7c53c22dca1d9745de00ead76573d514"
+checksum = "0bcc343da15609eaecd65f8aa76df8dc4209d325131d8219358c0aaaebab0bf6"
 dependencies = [
  "once_cell",
  "protobuf-support",
@@ -6394,13 +6411,13 @@ dependencies = [
 
 [[package]]
 name = "protobuf-codegen"
-version = "3.5.0"
+version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eab09155fad2d39333d3796f67845d43e29b266eea74f7bc93f153f707f126dc"
+checksum = "c4d0cde5642ea4df842b13eb9f59ea6fafa26dcb43e3e1ee49120e9757556189"
 dependencies = [
  "anyhow",
  "once_cell",
- "protobuf 3.5.0",
+ "protobuf 3.5.1",
  "protobuf-parse",
  "regex",
  "tempfile",
@@ -6409,14 +6426,14 @@ dependencies = [
 
 [[package]]
 name = "protobuf-parse"
-version = "3.5.0"
+version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a16027030d4ec33e423385f73bb559821827e9ec18c50e7874e4d6de5a4e96f"
+checksum = "1b0e9b447d099ae2c4993c0cbb03c7a9d6c937b17f2d56cfc0b1550e6fcfdb76"
 dependencies = [
  "anyhow",
- "indexmap 2.3.0",
+ "indexmap 2.4.0",
  "log",
- "protobuf 3.5.0",
+ "protobuf 3.5.1",
  "protobuf-support",
  "tempfile",
  "thiserror",
@@ -6425,9 +6442,9 @@ dependencies = [
 
 [[package]]
 name = "protobuf-support"
-version = "3.5.0"
+version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e2d30ab1878b2e72d1e2fc23ff5517799c9929e2cf81a8516f9f4dcf2b9cf3"
+checksum = "f0766e3675a627c327e4b3964582594b0e8741305d628a98a5de75a1d15f99b9"
 dependencies = [
  "thiserror",
 ]
@@ -6713,9 +6730,9 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom 0.2.15",
  "libredox",
@@ -6867,14 +6884,14 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "winreg 0.50.0",
+ "winreg",
 ]
 
 [[package]]
 name = "reqwest"
-version = "0.12.5"
+version = "0.12.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d6d2a27d57148378eb5e111173f4276ad26340ecc5c49a4a2152167a2d6a37"
+checksum = "f8f4955649ef5c38cc7f9e8aa41761d48fb9677197daea9984dc54f56aad5e63"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -6910,19 +6927,19 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "winreg 0.52.0",
+ "windows-registry",
 ]
 
 [[package]]
 name = "reqwest-middleware"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39346a33ddfe6be00cbc17a34ce996818b97b230b87229f10114693becca1268"
+checksum = "562ceb5a604d3f7c885a792d42c199fd8af239d0a51b2fa6a78aafa092452b04"
 dependencies = [
  "anyhow",
  "async-trait",
  "http 1.1.0",
- "reqwest 0.12.5",
+ "reqwest 0.12.7",
  "serde",
  "thiserror",
  "tower-service",
@@ -6980,9 +6997,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.7.44"
+version = "0.7.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cba464629b3394fc4dbc6f940ff8f5b4ff5c7aef40f29166fd4ad12acbc99c0"
+checksum = "9008cd6385b9e161d8229e1f6549dd23c3d022f132a2ea37ac3a10ac4935779b"
 dependencies = [
  "bitvec",
  "bytecheck",
@@ -6998,9 +7015,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.7.44"
+version = "0.7.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7dddfff8de25e6f62b9d64e6e432bf1c6736c57d20323e15ee10435fbda7c65"
+checksum = "503d1d27590a2b0a3a4ca4c94755aa2875657196ecbf401a42eff41d7de532c0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7335,9 +7352,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.205"
+version = "1.0.208"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33aedb1a7135da52b7c21791455563facbbcc43d0f0f66165b42c21b3dfb150"
+checksum = "cff085d2cb684faa248efb494c39b68e522822ac0de72ccf08109abde717cfb2"
 dependencies = [
  "serde_derive",
 ]
@@ -7375,13 +7392,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.205"
+version = "1.0.208"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692d6f5ac90220161d6774db30c662202721e64aed9058d2c394f451261420c1"
+checksum = "24008e81ff7613ed8e5ba0cfaf24e2c2f1e5b8a0495711e44fcd4882fca62bcf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -7395,9 +7412,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.122"
+version = "1.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784b6203951c57ff748476b126ccb5e8e2959a5c19e5c617ab1956be3dbc68da"
+checksum = "83c8e735a073ccf5be70aa8066aa984eaf2fa000db6c8d0100ae605b366d31ed"
 dependencies = [
  "itoa",
  "memchr",
@@ -7413,7 +7430,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -7447,7 +7464,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.3.0",
+ "indexmap 2.4.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -7464,7 +7481,7 @@ dependencies = [
  "darling 0.20.10",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -7473,7 +7490,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.3.0",
+ "indexmap 2.4.0",
  "itoa",
  "ryu",
  "serde",
@@ -7751,7 +7768,7 @@ dependencies = [
  "futures-util",
  "hashlink",
  "hex",
- "indexmap 2.3.0",
+ "indexmap 2.4.0",
  "log",
  "memchr",
  "native-tls",
@@ -8029,9 +8046,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.72"
+version = "2.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
+checksum = "f6af063034fc1935ede7be0122941bafa9bacb949334d090b77ca98b5817c7d9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8047,7 +8064,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -8061,6 +8078,9 @@ name = "sync_wrapper"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "sysinfo"
@@ -8146,7 +8166,7 @@ checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -8239,9 +8259,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.39.2"
+version = "1.39.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daa4fb1bc778bd6f04cbfc4bb2d06a7396a8f299dc33ea1900cedaa316f467b1"
+checksum = "9babc99b9923bfa4804bd74722ff02c0381021eafa4db9949217e3be8e84fff5"
 dependencies = [
  "backtrace",
  "bytes",
@@ -8274,7 +8294,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -8394,7 +8414,7 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
- "indexmap 2.3.0",
+ "indexmap 2.4.0",
  "toml_datetime",
  "winnow 0.5.40",
 ]
@@ -8405,7 +8425,7 @@ version = "0.22.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
 dependencies = [
- "indexmap 2.3.0",
+ "indexmap 2.4.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -8504,15 +8524,15 @@ dependencies = [
 
 [[package]]
 name = "tower-layer"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-service"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -8559,7 +8579,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -8740,9 +8760,9 @@ dependencies = [
 
 [[package]]
 name = "typeid"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "059d83cc991e7a42fc37bd50941885db0888e34209f8cfd9aab07ddec03bc9cf"
+checksum = "0e13db2e0ccd5e14a544e8a246ba2312cd25223f616442d7f2cb0e3db614236e"
 
 [[package]]
 name = "typenum"
@@ -8794,9 +8814,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-properties"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4259d9d4425d9f0661581b804cb85fe66a4c631cadd8f490d1c13a35d5d9291"
+checksum = "52ea75f83c0137a9b98608359a5f1af8144876eb67bcb1ce837368e906a9f524"
 
 [[package]]
 name = "unicode-segmentation"
@@ -8893,7 +8913,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -8961,34 +8981,35 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
 dependencies = [
  "cfg-if 1.0.0",
+ "once_cell",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.42"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
+checksum = "61e9300f63a621e96ed275155c108eb6f843b6a26d053f122ab69724559dc8ed"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -8998,9 +9019,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -9008,22 +9029,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
 
 [[package]]
 name = "wasm-encoder"
@@ -9262,7 +9283,7 @@ version = "0.115.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e06c0641a4add879ba71ccb3a1e4278fd546f76f1eafb21d8f7b07733b547cd5"
 dependencies = [
- "indexmap 2.3.0",
+ "indexmap 2.4.0",
  "semver 1.0.23",
 ]
 
@@ -9287,7 +9308,7 @@ dependencies = [
  "bumpalo",
  "cfg-if 1.0.0",
  "fxprof-processed-profile",
- "indexmap 2.3.0",
+ "indexmap 2.4.0",
  "libc",
  "log",
  "object 0.32.2",
@@ -9366,7 +9387,7 @@ dependencies = [
  "anyhow",
  "cranelift-entity",
  "gimli 0.28.1",
- "indexmap 2.3.0",
+ "indexmap 2.4.0",
  "log",
  "object 0.32.2",
  "serde",
@@ -9432,7 +9453,7 @@ dependencies = [
  "anyhow",
  "cc",
  "cfg-if 1.0.0",
- "indexmap 2.3.0",
+ "indexmap 2.4.0",
  "libc",
  "log",
  "mach",
@@ -9472,7 +9493,7 @@ checksum = "09b5575a75e711ca6c36bb9ad647c93541cdc8e34218031acba5da3f35919dd3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -9483,9 +9504,9 @@ checksum = "9dafab2db172a53e23940e0fa3078c202f567ee5f13f4b42f66b694fab43c658"
 
 [[package]]
 name = "web-sys"
-version = "0.3.69"
+version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
+checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -9578,6 +9599,36 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+dependencies = [
+ "windows-result",
+ "windows-strings",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result",
  "windows-targets 0.52.6",
 ]
 
@@ -9758,16 +9809,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winreg"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
-dependencies = [
- "cfg-if 1.0.0",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "wyz"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9821,7 +9862,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]

--- a/rpc-server/Cargo.toml
+++ b/rpc-server/Cargo.toml
@@ -23,7 +23,6 @@ erased-serde = "0.4.2"
 futures = "0.3.24"
 futures-locks = "0.7.1"
 hex = "0.4.3"
-jsonrpc-v2 = { git = "https://github.com/kobayurii/jsonrpc-v2", branch = "rpc-fork" }
 lazy_static = "1.4.0"
 lru = "0.12.2"
 mimalloc = { version = "0.1.41", default-features = false }

--- a/rpc-server/Cargo.toml
+++ b/rpc-server/Cargo.toml
@@ -55,4 +55,5 @@ near-vm-runner.workspace = true
 [features]
 default = []
 tracing-instrumentation = ["configuration/tracing-instrumentation"]
-shadow_data_consistency = ["dep:assert-json-diff"]
+shadow-data-consistency = ["dep:assert-json-diff"]
+detailed-status-codes = []

--- a/rpc-server/Cargo.toml
+++ b/rpc-server/Cargo.toml
@@ -19,7 +19,6 @@ anyhow = "1.0.70"
 assert-json-diff = { version = "2.0.2", optional = true }
 borsh = "1.3.1"
 chrono = "0.4.19"
-easy-ext = "1"
 erased-serde = "0.4.2"
 futures = "0.3.24"
 futures-locks = "0.7.1"

--- a/rpc-server/src/config.rs
+++ b/rpc-server/src/config.rs
@@ -76,7 +76,7 @@ pub struct ServerContext {
     /// Max gas burnt for contract function call
     pub max_gas_burnt: near_primitives::types::Gas,
     /// How many requests we should check for data consistency
-    #[cfg(feature = "shadow_data_consistency")]
+    #[cfg(feature = "shadow-data-consistency")]
     pub shadow_data_consistency_rate: f64,
     /// Max size for state prefetch during a view_call
     pub prefetch_state_size_limit: u64,
@@ -166,7 +166,7 @@ impl ServerContext {
             compiled_contract_code_cache,
             contract_code_cache,
             max_gas_burnt: rpc_server_config.general.max_gas_burnt,
-            #[cfg(feature = "shadow_data_consistency")]
+            #[cfg(feature = "shadow-data-consistency")]
             shadow_data_consistency_rate: rpc_server_config.general.shadow_data_consistency_rate,
             prefetch_state_size_limit: rpc_server_config.general.prefetch_state_size_limit,
             server_port: rpc_server_config.general.server_port,

--- a/rpc-server/src/errors.rs
+++ b/rpc-server/src/errors.rs
@@ -8,6 +8,12 @@ type BoxedSerialize = Box<dyn erased_serde::Serialize + Send + 'static>;
 #[serde(transparent)]
 pub struct RPCError(pub(crate) near_jsonrpc::primitives::errors::RpcError);
 
+impl From<RPCError> for near_jsonrpc::primitives::errors::RpcError {
+    fn from(err: RPCError) -> Self {
+        err.0
+    }
+}
+
 impl RPCError {
     pub(crate) fn unimplemented_error(method_name: &str) -> Self {
         Self::from(near_jsonrpc::primitives::errors::RpcError::new(

--- a/rpc-server/src/errors.rs
+++ b/rpc-server/src/errors.rs
@@ -2,8 +2,6 @@ use std::ops::{Deref, DerefMut};
 
 use near_jsonrpc_client::errors::{JsonRpcError, JsonRpcServerError};
 
-type BoxedSerialize = Box<dyn erased_serde::Serialize + Send + 'static>;
-
 #[derive(Debug, serde::Serialize)]
 #[serde(transparent)]
 pub struct RPCError(pub(crate) near_jsonrpc::primitives::errors::RpcError);
@@ -15,6 +13,14 @@ impl From<RPCError> for near_jsonrpc::primitives::errors::RpcError {
 }
 
 impl RPCError {
+    pub(crate) fn method_not_found() -> Self {
+        Self::from(near_jsonrpc::primitives::errors::RpcError::new(
+            -32601,
+            "Method not found".to_owned(),
+            None,
+        ))
+    }
+
     pub(crate) fn unimplemented_error(method_name: &str) -> Self {
         Self::from(near_jsonrpc::primitives::errors::RpcError::new(
             -32601,
@@ -53,24 +59,6 @@ impl DerefMut for RPCError {
 impl std::fmt::Display for RPCError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{:?}", self)
-    }
-}
-
-impl jsonrpc_v2::ErrorLike for RPCError {
-    fn code(&self) -> i64 {
-        self.code
-    }
-
-    fn message(&self) -> String {
-        self.message.to_string()
-    }
-
-    fn data(&self) -> Option<BoxedSerialize> {
-        Some(Box::new(self.data.clone()))
-    }
-
-    fn error_struct(&self) -> Option<BoxedSerialize> {
-        Some(Box::new(self.error_struct.clone()))
     }
 }
 

--- a/rpc-server/src/metrics.rs
+++ b/rpc-server/src/metrics.rs
@@ -171,7 +171,7 @@ lazy_static! {
 /// It should help to analyze the most popular requests
 /// And build s better caching strategy
 pub async fn increase_request_category_metrics(
-    data: &jsonrpc_v2::Data<crate::config::ServerContext>,
+    data: &actix_web::web::Data<crate::config::ServerContext>,
     block_reference: &near_primitives::types::BlockReference,
     method_name: &str,
     block_height: Option<u64>,

--- a/rpc-server/src/metrics.rs
+++ b/rpc-server/src/metrics.rs
@@ -77,41 +77,9 @@ impl OptimisticUpdating {
     }
 }
 
-// Help struct to store the RPC methods for the server
-// This is used to store the methods that are available for the server
-// It should be present of METHOD_CALLS_COUNTER metrics
-pub struct RpcMethods {
-    methods: futures_locks::RwLock<std::collections::HashMap<String, String>>,
-}
-
-impl RpcMethods {
-    pub fn new() -> Self {
-        Self {
-            methods: futures_locks::RwLock::new(std::collections::HashMap::new()),
-        }
-    }
-
-    // Insert all rpc methods to the hashmap after init the server
-    pub async fn insert(&self, methods_map: Vec<String>) {
-        for method_name in methods_map {
-            self.methods
-                .write()
-                .await
-                .insert(method_name.clone(), method_name);
-        }
-    }
-
-    // Method to get the method name from the hashmap
-    pub async fn get(&self, method_name: &str) -> Option<String> {
-        self.methods.read().await.get(method_name).cloned()
-    }
-}
-
 // Is not a metric, but a global variable to track the optimistic updating status
 lazy_static! {
     pub(crate) static ref OPTIMISTIC_UPDATING: OptimisticUpdating = OptimisticUpdating::new();
-    // Initialize the RPC methods hashmap
-    pub(crate) static ref RPC_METHODS: RpcMethods = RpcMethods::new();
 }
 
 // Metrics

--- a/rpc-server/src/middlewares.rs
+++ b/rpc-server/src/middlewares.rs
@@ -1,4 +1,4 @@
-use crate::metrics::{METHOD_CALLS_COUNTER, RPC_METHODS};
+use crate::metrics::METHOD_CALLS_COUNTER;
 use actix_web::dev::{forward_ready, Service, ServiceRequest, ServiceResponse, Transform};
 use futures::future::LocalBoxFuture;
 use futures::StreamExt;
@@ -63,8 +63,7 @@ where
             }
 
             if let Ok(obj) = serde_json::from_slice::<Request>(&body) {
-                let method = obj.method.as_ref();
-                if method == "query" {
+                if obj.method == "query" {
                     if let Ok(query_request) =
                         near_jsonrpc::primitives::types::query::RpcQueryRequest::parse(obj.params)
                     {
@@ -90,12 +89,6 @@ where
                         };
                         METHOD_CALLS_COUNTER.with_label_values(&[method]).inc()
                     }
-                } else if RPC_METHODS.get(method).await.is_some() {
-                    METHOD_CALLS_COUNTER.with_label_values(&[method]).inc()
-                } else {
-                    METHOD_CALLS_COUNTER
-                        .with_label_values(&["method_not_found"])
-                        .inc()
                 }
             };
 

--- a/rpc-server/src/modules/blocks/methods.rs
+++ b/rpc-server/src/modules/blocks/methods.rs
@@ -41,7 +41,7 @@ pub async fn chunk(
 ) -> Result<near_jsonrpc::primitives::types::chunks::RpcChunkResponse, RPCError> {
     tracing::debug!("`chunk` called with parameters: {:?}", request_data);
     let result = fetch_chunk(&data, request_data.chunk_reference.clone()).await;
-    #[cfg(feature = "shadow_data_consistency")]
+    #[cfg(feature = "shadow-data-consistency")]
     {
         crate::utils::shadow_compare_results_handler(
             data.shadow_data_consistency_rate,
@@ -129,7 +129,7 @@ async fn block_call(
         Err(err) => Err(err),
     };
 
-    #[cfg(feature = "shadow_data_consistency")]
+    #[cfg(feature = "shadow-data-consistency")]
     {
         if let Ok(res) = &result {
             if let near_primitives::types::BlockReference::Finality(_) =
@@ -171,7 +171,7 @@ async fn changes_in_block_call(
     .map_err(near_jsonrpc::primitives::errors::RpcError::from)?;
 
     let result = fetch_changes_in_block(&data, cache_block, &params.block_reference).await;
-    #[cfg(feature = "shadow_data_consistency")]
+    #[cfg(feature = "shadow-data-consistency")]
     {
         if let near_primitives::types::BlockReference::Finality(_) = params.block_reference {
             params.block_reference = near_primitives::types::BlockReference::from(
@@ -211,7 +211,7 @@ async fn changes_in_block_by_type_call(
     )
     .await;
 
-    #[cfg(feature = "shadow_data_consistency")]
+    #[cfg(feature = "shadow-data-consistency")]
     {
         if let near_primitives::types::BlockReference::Finality(_) = params.block_reference {
             params.block_reference = near_primitives::types::BlockReference::from(

--- a/rpc-server/src/modules/blocks/methods.rs
+++ b/rpc-server/src/modules/blocks/methods.rs
@@ -1,13 +1,12 @@
+use actix_web::web::Data;
+use near_primitives::trie_key::TrieKey;
+use near_primitives::views::StateChangeValueView;
+
 use crate::config::ServerContext;
 use crate::errors::RPCError;
 use crate::modules::blocks::utils::{
     fetch_block_from_cache_or_get, fetch_chunk_from_s3, is_matching_change,
 };
-
-use near_primitives::trie_key::TrieKey;
-use near_primitives::views::StateChangeValueView;
-
-use actix_web::web::Data;
 
 /// `block` rpc method implementation
 /// calls proxy_rpc_call to get `block` from near-rpc if request parameters not supported by read-rpc

--- a/rpc-server/src/modules/blocks/utils.rs
+++ b/rpc-server/src/modules/blocks/utils.rs
@@ -77,7 +77,7 @@ pub async fn fetch_chunk_from_s3(
 
 #[cfg_attr(feature = "tracing-instrumentation", tracing::instrument(skip(data)))]
 pub async fn fetch_block_from_cache_or_get(
-    data: &jsonrpc_v2::Data<ServerContext>,
+    data: &actix_web::web::Data<ServerContext>,
     block_reference: &near_primitives::types::BlockReference,
     method_name: &str,
 ) -> Result<CacheBlock, near_jsonrpc::primitives::types::blocks::RpcBlockError> {

--- a/rpc-server/src/modules/blocks/utils.rs
+++ b/rpc-server/src/modules/blocks/utils.rs
@@ -1,7 +1,8 @@
+use near_primitives::views::{StateChangeValueView, StateChangesRequestView};
+
 use crate::config::ServerContext;
 use crate::modules::blocks::methods::fetch_block;
 use crate::modules::blocks::CacheBlock;
-use near_primitives::views::{StateChangeValueView, StateChangesRequestView};
 
 #[cfg_attr(
     feature = "tracing-instrumentation",

--- a/rpc-server/src/modules/clients/methods.rs
+++ b/rpc-server/src/modules/clients/methods.rs
@@ -1,37 +1,29 @@
 use crate::config::ServerContext;
 use crate::errors::RPCError;
-use jsonrpc_v2::{Data, Params};
-use near_jsonrpc::RpcRequest;
+
+use actix_web::web::Data;
 
 pub async fn light_client_proof(
     data: Data<ServerContext>,
-    Params(params): Params<serde_json::Value>,
+    request_data: near_jsonrpc::primitives::types::light_client::RpcLightClientExecutionProofRequest,
 ) -> Result<
     near_jsonrpc::primitives::types::light_client::RpcLightClientExecutionProofResponse,
     RPCError,
 > {
-    let request =
-        near_jsonrpc::primitives::types::light_client::RpcLightClientExecutionProofRequest::parse(
-            params,
-        )?;
     Ok(data
         .near_rpc_client
-        .archival_call(request, Some("light_client_proof"))
+        .archival_call(request_data, Some("light_client_proof"))
         .await?)
 }
 
 pub async fn next_light_client_block(
     data: Data<ServerContext>,
-    Params(params): Params<serde_json::Value>,
+    request_data: near_jsonrpc::primitives::types::light_client::RpcLightClientNextBlockRequest,
 ) -> Result<near_jsonrpc::primitives::types::light_client::RpcLightClientNextBlockResponse, RPCError>
 {
-    let request =
-        near_jsonrpc::primitives::types::light_client::RpcLightClientNextBlockRequest::parse(
-            params,
-        )?;
     match data
         .near_rpc_client
-        .call(request, Some("next_light_client_block"))
+        .call(request_data, Some("next_light_client_block"))
         .await?
     {
         Some(light_client_block) => Ok(

--- a/rpc-server/src/modules/clients/methods.rs
+++ b/rpc-server/src/modules/clients/methods.rs
@@ -1,7 +1,7 @@
+use actix_web::web::Data;
+
 use crate::config::ServerContext;
 use crate::errors::RPCError;
-
-use actix_web::web::Data;
 
 pub async fn light_client_proof(
     data: Data<ServerContext>,

--- a/rpc-server/src/modules/gas/methods.rs
+++ b/rpc-server/src/modules/gas/methods.rs
@@ -2,7 +2,8 @@ use crate::config::ServerContext;
 use crate::errors::RPCError;
 use crate::modules::blocks::utils::fetch_block_from_cache_or_get;
 use crate::modules::blocks::CacheBlock;
-use jsonrpc_v2::{Data, Params};
+use actix_web::web::Data;
+use jsonrpc_v2::Params;
 use near_jsonrpc::RpcRequest;
 
 #[allow(unused_mut)]

--- a/rpc-server/src/modules/gas/methods.rs
+++ b/rpc-server/src/modules/gas/methods.rs
@@ -2,23 +2,17 @@ use crate::config::ServerContext;
 use crate::errors::RPCError;
 use crate::modules::blocks::utils::fetch_block_from_cache_or_get;
 use crate::modules::blocks::CacheBlock;
+
 use actix_web::web::Data;
-use jsonrpc_v2::Params;
-use near_jsonrpc::RpcRequest;
 
 #[allow(unused_mut)]
 #[cfg_attr(feature = "tracing-instrumentation", tracing::instrument(skip(data)))]
 pub async fn gas_price(
     data: Data<ServerContext>,
-    Params(params): Params<serde_json::Value>,
+    mut request_data: near_jsonrpc::primitives::types::gas_price::RpcGasPriceRequest,
 ) -> Result<near_jsonrpc::primitives::types::gas_price::RpcGasPriceResponse, RPCError> {
-    let mut gas_price_request =
-        near_jsonrpc::primitives::types::gas_price::RpcGasPriceRequest::parse(params)?;
-    tracing::debug!(
-        "`gas_price` called with parameters: {:?}",
-        gas_price_request
-    );
-    let block_reference = match gas_price_request.block_id.clone() {
+    tracing::debug!("`gas_price` called with parameters: {:?}", request_data);
+    let block_reference = match request_data.block_id.clone() {
         Some(block_id) => near_primitives::types::BlockReference::BlockId(block_id),
         None => near_primitives::types::BlockReference::Finality(
             near_primitives::types::Finality::Final,
@@ -30,8 +24,8 @@ pub async fn gas_price(
     {
         let result = match &cache_block {
             Ok(block) => {
-                if gas_price_request.block_id.is_none() {
-                    gas_price_request.block_id =
+                if request_data.block_id.is_none() {
+                    request_data.block_id =
                         Some(near_primitives::types::BlockId::Height(block.block_height));
                 };
                 Ok(near_primitives::views::GasPriceView {
@@ -45,7 +39,7 @@ pub async fn gas_price(
             data.shadow_data_consistency_rate,
             &result,
             data.near_rpc_client.clone(),
-            gas_price_request,
+            request_data,
             "gas_price",
         )
         .await;

--- a/rpc-server/src/modules/gas/methods.rs
+++ b/rpc-server/src/modules/gas/methods.rs
@@ -20,7 +20,7 @@ pub async fn gas_price(
     };
     let cache_block = gas_price_call(&data, block_reference).await;
 
-    #[cfg(feature = "shadow_data_consistency")]
+    #[cfg(feature = "shadow-data-consistency")]
     {
         let result = match &cache_block {
             Ok(block) => {

--- a/rpc-server/src/modules/gas/methods.rs
+++ b/rpc-server/src/modules/gas/methods.rs
@@ -1,9 +1,9 @@
+use actix_web::web::Data;
+
 use crate::config::ServerContext;
 use crate::errors::RPCError;
 use crate::modules::blocks::utils::fetch_block_from_cache_or_get;
 use crate::modules::blocks::CacheBlock;
-
-use actix_web::web::Data;
 
 #[allow(unused_mut)]
 #[cfg_attr(feature = "tracing-instrumentation", tracing::instrument(skip(data)))]

--- a/rpc-server/src/modules/network/methods.rs
+++ b/rpc-server/src/modules/network/methods.rs
@@ -133,7 +133,7 @@ pub async fn validators(
 
     let validator_info = validators_call(&data, &request_data).await;
 
-    #[cfg(feature = "shadow_data_consistency")]
+    #[cfg(feature = "shadow-data-consistency")]
     {
         crate::utils::shadow_compare_results_handler(
             data.shadow_data_consistency_rate,
@@ -227,7 +227,7 @@ pub async fn protocol_config(
 
     let config_view = protocol_config_call(&data, request_data.block_reference.clone()).await;
 
-    #[cfg(feature = "shadow_data_consistency")]
+    #[cfg(feature = "shadow-data-consistency")]
     {
         crate::utils::shadow_compare_results_handler(
             data.shadow_data_consistency_rate,

--- a/rpc-server/src/modules/network/methods.rs
+++ b/rpc-server/src/modules/network/methods.rs
@@ -1,11 +1,10 @@
+use actix_web::web::Data;
+use near_primitives::epoch_manager::{AllEpochConfig, EpochConfig};
+
 use crate::config::ServerContext;
 use crate::errors::RPCError;
 use crate::modules::blocks::utils::fetch_block_from_cache_or_get;
 use crate::modules::network::get_protocol_version;
-
-use near_primitives::epoch_manager::{AllEpochConfig, EpochConfig};
-
-use actix_web::web::Data;
 
 pub async fn client_config(_data: Data<ServerContext>) -> Result<(), RPCError> {
     Err(RPCError::unimplemented_error("client_config"))

--- a/rpc-server/src/modules/network/methods.rs
+++ b/rpc-server/src/modules/network/methods.rs
@@ -1,4 +1,5 @@
-use jsonrpc_v2::{Data, Params};
+use actix_web::web::Data;
+use jsonrpc_v2::Params;
 use near_jsonrpc::RpcRequest;
 use near_primitives::epoch_manager::{AllEpochConfig, EpochConfig};
 

--- a/rpc-server/src/modules/network/mod.rs
+++ b/rpc-server/src/modules/network/mod.rs
@@ -2,7 +2,7 @@ pub mod methods;
 
 // Helper function to get the protocol version
 pub(crate) async fn get_protocol_version(
-    data: &jsonrpc_v2::Data<crate::config::ServerContext>,
+    data: &actix_web::web::Data<crate::config::ServerContext>,
     block_reference: near_primitives::types::BlockReference,
     method_name: &str,
 ) -> anyhow::Result<near_primitives::types::ProtocolVersion> {

--- a/rpc-server/src/modules/queries/contract_runner/code_storage.rs
+++ b/rpc-server/src/modules/queries/contract_runner/code_storage.rs
@@ -1,9 +1,10 @@
 use std::collections::HashMap;
 
+use futures::executor::block_on;
+
 use crate::modules::queries::utils;
 use crate::modules::queries::utils::get_state_key_value_from_db;
 use database::ReaderDbManager;
-use futures::executor::block_on;
 
 pub type Result<T> = ::std::result::Result<T, near_vm_runner::logic::VMLogicError>;
 

--- a/rpc-server/src/modules/queries/contract_runner/mod.rs
+++ b/rpc-server/src/modules/queries/contract_runner/mod.rs
@@ -5,7 +5,6 @@ use near_vm_runner::ContractRuntimeCache;
 
 use crate::errors::FunctionCallError;
 use crate::modules::blocks::BlocksInfoByFinality;
-
 use code_storage::CodeStorage;
 
 mod code_storage;

--- a/rpc-server/src/modules/queries/methods.rs
+++ b/rpc-server/src/modules/queries/methods.rs
@@ -2,7 +2,8 @@ use crate::config::ServerContext;
 use crate::errors::RPCError;
 use crate::modules::blocks::utils::fetch_block_from_cache_or_get;
 use crate::modules::blocks::CacheBlock;
-use jsonrpc_v2::{Data, Params};
+use actix_web::web::Data;
+use jsonrpc_v2::Params;
 use near_jsonrpc::RpcRequest;
 
 use super::contract_runner;

--- a/rpc-server/src/modules/queries/methods.rs
+++ b/rpc-server/src/modules/queries/methods.rs
@@ -118,7 +118,7 @@ async fn query_call(
         }
     };
 
-    #[cfg(feature = "shadow_data_consistency")]
+    #[cfg(feature = "shadow-data-consistency")]
     {
         // Since we do queries with the clause WHERE block_height <= X, we need to
         // make sure that the block we are doing a shadow data consistency check for

--- a/rpc-server/src/modules/queries/methods.rs
+++ b/rpc-server/src/modules/queries/methods.rs
@@ -2,12 +2,11 @@ use crate::config::ServerContext;
 use crate::errors::RPCError;
 use crate::modules::blocks::utils::fetch_block_from_cache_or_get;
 use crate::modules::blocks::CacheBlock;
-use actix_web::web::Data;
-use jsonrpc_v2::Params;
-use near_jsonrpc::RpcRequest;
 
 use super::contract_runner;
 use super::utils::get_state_from_db;
+
+use actix_web::web::Data;
 
 /// `query` rpc method implementation
 /// calls proxy_rpc_call to get `query` from near-rpc if request parameters not supported by read-rpc
@@ -16,16 +15,14 @@ use super::utils::get_state_from_db;
 #[cfg_attr(feature = "tracing-instrumentation", tracing::instrument(skip(data)))]
 pub async fn query(
     data: Data<ServerContext>,
-    Params(params): Params<serde_json::Value>,
+    request_data: near_jsonrpc::primitives::types::query::RpcQueryRequest,
 ) -> Result<near_jsonrpc::primitives::types::query::RpcQueryResponse, RPCError> {
-    let query_request = near_jsonrpc::primitives::types::query::RpcQueryRequest::parse(params)?;
-
     // When the data check fails, we want to emit the log message and increment the
     // corresponding metric. Despite the metrics have "proxies" in their names, we
     // are not proxying the requests anymore and respond with the error to the client.
     // Since we already have the dashboard using these metric names, we don't want to
     // change them and reuse them for the observability of the shadow data consistency checks.
-    let method_name = match &query_request.request {
+    let method_name = match &request_data.request {
         near_primitives::views::QueryRequest::ViewAccount { .. } => "query_view_account",
         near_primitives::views::QueryRequest::ViewCode { .. } => "query_view_code",
         near_primitives::views::QueryRequest::ViewAccessKey { .. } => "query_view_access_key",
@@ -38,21 +35,21 @@ pub async fn query(
 
     if let near_primitives::types::BlockReference::Finality(
         near_primitives::types::Finality::None,
-    ) = &query_request.block_reference
+    ) = &request_data.block_reference
     {
         return if crate::metrics::OPTIMISTIC_UPDATING.is_not_working() {
             // Proxy if the optimistic updating is not working
             Ok(data
                 .near_rpc_client
-                .call(query_request, Some(method_name))
+                .call(request_data, Some(method_name))
                 .await?)
         } else {
             // query_call with optimistic block
-            query_call(&data, query_request, method_name, true).await
+            query_call(&data, request_data, method_name, true).await
         };
     };
 
-    query_call(&data, query_request, method_name, false).await
+    query_call(&data, request_data, method_name, false).await
 }
 
 /// fetch query result from read-rpc

--- a/rpc-server/src/modules/queries/methods.rs
+++ b/rpc-server/src/modules/queries/methods.rs
@@ -1,3 +1,5 @@
+use actix_web::web::Data;
+
 use crate::config::ServerContext;
 use crate::errors::RPCError;
 use crate::modules::blocks::utils::fetch_block_from_cache_or_get;
@@ -5,8 +7,6 @@ use crate::modules::blocks::CacheBlock;
 
 use super::contract_runner;
 use super::utils::get_state_from_db;
-
-use actix_web::web::Data;
 
 /// `query` rpc method implementation
 /// calls proxy_rpc_call to get `query` from near-rpc if request parameters not supported by read-rpc

--- a/rpc-server/src/modules/receipts/methods.rs
+++ b/rpc-server/src/modules/receipts/methods.rs
@@ -13,7 +13,7 @@ pub async fn receipt(
     tracing::debug!("`receipt` call. Params: {:?}", request_data);
     let result = fetch_receipt(&data, &request_data).await;
 
-    #[cfg(feature = "shadow_data_consistency")]
+    #[cfg(feature = "shadow-data-consistency")]
     {
         crate::utils::shadow_compare_results_handler(
             data.shadow_data_consistency_rate,

--- a/rpc-server/src/modules/receipts/methods.rs
+++ b/rpc-server/src/modules/receipts/methods.rs
@@ -1,4 +1,5 @@
-use jsonrpc_v2::{Data, Params};
+use actix_web::web::Data;
+use jsonrpc_v2::Params;
 use near_jsonrpc::RpcRequest;
 
 use crate::config::ServerContext;
@@ -36,13 +37,11 @@ pub async fn receipt(
 #[cfg_attr(feature = "tracing-instrumentation", tracing::instrument(skip(data)))]
 pub async fn view_receipt_record(
     data: Data<ServerContext>,
-    Params(params): Params<serde_json::Value>,
+    request_data: near_jsonrpc::primitives::types::receipts::RpcReceiptRequest,
 ) -> Result<crate::modules::receipts::RpcReceiptRecordResponse, RPCError> {
-    tracing::debug!("`view_receipt_record` call. Params: {:?}", params);
-    let receipt_request =
-        near_jsonrpc::primitives::types::receipts::RpcReceiptRequest::parse(params)?;
+    tracing::debug!("`view_receipt_record` call. Params: {:?}", request_data);
 
-    let result = fetch_receipt_record(&data, &receipt_request, "view_receipt_record").await;
+    let result = fetch_receipt_record(&data, &request_data, "view_receipt_record").await;
 
     Ok(result
         .map_err(near_jsonrpc::primitives::errors::RpcError::from)?

--- a/rpc-server/src/modules/state/methods.rs
+++ b/rpc-server/src/modules/state/methods.rs
@@ -2,7 +2,8 @@ use crate::config::ServerContext;
 use crate::errors::RPCError;
 use crate::modules::blocks::utils::fetch_block_from_cache_or_get;
 use crate::modules::state::utils::get_state_from_db_paginated;
-use jsonrpc_v2::{Data, Params};
+use actix_web::web::Data;
+use jsonrpc_v2::Params;
 
 #[cfg_attr(feature = "tracing-instrumentation", tracing::instrument(skip(data)))]
 pub async fn view_state_paginated(

--- a/rpc-server/src/modules/state/methods.rs
+++ b/rpc-server/src/modules/state/methods.rs
@@ -1,9 +1,9 @@
+use actix_web::web::Data;
+
 use crate::config::ServerContext;
 use crate::errors::RPCError;
 use crate::modules::blocks::utils::fetch_block_from_cache_or_get;
 use crate::modules::state::utils::get_state_from_db_paginated;
-
-use actix_web::web::Data;
 
 #[cfg_attr(feature = "tracing-instrumentation", tracing::instrument(skip(data)))]
 pub async fn view_state_paginated(

--- a/rpc-server/src/modules/transactions/methods.rs
+++ b/rpc-server/src/modules/transactions/methods.rs
@@ -26,7 +26,7 @@ pub async fn tx(
 
     let result = tx_status_common(&data, &request_data.transaction_info, false).await;
 
-    #[cfg(feature = "shadow_data_consistency")]
+    #[cfg(feature = "shadow-data-consistency")]
     {
         crate::utils::shadow_compare_results_handler(
             data.shadow_data_consistency_rate,
@@ -58,7 +58,7 @@ pub async fn tx_status(
 
     let result = tx_status_common(&data, &request_data.transaction_info, true).await;
 
-    #[cfg(feature = "shadow_data_consistency")]
+    #[cfg(feature = "shadow-data-consistency")]
     {
         crate::utils::shadow_compare_results_handler(
             data.shadow_data_consistency_rate,

--- a/rpc-server/src/modules/transactions/methods.rs
+++ b/rpc-server/src/modules/transactions/methods.rs
@@ -1,10 +1,10 @@
-use crate::config::ServerContext;
-use crate::errors::RPCError;
-
 use actix_web::web::Data;
 use near_primitives::views::FinalExecutionOutcomeViewEnum::{
     FinalExecutionOutcome, FinalExecutionOutcomeWithReceipt,
 };
+
+use crate::config::ServerContext;
+use crate::errors::RPCError;
 
 pub async fn send_tx(
     data: Data<ServerContext>,

--- a/rpc-server/src/modules/transactions/methods.rs
+++ b/rpc-server/src/modules/transactions/methods.rs
@@ -1,6 +1,7 @@
 use crate::config::ServerContext;
 use crate::errors::RPCError;
-use jsonrpc_v2::{Data, Params};
+use actix_web::web::Data;
+use jsonrpc_v2::Params;
 use near_jsonrpc::RpcRequest;
 use near_primitives::views::FinalExecutionOutcomeViewEnum::{
     FinalExecutionOutcome, FinalExecutionOutcomeWithReceipt,

--- a/rpc-server/src/modules/transactions/mod.rs
+++ b/rpc-server/src/modules/transactions/mod.rs
@@ -1,5 +1,5 @@
 use crate::config::ServerContext;
-use jsonrpc_v2::Data;
+use actix_web::web::Data;
 
 pub mod methods;
 

--- a/rpc-server/src/modules/transactions/mod.rs
+++ b/rpc-server/src/modules/transactions/mod.rs
@@ -1,5 +1,6 @@
-use crate::config::ServerContext;
 use actix_web::web::Data;
+
+use crate::config::ServerContext;
 
 pub mod methods;
 

--- a/rpc-server/src/utils.rs
+++ b/rpc-server/src/utils.rs
@@ -1,9 +1,9 @@
 use crate::modules::blocks::{BlockInfo, BlocksInfoByFinality, CacheBlock};
-#[cfg(feature = "shadow_data_consistency")]
+#[cfg(feature = "shadow-data-consistency")]
 use assert_json_diff::{assert_json_matches_no_panic, CompareMode, Config, NumericMode};
 use futures::StreamExt;
 
-#[cfg(feature = "shadow_data_consistency")]
+#[cfg(feature = "shadow-data-consistency")]
 const DEFAULT_RETRY_COUNT: u8 = 3;
 
 /// JsonRpcClient represents a client capable of interacting with NEAR JSON-RPC endpoints,
@@ -93,7 +93,7 @@ impl JsonRpcClient {
     }
 
     /// Performs a RPC call to the archival endpoint for shadow comparison results.
-    #[cfg(feature = "shadow_data_consistency")]
+    #[cfg(feature = "shadow-data-consistency")]
     pub async fn shadow_comparison_call<M>(
         &self,
         params: M,
@@ -369,7 +369,7 @@ pub fn friendly_memory_size_format(memory_size_bytes: usize) -> String {
     }
 }
 
-#[cfg(feature = "shadow_data_consistency")]
+#[cfg(feature = "shadow-data-consistency")]
 pub async fn shadow_compare_results_handler<T, E, M>(
     shadow_rate: f64,
     read_rpc_result: &Result<T, E>,
@@ -445,7 +445,7 @@ pub async fn shadow_compare_results_handler<T, E, M>(
     };
 }
 
-#[cfg(feature = "shadow_data_consistency")]
+#[cfg(feature = "shadow-data-consistency")]
 pub async fn is_should_shadow_compare_results(method_total_requests: u64, rate: f64) -> bool {
     let every_request = 100.0 / rate;
     method_total_requests % every_request as u64 == 0
@@ -465,7 +465,7 @@ pub async fn is_should_shadow_compare_results(method_total_requests: u64, rate: 
 ///
 /// In case of a successful comparison, the function returns `Ok(())`.
 /// Otherwise, it returns `Err(ShadowDataConsistencyError)`.
-#[cfg(feature = "shadow_data_consistency")]
+#[cfg(feature = "shadow-data-consistency")]
 pub async fn shadow_compare_results<M>(
     read_rpc_response: Result<serde_json::Value, serde_json::Error>,
     client: JsonRpcClient,
@@ -595,7 +595,7 @@ where
 }
 
 /// Represents the error that can occur during the shadow data consistency check.
-#[cfg(feature = "shadow_data_consistency")]
+#[cfg(feature = "shadow-data-consistency")]
 #[derive(thiserror::Error, Debug)]
 pub enum ShadowDataConsistencyError {
     #[error("Failed to parse ReadRPC response: {0}")]
@@ -616,7 +616,7 @@ pub enum ShadowDataConsistencyError {
 /// This enum is used to track the mismatch between the data returned by the READ RPC server and
 /// the data returned by the NEAR RPC server. The mismatch can be caused by a limited number of
 /// reasons, and this enum is used to track them.
-#[cfg(feature = "shadow_data_consistency")]
+#[cfg(feature = "shadow-data-consistency")]
 #[derive(Debug)]
 pub enum DataMismatchReason {
     /// ReadRPC returns success result and NEAR RPC returns success result but the results mismatch
@@ -629,7 +629,7 @@ pub enum DataMismatchReason {
     ErrorNearRpcError,
 }
 
-#[cfg(feature = "shadow_data_consistency")]
+#[cfg(feature = "shadow-data-consistency")]
 impl DataMismatchReason {
     /// This method converts the reason into a number from 0 to 3. These numbers are used in the
     /// metrics like BLOCK_ERROR_0, BLOCK_ERROR_1, BLOCK_ERROR_2, BLOCK_ERROR_3 etc.
@@ -658,7 +658,7 @@ impl DataMismatchReason {
 ///
 /// 1. sort object key
 /// 2. sort array
-#[cfg(feature = "shadow_data_consistency")]
+#[cfg(feature = "shadow-data-consistency")]
 fn json_sort_value(value: serde_json::Value) -> serde_json::Value {
     match value {
         serde_json::Value::Array(array) => {
@@ -699,7 +699,7 @@ fn json_sort_value(value: serde_json::Value) -> serde_json::Value {
 }
 
 /// Generate array key for sorting
-#[cfg(feature = "shadow_data_consistency")]
+#[cfg(feature = "shadow-data-consistency")]
 fn generate_array_key(value: &serde_json::Value) -> String {
     match value {
         serde_json::Value::Null => "__null__".to_string(),


### PR DESCRIPTION
This migration would help us to:
- Implement custom status codes (200, 400, 404, 408 and 500) like we do it in jsonrpc
- Build a unified server configuration across jsonrpc and read-rpc
- Implement a public jsonrpc trait to have same definition of rpc methods
