### PR TITLE
chore: Drop `database-new` branch from GH workflow

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -5,12 +5,10 @@ on:
     branches:
       - main
       - develop
-      - database-new
   push:
     branches:
       - main
       - develop
-      - database-new
 
 jobs:
   check:


### PR DESCRIPTION
Cleaning up the workflows and repo. 

I have made a backup of the scylladb version of the readRPC (aka v1) to a separate branch `main-scylladb`. 

Also, I update the build workflows accordingly and dropping the `database-new` from the GH Actions workflow since we deprecate that branch (promoted to `main`)