### PR TITLE
Reduce Worker Count to 2 for Indexer Metrics Servers

### DIFF
--- a/logic-state-indexer/src/metrics.rs
+++ b/logic-state-indexer/src/metrics.rs
@@ -54,6 +54,7 @@ pub fn init_server(port: u16) -> anyhow::Result<actix_web::dev::Server> {
     Ok(HttpServer::new(|| App::new().service(get_metrics))
         .bind(("0.0.0.0", port))?
         .disable_signals()
+        .workers(2) // for indexers metrics server we don't need many workers
         .run())
 }
 

--- a/tx-indexer/src/metrics.rs
+++ b/tx-indexer/src/metrics.rs
@@ -82,6 +82,7 @@ pub(crate) fn init_server(port: u16) -> anyhow::Result<actix_web::dev::Server> {
     Ok(HttpServer::new(|| App::new().service(get_metrics))
         .bind(("0.0.0.0", port))?
         .disable_signals()
+        .workers(2) // for indexer metrics server we don't need many workers
         .run())
 }
 


### PR DESCRIPTION
This PR updates the configuration of the indexers metrics server to use only 2 workers. Since the metrics server workload is lightweight and does not require a large number of workers, reducing the count to 2 optimizes resource utilization without impacting performance.

The metrics server's operations are not resource-intensive, and a higher worker count is unnecessary. This change helps conserve system resources and ensures efficient operation.