### PR TITLE
(state-indexer-logic): improvement to bulk insert state changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/near/read-rpc/compare/main...develop)
 
-## [0.3.0](https://github.com/near/read-rpc/releases/tag/v0.2.17)
+### What's Changed
+* Improved bulk insertion of state_changes, reducing database requests from hundreds to a maximum of 7 per block.
+
+## [0.3.0](https://github.com/near/read-rpc/releases/tag/v0.3.0)
 
 ### BREAKING CHANGES
 

--- a/database/src/postgres/state_indexer.rs
+++ b/database/src/postgres/state_indexer.rs
@@ -254,9 +254,7 @@ impl crate::StateIndexerDbManager for crate::PostgresDBManager {
                         .push_bind(hex::encode(data_key).to_string())
                         .push_bind(data_value);
                 }
-                _ => {
-                    println!("Alarm! Unknown state change value: {:?}", state_change.value);
-                }
+                _ => {}
             }
         });
         query_builder.push(" ON CONFLICT DO NOTHING;");
@@ -319,9 +317,7 @@ impl crate::StateIndexerDbManager for crate::PostgresDBManager {
                         .push_bind(hex::encode(data_key).to_string())
                         .push_bind(data_value);
                 }
-                _ => {
-                    println!("Alarm! Unknown state change value: {:?}", state_change.value);
-                }
+                _ => {}
             }
         });
         query_builder.push(" ON CONFLICT DO NOTHING;");
@@ -375,9 +371,7 @@ impl crate::StateIndexerDbManager for crate::PostgresDBManager {
                         .push_bind(block_hash.to_string())
                         .push_bind(data_value);
                 }
-                _ => {
-                    println!("Alarm! Unknown state change value: {:?}", state_change.value);
-                }
+                _ => {}
             }
         });
         query_builder.push(" ON CONFLICT DO NOTHING;");
@@ -431,9 +425,7 @@ impl crate::StateIndexerDbManager for crate::PostgresDBManager {
                         .push_bind(block_hash.to_string())
                         .push_bind(data_value);
                 }
-                _ => {
-                    println!("Alarm! Unknown state change value: {:?}", state_change.value);
-                }
+                _ => {}
             }
         });
         query_builder.push(" ON CONFLICT DO NOTHING;");

--- a/database/src/postgres/state_indexer.rs
+++ b/database/src/postgres/state_indexer.rs
@@ -254,10 +254,12 @@ impl crate::StateIndexerDbManager for crate::PostgresDBManager {
                         .push_bind(hex::encode(data_key).to_string())
                         .push_bind(data_value);
                 }
-                _ => {}
+                _ => {
+                    println!("Alarm! Unknown state change value: {:?}", state_change.value);
+                }
             }
         });
-        query_builder.push(" ON CONFLICT (account_id, data_key, block_height) DO UPDATE SET data_value = EXCLUDED.data_value;");
+        query_builder.push(" ON CONFLICT DO NOTHING;");
         query_builder
             .build()
             .execute(self.shards_pool.get(&shard_id).ok_or(anyhow::anyhow!(
@@ -317,10 +319,12 @@ impl crate::StateIndexerDbManager for crate::PostgresDBManager {
                         .push_bind(hex::encode(data_key).to_string())
                         .push_bind(data_value);
                 }
-                _ => {}
+                _ => {
+                    println!("Alarm! Unknown state change value: {:?}", state_change.value);
+                }
             }
         });
-        query_builder.push(" ON CONFLICT (account_id, data_key, block_height) DO UPDATE SET data_value = EXCLUDED.data_value;");
+        query_builder.push(" ON CONFLICT DO NOTHING;");
         query_builder
             .build()
             .execute(self.shards_pool.get(&shard_id).ok_or(anyhow::anyhow!(
@@ -371,10 +375,12 @@ impl crate::StateIndexerDbManager for crate::PostgresDBManager {
                         .push_bind(block_hash.to_string())
                         .push_bind(data_value);
                 }
-                _ => {}
+                _ => {
+                    println!("Alarm! Unknown state change value: {:?}", state_change.value);
+                }
             }
         });
-        query_builder.push(" ON CONFLICT (account_id, block_height) DO UPDATE SET data_value = EXCLUDED.data_value;");
+        query_builder.push(" ON CONFLICT DO NOTHING;");
         query_builder
             .build()
             .execute(self.shards_pool.get(&shard_id).ok_or(anyhow::anyhow!(
@@ -425,10 +431,12 @@ impl crate::StateIndexerDbManager for crate::PostgresDBManager {
                         .push_bind(block_hash.to_string())
                         .push_bind(data_value);
                 }
-                _ => {}
+                _ => {
+                    println!("Alarm! Unknown state change value: {:?}", state_change.value);
+                }
             }
         });
