### PR TITLE
(rpc_server): Add `block_height_checker` and Fix Chunk Fetch Bug

### DIFF
--- a/rpc-server/src/modules/blocks/methods.rs
+++ b/rpc-server/src/modules/blocks/methods.rs
@@ -1,5 +1,4 @@
 use actix_web::web::Data;
-use near_primitives::block;
 use near_primitives::trie_key::TrieKey;
 use near_primitives::views::StateChangeValueView;
 
@@ -290,7 +289,7 @@ pub async fn fetch_block(
     let block_height = match block_reference {
         near_primitives::types::BlockReference::BlockId(block_id) => match block_id {
             near_primitives::types::BlockId::Height(block_height) => {
-                check_block_height(data, block_height.clone()).await?;
+                check_block_height(data, *block_height).await?;
                 Ok(*block_height)
             }
             near_primitives::types::BlockId::Hash(block_hash) => {
@@ -392,7 +391,7 @@ pub async fn fetch_chunk(
             let block_height =
                 match block_id {
                     near_primitives::types::BlockId::Height(block_height) => {
-                        check_block_height(data, block_height.clone()).await.map_err(|err| {
+                        check_block_height(data, block_height).await.map_err(|err| {
                         near_jsonrpc::primitives::types::chunks::RpcChunkError::UnknownBlock {
                             error_message: err.to_string(),
                         }

--- a/rpc-server/src/modules/blocks/utils.rs
+++ b/rpc-server/src/modules/blocks/utils.rs
@@ -123,7 +123,7 @@ pub async fn fetch_block_from_cache_or_get(
         near_primitives::types::BlockReference::BlockId(block_id) => {
             let block_height = match block_id {
                 near_primitives::types::BlockId::Height(block_height) => {
-                    check_block_height(data, block_height.clone()).await?;
+                    check_block_height(data, *block_height).await?;
                     *block_height
                 }
                 near_primitives::types::BlockId::Hash(hash) => data

--- a/rpc-server/src/modules/blocks/utils.rs
+++ b/rpc-server/src/modules/blocks/utils.rs
@@ -4,6 +4,43 @@ use crate::config::ServerContext;
 use crate::modules::blocks::methods::fetch_block;
 use crate::modules::blocks::CacheBlock;
 
+// Helper function to check if the requested block height is within the range of the available blocks
+// If block height is lower than genesis block height, return an error block height is too low
+// If block height is higher than optimistic block height, return an error block height is too high
+// Otherwise return Ok(())
+pub async fn check_block_height(
+    data: &actix_web::web::Data<ServerContext>,
+    block_height: near_primitives::types::BlockHeight,
+) -> Result<(), near_jsonrpc::primitives::types::blocks::RpcBlockError> {
+    let optimistic_block_height = data
+        .blocks_info_by_finality
+        .optimistic_cache_block()
+        .await
+        .block_height;
+    let genesis_block_height = data.genesis_info.genesis_block_cache.block_height;
+    if block_height < genesis_block_height {
+        return Err(
+            near_jsonrpc::primitives::types::blocks::RpcBlockError::UnknownBlock {
+                error_message: format!(
+                    "Requested block height {} is to low, genesis block height is {}",
+                    block_height, genesis_block_height
+                ),
+            },
+        );
+    }
+    if block_height > optimistic_block_height {
+        return Err(
+            near_jsonrpc::primitives::types::blocks::RpcBlockError::UnknownBlock {
+                error_message: format!(
+                    "Requested block height {} is to high, optimistic block height is {}",
+                    block_height, optimistic_block_height
+                ),
+            },
+        );
+    }
+    Ok(())
+}
+
 #[cfg_attr(
     feature = "tracing-instrumentation",
     tracing::instrument(skip(s3_client))
@@ -85,7 +122,10 @@ pub async fn fetch_block_from_cache_or_get(
     let block = match block_reference {
         near_primitives::types::BlockReference::BlockId(block_id) => {
             let block_height = match block_id {
-                near_primitives::types::BlockId::Height(block_height) => *block_height,
+                near_primitives::types::BlockId::Height(block_height) => {
+                    check_block_height(data, block_height.clone()).await?;
+                    *block_height
+                }
                 near_primitives::types::BlockId::Hash(hash) => data
                     .db_manager
                     .get_block_height_by_hash(*hash, method_name)


### PR DESCRIPTION
**1. Add block_height_checker**

- Implemented a block_height_checker to ensure that non-existing blocks are not fetched. This improvement prevents unnecessary fetch attempts for blocks that do not exist, optimizing resource usage and reducing potential errors.

**2. Fix Bug with Fetch Chunk**

- Resolved a bug related to chunk fetching where the system was encountering issues with incomplete or incorrect chunk retrievals. This fix ensures that the chunk data is fetched correctly and reliably.