### PR TITLE
Add ScyllaDB as a Transaction Storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1551,7 +1551,7 @@ dependencies = [
  "dotenv",
  "futures-util",
  "hex",
- "jsonwebtoken 7.2.0",
+ "jsonwebtoken",
  "lazy_static",
  "openssl",
  "percent-encoding",
@@ -1605,12 +1605,12 @@ version = "0.3.3"
 dependencies = [
  "anyhow",
  "dotenv",
- "google-cloud-storage",
  "lazy_static",
  "near-lake-framework",
  "opentelemetry 0.19.0",
  "opentelemetry-jaeger",
  "regex",
+ "scylla",
  "serde",
  "serde_derive",
  "serde_json",
@@ -2876,10 +2876,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if 1.0.0",
- "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -2904,81 +2902,6 @@ name = "glob"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
-
-[[package]]
-name = "google-cloud-auth"
-version = "0.17.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e57a13fbacc5e9c41ded3ad8d0373175a6b7a6ad430d99e89d314ac121b7ab06"
-dependencies = [
- "async-trait",
- "base64 0.21.7",
- "google-cloud-metadata",
- "google-cloud-token",
- "home",
- "jsonwebtoken 9.3.0",
- "reqwest 0.12.12",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "time",
- "tokio",
- "tracing",
- "urlencoding",
-]
-
-[[package]]
-name = "google-cloud-metadata"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04f945a208886a13d07636f38fb978da371d0abc3e34bad338124b9f8c135a8f"
-dependencies = [
- "reqwest 0.12.12",
- "thiserror 1.0.69",
- "tokio",
-]
-
-[[package]]
-name = "google-cloud-storage"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e81dff54dbfa83705c896179ecaa4f384bfbfac90f3b637f38541443275b8a3f"
-dependencies = [
- "anyhow",
- "async-stream",
- "async-trait",
- "base64 0.21.7",
- "bytes",
- "futures-util",
- "google-cloud-auth",
- "google-cloud-metadata",
- "google-cloud-token",
- "hex",
- "once_cell",
- "percent-encoding",
- "pkcs8 0.10.2",
- "regex",
- "reqwest 0.12.12",
- "reqwest-middleware",
- "ring 0.17.8",
- "serde",
- "serde_json",
- "sha2",
- "thiserror 1.0.69",
- "time",
- "tokio",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "google-cloud-token"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f49c12ba8b21d128a2ce8585955246977fbce4415f680ebf9199b6f9d6d725f"
-dependencies = [
- "async-trait",
-]
 
 [[package]]
 name = "group"
@@ -3697,26 +3620,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afabcc15e437a6484fc4f12d0fd63068fe457bf93f1c148d3d9649c60b103f32"
 dependencies = [
  "base64 0.12.3",
- "pem 0.8.3",
+ "pem",
  "ring 0.16.20",
  "serde",
  "serde_json",
- "simple_asn1 0.4.1",
-]
-
-[[package]]
-name = "jsonwebtoken"
-version = "9.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ae10193d25051e74945f1ea2d0b42e03cc3b890f7e4cc5faa44997d808193f"
-dependencies = [
- "base64 0.21.7",
- "js-sys",
- "pem 3.0.4",
- "ring 0.17.8",
- "serde",
- "serde_json",
- "simple_asn1 0.6.3",
+ "simple_asn1",
 ]
 
 [[package]]
@@ -6265,16 +6173,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pem"
-version = "3.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae"
-dependencies = [
- "base64 0.22.1",
- "serde",
-]
-
-[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7117,7 +7015,6 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
- "mime_guess",
  "native-tls",
  "once_cell",
  "percent-encoding",
@@ -7130,30 +7027,13 @@ dependencies = [
  "system-configuration 0.6.1",
  "tokio",
  "tokio-native-tls",
- "tokio-util 0.7.13",
  "tower 0.5.2",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
  "web-sys",
  "windows-registry",
-]
-
-[[package]]
-name = "reqwest-middleware"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1ccd3b55e711f91a9885a2fa6fbbb2e39db1776420b062efc058c6410f7e5e3"
-dependencies = [
- "anyhow",
- "async-trait",
- "http 1.2.0",
- "reqwest 0.12.12",
- "serde",
- "thiserror 1.0.69",
- "tower-service",
 ]
 
 [[package]]
@@ -7890,18 +7770,6 @@ dependencies = [
  "chrono",
  "num-bigint 0.2.6",
  "num-traits",
-]
-
-[[package]]
-name = "simple_asn1"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
-dependencies = [
- "num-bigint 0.4.6",
- "num-traits",
- "thiserror 2.0.11",
- "time",
 ]
 
 [[package]]
@@ -9080,7 +8948,6 @@ name = "tx-details-storage"
 version = "0.3.3"
 dependencies = [
  "anyhow",
- "google-cloud-storage",
  "scylla",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3054,6 +3054,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash 0.8.11",
+ "allocator-api2",
 ]
 
 [[package]]
@@ -3111,6 +3112,12 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "histogram"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12cb882ccb290b8646e554b157ab0b71e64e8d5bef775cd66b6531e52d302669"
 
 [[package]]
 name = "hkdf"
@@ -3934,6 +3941,15 @@ checksum = "6bd8c0d6c6ed0cd30b3652886bb8711dc4bb01d637a68105a3d5158039b418e6"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "lz4_flex"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75761162ae2b0e580d7e7c390558127e5f01b4194debd6221fd8c207fc80e3f5"
+dependencies = [
+ "twox-hash",
 ]
 
 [[package]]
@@ -6778,6 +6794,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_pcg"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59cad018caf63deb318e5a4586d99a24424a364f40f1e5778c29aca23f4fc73e"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "rand_xoshiro"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7477,6 +7502,68 @@ dependencies = [
 ]
 
 [[package]]
+name = "scylla"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0408e59e11f589071d1cefc3928270aa8fe4d03f654cb118e0c24d16013ea82"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "dashmap",
+ "futures",
+ "hashbrown 0.14.5",
+ "histogram",
+ "itertools 0.13.0",
+ "lazy_static",
+ "lz4_flex",
+ "rand 0.8.5",
+ "rand_pcg",
+ "scylla-cql",
+ "scylla-macros",
+ "smallvec",
+ "snap",
+ "socket2",
+ "thiserror 2.0.11",
+ "tokio",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "scylla-cql"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0cefd8b924bb8f67525937a811038d5662f9febc30c74c778a8205f63c4b365"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "lz4_flex",
+ "scylla-macros",
+ "snap",
+ "stable_deref_trait",
+ "thiserror 2.0.11",
+ "tokio",
+ "uuid",
+ "yoke",
+]
+
+[[package]]
+name = "scylla-macros"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e878bfb8a235207864ac3fb0b51d7954c77fd38486e0e4fb4e037935ff7eb46c"
+dependencies = [
+ "darling 0.20.10",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
 name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7883,6 +7970,12 @@ dependencies = [
  "static_assertions",
  "version_check",
 ]
+
+[[package]]
+name = "snap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 
 [[package]]
 name = "socket2"
@@ -8973,11 +9066,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "twox-hash"
+version = "1.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
+dependencies = [
+ "cfg-if 1.0.0",
+ "static_assertions",
+]
+
+[[package]]
 name = "tx-details-storage"
 version = "0.3.3"
 dependencies = [
  "anyhow",
  "google-cloud-storage",
+ "scylla",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1607,6 +1607,7 @@ dependencies = [
  "dotenv",
  "lazy_static",
  "near-lake-framework",
+ "openssl",
  "opentelemetry 0.19.0",
  "opentelemetry-jaeger",
  "regex",
@@ -7399,6 +7400,7 @@ dependencies = [
  "itertools 0.13.0",
  "lazy_static",
  "lz4_flex",
+ "openssl",
  "rand 0.8.5",
  "rand_pcg",
  "scylla-cql",
@@ -7408,6 +7410,7 @@ dependencies = [
  "socket2",
  "thiserror 2.0.11",
  "tokio",
+ "tokio-openssl",
  "tracing",
  "uuid",
 ]

--- a/configuration/Cargo.toml
+++ b/configuration/Cargo.toml
@@ -22,7 +22,8 @@ opentelemetry-jaeger = { version = "0.18", features = [
     "collector_client",
     "isahc_collector_client",
 ], optional = true }
-scylla = "0.15.1"
+openssl = "0.10.68"
+scylla = { version = "0.15.1", features = ["ssl"] }
 toml = "0.8.4"
 tracing = "0.1.34"
 tracing-subscriber = { version = "0.3.15", features = [

--- a/configuration/Cargo.toml
+++ b/configuration/Cargo.toml
@@ -10,7 +10,6 @@ license.workspace = true
 [dependencies]
 anyhow = "1.0.70"
 dotenv = "0.15.0"
-google-cloud-storage = "0.23.0"
 lazy_static = "1.4.0"
 regex = "1.10.2"
 serde = "1.0.145"
@@ -23,6 +22,7 @@ opentelemetry-jaeger = { version = "0.18", features = [
     "collector_client",
     "isahc_collector_client",
 ], optional = true }
+scylla = "0.15.1"
 toml = "0.8.4"
 tracing = "0.1.34"
 tracing-subscriber = { version = "0.3.15", features = [

--- a/configuration/src/configs/tx_details_storage.rs
+++ b/configuration/src/configs/tx_details_storage.rs
@@ -17,7 +17,7 @@ impl TxDetailsStorageConfig {
         let ca_cert_path = std::env::var("SCYLLA_CA_CERT")?;
         let client_cert_path = std::env::var("SCYLLA_CLIENT_CERT")?;
         let client_key_path = std::env::var("SCYLLA_CLIENT_KEY")?;
-        
+
         let mut builder = openssl::ssl::SslContextBuilder::new(openssl::ssl::SslMethod::tls())?;
         builder.set_ca_file(ca_cert_path)?;
         builder.set_certificate_file(client_cert_path, openssl::ssl::SslFiletype::PEM)?;

--- a/configuration/src/default_env_configs.rs
+++ b/configuration/src/default_env_configs.rs
@@ -129,8 +129,30 @@ tracked_changes = "${TRACKED_CHANGES}"
 ## Transaction details are stored in the Google Cloud Storage
 [tx_details_storage]
 
-## Storage Bucket Name
-bucket_name = "${TX_BUCKET_NAME}"
+## ScyllaDB database connection URL
+## Example: "127.0.0.1:9042"
+scylla_url = "${SCYLLA_URL}"
+
+## Scylla user(login)
+## Optional database user
+scylla_user = "${SCYLLA_USER}"
+
+## Scylla password
+## Optional database password
+scylla_password = "${SCYLLA_PASSWORD}"
+
+## ScyllaDB preferred DataCenter
+## Accepts the DC name of the ScyllaDB to filter the connection to that DC only (preferrably).
+## If you connect to multi-DC cluter, you might experience big latencies while working with the DB.
+## This is due to the fact that ScyllaDB driver tries to connect to any of the nodes in the cluster disregarding of the location of the DC.
+## This option allows to filter the connection to the DC you need.
+## Example: "DC1" where DC1 is located in the same region as the application.
+## Default value is None
+scylla_preferred_dc = "${SCYLLA_PREFERRED_DC}"
+
+## Scylla keepalive interval
+## By default we use 60 seconds
+scylla_keepalive_interval = "${SCYLLA_KEEPALIVE_INTERVAL}"
 
 ## Database configuration
 [database]

--- a/rpc-server/src/config.rs
+++ b/rpc-server/src/config.rs
@@ -140,9 +140,9 @@ impl ServerContext {
         );
 
         let tx_details_storage = tx_details_storage::TxDetailsStorage::new(
-            rpc_server_config.tx_details_storage.storage_client().await,
-            rpc_server_config.tx_details_storage.bucket_name.clone(),
-        );
+            rpc_server_config.tx_details_storage.scylla_client().await,
+        )
+        .await?;
 
         let tx_cache_storage =
             cache_storage::TxIndexerCache::new(rpc_server_config.general.redis_url.to_string())

--- a/tx-details-storage/Cargo.toml
+++ b/tx-details-storage/Cargo.toml
@@ -12,3 +12,4 @@ license.workspace = true
 [dependencies]
 anyhow = "1.0.70"
 google-cloud-storage = "0.23.0"
+scylla = "0.15.1"

--- a/tx-details-storage/Cargo.toml
+++ b/tx-details-storage/Cargo.toml
@@ -11,5 +11,4 @@ license.workspace = true
 
 [dependencies]
 anyhow = "1.0.70"
-google-cloud-storage = "0.23.0"
 scylla = "0.15.1"

--- a/tx-details-storage/src/lib.rs
+++ b/tx-details-storage/src/lib.rs
@@ -2,6 +2,88 @@ use google_cloud_storage::http::objects::download::Range;
 use google_cloud_storage::http::objects::get::GetObjectRequest;
 use google_cloud_storage::http::objects::upload::{Media, UploadObjectRequest, UploadType};
 
+pub struct ScyllaTxDetailsStorage {
+    add_transaction: scylla::prepared_statement::PreparedStatement,
+    get_transaction: scylla::prepared_statement::PreparedStatement,
+    scylla_session: scylla::Session,
+}
+
+impl ScyllaTxDetailsStorage {
+    pub async fn new(scylla_session: scylla::Session) -> anyhow::Result<Self> {
+        Self::create_keyspace(&scylla_session).await?;
+        Self::create_table(&scylla_session).await?;
+        Ok(Self {
+            add_transaction: Self::prepare_query(
+                &scylla_session,
+                "INSERT INTO tx_details.transactions
+                (transaction_hash, transaction_details)
+                VALUES(?, ?)",
+                scylla::frame::types::Consistency::LocalQuorum,
+            ).await?,
+            get_transaction: Self::prepare_query(
+                &scylla_session,
+                "SELECT block_height, transaction_details FROM tx_details.transactions WHERE transaction_hash = ? LIMIT 1",
+                scylla::frame::types::Consistency::LocalOne,
+            ).await?,
+            scylla_session,
+        })
+    }
+
+    async fn prepare_query(
+        scylla_db_session: &scylla::Session,
+        query_text: &str,
+        consistency: scylla::frame::types::Consistency,
+    ) -> anyhow::Result<scylla::prepared_statement::PreparedStatement> {
+        let mut query = scylla::statement::query::Query::new(query_text);
+        query.set_consistency(consistency);
+        Ok(scylla_db_session.prepare(query).await?)
+    }
+
+    pub async fn create_keyspace(scylla_session: &scylla::Session) -> anyhow::Result<()> {
+        scylla_session
+            .query_unpaged(
+                "CREATE KEYSPACE IF NOT EXISTS tx_details
+                WITH REPLICATION = {
+                    'class': 'SimpleStrategy',
+                    'replication_factor': 1
+                }",
+                &[],
+            )
+            .await?;
+        Ok(())
+    }
+
+    pub async fn create_table(scylla_session: &scylla::Session) -> anyhow::Result<()> {
+        scylla_session
+            .query_unpaged(
+                "CREATE TABLE IF NOT EXISTS transactions (
+                    transaction_hash varchar PRIMARY KEY,
+                    transaction_details BLOB
+                )",
+                &[],
+            )
+            .await?;
+        Ok(())
+    }
+
+    pub async fn store(&self, key: &str, data: Vec<u8>) -> anyhow::Result<()> {
+        self.scylla_session
+            .execute_unpaged(&self.add_transaction, (key, data))
+            .await?;
+        Ok(())
+    }
+
+    pub async fn retrieve(&self, key: &str) -> anyhow::Result<Vec<u8>> {
+        let (data,) = self
+            .scylla_session
+            .execute_unpaged(&self.get_transaction, (key.to_string(),))
+            .await?
+            .into_rows_result()?
+            .single_row::<(Vec<u8>,)>()?;
+        Ok(data)
+    }
+}
+
 pub struct TxDetailsStorage {
     client: google_cloud_storage::client::Client,
     bucket_name: String,

--- a/tx-details-storage/src/lib.rs
+++ b/tx-details-storage/src/lib.rs
@@ -40,8 +40,8 @@ impl TxDetailsStorage {
             .query_unpaged(
                 "CREATE KEYSPACE IF NOT EXISTS tx_details
                 WITH REPLICATION = {
-                    'class': 'SimpleStrategy',
-                    'replication_factor': 1
+                    'class': 'NetworkTopologyStrategy',
+                    'replication_factor': 3
                 }",
                 &[],
             )

--- a/tx-indexer/src/main.rs
+++ b/tx-indexer/src/main.rs
@@ -79,10 +79,9 @@ async fn main() -> anyhow::Result<()> {
     );
 
     tracing::info!(target: INDEXER, "Instantiating the tx_details storage client...");
-    let tx_details_storage = std::sync::Arc::new(TxDetailsStorage::new(
-        indexer_config.tx_details_storage.storage_client().await,
-        indexer_config.tx_details_storage.bucket_name.clone(),
-    ));
+    let tx_details_storage = std::sync::Arc::new(
+        TxDetailsStorage::new(indexer_config.tx_details_storage.scylla_client().await).await?,
+    );
 
     tracing::info!(target: INDEXER, "Instantiating the stream...",);
     let (sender, stream) = near_lake_framework::streamer(lake_config);


### PR DESCRIPTION
This pull request introduces ScyllaDB as a new transaction storage backend. It integrates ScyllaDB to store and retrieve transaction data, providing an alternative to existing storage solutions.

**Key Changes**

1. Added connection setup and configuration for ScyllaDB.
2. Implemented methods for storing, querying, and managing transaction data.

This PR lays the groundwork for incorporating ScyllaDB into the system and may require subsequent optimizations based on production workloads.