-        query_builder.push(" ON CONFLICT (account_id, block_height) DO UPDATE SET data_value = EXCLUDED.data_value;");
+        query_builder.push(" ON CONFLICT DO NOTHING;");
         query_builder
             .build()
             .execute(self.shards_pool.get(&shard_id).ok_or(anyhow::anyhow!(

--- a/logic-state-indexer/src/lib.rs
+++ b/logic-state-indexer/src/lib.rs
@@ -1,8 +1,8 @@
-use std::collections::HashMap;
 pub use near_client::{NearClient, NearJsonRpc};
 use near_indexer_primitives::views::StateChangeValueView;
 use near_indexer_primitives::CryptoHash;
 use near_primitives::types::ShardId;
+use std::collections::HashMap;
 
 use futures::FutureExt;
 
@@ -25,10 +25,22 @@ pub type AccountIdStateChangeKey = String;
 
 #[derive(Debug, Default)]
 struct StateChangesToStore {
-    data: HashMap<ShardId, HashMap<AccountIdStateChangeKey, near_indexer_primitives::views::StateChangeWithCauseView>>,
-    access_key: HashMap<ShardId, HashMap<AccountIdStateChangeKey, near_indexer_primitives::views::StateChangeWithCauseView>>,
-    contract: HashMap<ShardId, HashMap<AccountIdStateChangeKey, near_indexer_primitives::views::StateChangeWithCauseView>>,
-    account: HashMap<ShardId, HashMap<AccountIdStateChangeKey, near_indexer_primitives::views::StateChangeWithCauseView>>,
+    data: HashMap<
+        ShardId,
+        HashMap<AccountIdStateChangeKey, near_indexer_primitives::views::StateChangeWithCauseView>,
+    >,
+    access_key: HashMap<
+        ShardId,
+        HashMap<AccountIdStateChangeKey, near_indexer_primitives::views::StateChangeWithCauseView>,
+    >,
+    contract: HashMap<
+        ShardId,
+        HashMap<AccountIdStateChangeKey, near_indexer_primitives::views::StateChangeWithCauseView>,
+    >,
+    account: HashMap<
+        ShardId,
+        HashMap<AccountIdStateChangeKey, near_indexer_primitives::views::StateChangeWithCauseView>,
+    >,
 }
 
 impl StateChangesToStore {
@@ -41,16 +53,14 @@ impl StateChangesToStore {
         block_hash: CryptoHash,
     ) -> anyhow::Result<()> {
         if !self.data.is_empty() {
-            let futures = self.data.iter().map(
-                |(shard_id, state_changes)| {
-                    db_manager.save_state_changes_data(
-                        *shard_id,
-                        state_changes.values().cloned().collect(),
-                        block_height,
-                        block_hash,
-                    )
-                },
-            );
+            let futures = self.data.iter().map(|(shard_id, state_changes)| {
+                db_manager.save_state_changes_data(
+                    *shard_id,
+                    state_changes.values().cloned().collect(),
+                    block_height,
+                    block_hash,
+                )
+            });
             futures::future::join_all(futures)
                 .await
                 .into_iter()
@@ -68,16 +78,14 @@ impl StateChangesToStore {
         block_hash: CryptoHash,
     ) -> anyhow::Result<()> {
         if !self.access_key.is_empty() {
-            let futures = self.access_key.iter().map(
-                |(shard_id, state_changes)| {
-                    db_manager.save_state_changes_access_key(
-                        *shard_id,
-                        state_changes.values().cloned().collect(),
-                        block_height,
-                        block_hash,
-                    )
-                },
-            );
+            let futures = self.access_key.iter().map(|(shard_id, state_changes)| {
+                db_manager.save_state_changes_access_key(
+                    *shard_id,
+                    state_changes.values().cloned().collect(),
+                    block_height,
+                    block_hash,
+                )
+            });
             futures::future::join_all(futures)
                 .await
                 .into_iter()
@@ -95,16 +103,14 @@ impl StateChangesToStore {
         block_hash: CryptoHash,
     ) -> anyhow::Result<()> {
         if !self.contract.is_empty() {
-            let futures = self.contract.iter().map(
-                |(shard_id, state_changes)| {
-                    db_manager.save_state_changes_contract(
-                        *shard_id,
-                        state_changes.values().cloned().collect(),
-                        block_height,
-                        block_hash,
-                    )
-                },
-            );
+            let futures = self.contract.iter().map(|(shard_id, state_changes)| {
+                db_manager.save_state_changes_contract(
+                    *shard_id,
+                    state_changes.values().cloned().collect(),
+                    block_height,
+                    block_hash,
+                )
+            });
             futures::future::join_all(futures)
                 .await
                 .into_iter()
@@ -122,16 +128,14 @@ impl StateChangesToStore {
         block_hash: CryptoHash,
     ) -> anyhow::Result<()> {
         if !self.account.is_empty() {
-            let futures = self.account.iter().map(
-                |(shard_id, state_changes)| {
-                    db_manager.save_state_changes_account(
-                        *shard_id,
-                        state_changes.values().cloned().collect(),
-                        block_height,
-                        block_hash,
-                    )
-                },
-            );
+            let futures = self.account.iter().map(|(shard_id, state_changes)| {
+                db_manager.save_state_changes_account(
+                    *shard_id,
+                    state_changes.values().cloned().collect(),
+                    block_height,
+                    block_hash,
+                )
+            });
             futures::future::join_all(futures)
                 .await
                 .into_iter()
@@ -364,9 +368,13 @@ async fn handle_state_changes(
                 let data_key: &[u8] = key.as_ref();
                 let key = format!("{}_data_{}", account_id.as_str(), hex::encode(data_key));
                 // This will override the previous record for this account_id + state change kind + suffix
-                state_changes_to_store.data.entry(shard_id).and_modify(|sharded_state_changes| {
-                    sharded_state_changes.insert(key.clone(), state_change.clone());
-                }).or_insert(HashMap::from([(key, state_change)]));
+                state_changes_to_store
+                    .data
+                    .entry(shard_id)
+                    .and_modify(|sharded_state_changes| {
+                        sharded_state_changes.insert(key.clone(), state_change.clone());
+                    })
+                    .or_insert(HashMap::from([(key, state_change)]));
             }
             StateChangeValueView::AccessKeyUpdate {
                 account_id,
@@ -387,9 +395,13 @@ async fn handle_state_changes(
                     hex::encode(borsh::to_vec(&public_key)?)
                 );
                 // This will override the previous record for this account_id + state change kind + suffix
-                state_changes_to_store.access_key.entry(shard_id).and_modify(|sharded_state_changes| {
-                    sharded_state_changes.insert(key.clone(), state_change.clone());
-                }).or_insert(HashMap::from([(key, state_change)]));
+                state_changes_to_store
+                    .access_key
+                    .entry(shard_id)
+                    .and_modify(|sharded_state_changes| {
+                        sharded_state_changes.insert(key.clone(), state_change.clone());
+                    })
+                    .or_insert(HashMap::from([(key, state_change)]));
             }
             // ContractCode and Account changes is not separate-able by any key, we can omit the suffix
             StateChangeValueView::ContractCodeUpdate { account_id, .. }
@@ -398,9 +410,13 @@ async fn handle_state_changes(
                     near_primitives::shard_layout::account_id_to_shard_id(account_id, shard_layout);
                 let key = format!("{}_contract", account_id.as_str());
                 // This will override the previous record for this account_id + state change kind + suffix
-                state_changes_to_store.contract.entry(shard_id).and_modify(|sharded_state_changes| {
-                    sharded_state_changes.insert(key.clone(), state_change.clone());
-                }).or_insert(HashMap::from([(key, state_change)]));
+                state_changes_to_store
+                    .contract
+                    .entry(shard_id)
+                    .and_modify(|sharded_state_changes| {
+                        sharded_state_changes.insert(key.clone(), state_change.clone());
+                    })
+                    .or_insert(HashMap::from([(key, state_change)]));
             }
             StateChangeValueView::AccountUpdate { account_id, .. }
             | StateChangeValueView::AccountDeletion { account_id } => {
@@ -408,9 +424,13 @@ async fn handle_state_changes(
                     near_primitives::shard_layout::account_id_to_shard_id(account_id, shard_layout);
                 let key = format!("{}_account", account_id.as_str());
                 // This will override the previous record for this account_id + state change kind + suffix
-                state_changes_to_store.account.entry(shard_id).and_modify(|sharded_state_changes| {
-                    sharded_state_changes.insert(key.clone(), state_change.clone());
-                }).or_insert(HashMap::from([(key, state_change)]));
+                state_changes_to_store
+                    .account
+                    .entry(shard_id)
+                    .and_modify(|sharded_state_changes| {
+                        sharded_state_changes.insert(key.clone(), state_change.clone());
+                    })
+                    .or_insert(HashMap::from([(key, state_change)]));
             }
         };
     }


### PR DESCRIPTION
This PR introduces significant improvements to the way state changes are inserted into the database. Previously, the system was making hundreds of individual requests per block, while we expected a maximum of 7 requests per block. This resulted in inefficiencies and a higher database load.

In this update, the logic for saving `state_changes` has been rewritten to use bulk inserts. Now, for each type of `state_changes`, only a single query is executed to perform a bulk insert, reducing the number of requests drastically and improving performance.

**Changes:**

- Refactored `state_changes` insertion logic to use bulk inserts.
- Reduced the number of database requests from hundreds to 7 or fewer per block.

This enhancement should improve overall performance and reduce database overhead.