### PR TITLE
regular node mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
  "futures-util",
  "log",
  "once_cell",
- "parking_lot 0.12.3",
+ "parking_lot 0.12.4",
  "pin-project-lite",
  "smallvec",
  "tokio",
@@ -130,7 +130,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
 dependencies = [
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -140,7 +140,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13d324164c51f63867b57e73ba5936ea151b8a41a1d23d1031eeb9f70d0236f8"
 dependencies = [
  "bytestring",
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "http 0.2.12",
  "regex",
  "regex-lite",
@@ -234,7 +234,7 @@ dependencies = [
  "actix-web-codegen",
  "bytes",
  "bytestring",
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "cookie",
  "derive_more 2.0.1",
  "encoding_rs",
@@ -269,7 +269,7 @@ dependencies = [
  "actix-router",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -280,7 +280,7 @@ checksum = "b6ac1e58cded18cb28ddc17143c4dea5345b3ad575e14f32f66e4054a56eb271"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -294,9 +294,9 @@ dependencies = [
 
 [[package]]
 name = "adler2"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "ahash"
@@ -315,7 +315,7 @@ version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -368,9 +368,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.18"
+version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -383,33 +383,33 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
 dependencies = [
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.8"
+version = "3.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6680de5231bd6ee4c6191b8a1325daa282b415391ec9d3a37bd34f2060dc73fa"
+checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
@@ -495,7 +495,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -506,7 +506,7 @@ checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -560,7 +560,7 @@ dependencies = [
  "actix-utils",
  "base64 0.22.1",
  "bytes",
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "cookie",
  "derive_more 2.0.1",
  "futures-core",
@@ -697,9 +697,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.89.0"
+version = "1.91.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f676a4b4d6ff85d9906339a8da6d407f787ab64b00c9742272a12a6f31f33313"
+checksum = "10c7d58f9c99e7d33e5a9b288ec84db24de046add7ba4c1e98baf6b3a5b37fde"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -731,9 +731,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.71.0"
+version = "1.72.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a4fd09d6e863655d99cd2260f271c6d1030dc6bfad68e19e126d2e4c8ceb18"
+checksum = "13118ad30741222f67b1a18e5071385863914da05124652b38e172d6d3d9ce31"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -753,9 +753,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.72.0"
+version = "1.73.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3224ab02ebb3074467a33d57caf6fcb487ca36f3697fdd381b0428dc72380696"
+checksum = "f879a8572b4683a8f84f781695bebf2f25cf11a81a2693c31fc0e0215c2c1726"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -775,9 +775,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.72.0"
+version = "1.73.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6933f189ed1255e78175fbd73fb200c0aae7240d220ed3346f567b0ddca3083"
+checksum = "f1e9c3c24e36183e2f698235ed38dcfbbdff1d09b9232dc866c4be3011e0b47e"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -889,13 +889,14 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e44697a9bded898dcd0b1cb997430d949b87f4f8940d91023ae9062bf218250"
+checksum = "073d330f94bdf1f47bb3e0f5d45dda1e372a54a553c39ab6e9646902c8c81594"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
+ "h2 0.3.26",
  "h2 0.4.10",
  "http 0.2.12",
  "http 1.3.1",
@@ -903,7 +904,7 @@ dependencies = [
  "hyper 0.14.32",
  "hyper 1.6.0",
  "hyper-rustls 0.24.2",
- "hyper-rustls 0.27.6",
+ "hyper-rustls 0.27.7",
  "hyper-util",
  "pin-project-lite",
  "rustls 0.21.12",
@@ -1094,7 +1095,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
 dependencies = [
  "addr2line",
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "libc",
  "miniz_oxide",
  "object",
@@ -1144,9 +1145,9 @@ dependencies = [
 
 [[package]]
 name = "base64ct"
-version = "1.7.3"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
+checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 
 [[package]]
 name = "bigdecimal"
@@ -1188,7 +1189,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -1210,7 +1211,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.101",
+ "syn 2.0.102",
  "which",
 ]
 
@@ -1229,7 +1230,7 @@ dependencies = [
  "regex",
  "rustc-hash 2.1.1",
  "shlex",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -1297,7 +1298,7 @@ dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "constant_time_eq",
 ]
 
@@ -1322,9 +1323,9 @@ dependencies = [
 
 [[package]]
 name = "blst"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47c79a94619fade3c0b887670333513a67ac28a6a7e653eb260bf0d4103db38d"
+checksum = "4fd49896f12ac9b6dcd7a5998466b9b58263a695a3dd1ecc1aaca2e12a90b080"
 dependencies = [
  "cc",
  "glob",
@@ -1352,7 +1353,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -1384,9 +1385,9 @@ checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 
 [[package]]
 name = "bumpalo"
-version = "3.17.0"
+version = "3.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
 dependencies = [
  "allocator-api2",
 ]
@@ -1433,7 +1434,7 @@ checksum = "efb7846e0cb180355c2dec69e721edafa36919850f1a9f52ffba4ebc0393cb71"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -1517,9 +1518,9 @@ checksum = "a2698f953def977c68f935bb0dfa959375ad4638570e969e2f1e9f433cbf1af6"
 
 [[package]]
 name = "cc"
-version = "1.2.24"
+version = "1.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16595d3be041c03b09d08d0858631facccee9221e579704070e6e9e4915d3bc7"
+checksum = "956a5e21988b87f372569b66183b78babf23ebc2e744b733e4350a752c4dafac"
 dependencies = [
  "jobserver",
  "libc",
@@ -1543,9 +1544,9 @@ checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "cfg_aliases"
@@ -1590,9 +1591,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.39"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd60e63e9be68e5fb56422e397cf9baddded06dae1d2e523401542383bc72a9f"
+checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1600,9 +1601,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.39"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89cc6392a1f72bbeb820d71f32108f61fdaf18bc526e1d23954168a67759ef51"
+checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1612,21 +1613,21 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.32"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
+checksum = "d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "cloud-storage"
@@ -1677,9 +1678,9 @@ checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "combine"
@@ -1846,7 +1847,7 @@ dependencies = [
  "cranelift-entity",
  "cranelift-isle",
  "gimli",
- "hashbrown 0.15.3",
+ "hashbrown 0.15.4",
  "log",
  "pulley-interpreter",
  "regalloc2",
@@ -1939,9 +1940,9 @@ checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
 name = "crc-fast"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add8d3a4c789d77eeb0f0e3c1035f73610d017f9047e87db94f89c02a56d8fef"
+checksum = "68fcb2be5386ffb77e30bf10820934cb89a628bcb976e7cc632dcd88c059ebea"
 dependencies = [
  "cc",
  "crc",
@@ -1957,7 +1958,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
 ]
 
 [[package]]
@@ -2066,9 +2067,9 @@ dependencies = [
 
 [[package]]
 name = "curl"
-version = "0.4.47"
+version = "0.4.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9fb4d13a1be2b58f14d60adba57c9834b78c62fd86c3e76a148f732686e9265"
+checksum = "9e2d5c8f48d9c0c23250e52b55e82a6ab4fdba6650c931f5a0a57a43abda812b"
 dependencies = [
  "curl-sys",
  "libc",
@@ -2076,14 +2077,14 @@ dependencies = [
  "openssl-sys",
  "schannel",
  "socket2",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "curl-sys"
-version = "0.4.80+curl-8.12.1"
+version = "0.4.82+curl-8.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55f7df2eac63200c3ab25bde3b2268ef2ee56af3d238e76d61f01c3c49bff734"
+checksum = "c4d63638b5ec65f1a4ae945287b3fd035be4554bbaf211901159c9a2a74fb5be"
 dependencies = [
  "cc",
  "libc",
@@ -2091,7 +2092,7 @@ dependencies = [
  "openssl-sys",
  "pkg-config",
  "vcpkg",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2100,7 +2101,7 @@ version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "cpufeatures",
  "curve25519-dalek-derive",
  "digest 0.10.7",
@@ -2119,7 +2120,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -2143,7 +2144,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -2154,7 +2155,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -2163,11 +2164,11 @@ version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "hashbrown 0.14.5",
- "lock_api 0.4.12",
+ "lock_api 0.4.13",
  "once_cell",
- "parking_lot_core 0.9.10",
+ "parking_lot_core 0.9.11",
 ]
 
 [[package]]
@@ -2232,7 +2233,7 @@ checksum = "e73f2692d4bd3cac41dca28934a39894200c9fabf49586d77d0e5954af1d7902"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -2243,7 +2244,7 @@ checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -2264,7 +2265,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -2274,7 +2275,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -2287,7 +2288,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version 0.4.1",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -2316,7 +2317,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -2327,7 +2328,7 @@ checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
  "unicode-xid",
 ]
 
@@ -2389,7 +2390,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -2562,7 +2563,7 @@ version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
 ]
 
 [[package]]
@@ -2582,7 +2583,7 @@ checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -2603,7 +2604,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -2649,7 +2650,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "home",
  "windows-sys 0.48.0",
 ]
@@ -2741,9 +2742,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
+checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -2867,8 +2868,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
 dependencies = [
  "futures-core",
- "lock_api 0.4.12",
- "parking_lot 0.12.3",
+ "lock_api 0.4.13",
+ "parking_lot 0.12.4",
 ]
 
 [[package]]
@@ -2911,7 +2912,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -2969,7 +2970,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
 ]
@@ -2980,7 +2981,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
 ]
@@ -2991,7 +2992,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "libc",
  "r-efi",
  "wasi 0.14.2+wasi-0.2.4",
@@ -3084,9 +3085,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.3"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -3100,7 +3101,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
- "hashbrown 0.15.3",
+ "hashbrown 0.15.4",
 ]
 
 [[package]]
@@ -3126,9 +3127,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.9"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+checksum = "f154ce46856750ed433c8649605bf7ed2de3bc35fd9d2a9f30cddd873c80cb08"
 
 [[package]]
 name = "hex"
@@ -3308,9 +3309,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.6"
+version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a01595e11bdcec50946522c32dde3fc6914743000a68b93000965f2f02406d"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
  "http 1.3.1",
  "hyper 1.6.0",
@@ -3366,9 +3367,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c293b6b3d21eca78250dc7dbebd6b9210ec5530e038cbfe0661b5c47ab06e8"
+checksum = "dc2fdfdbff08affe55bb779f33b053aa1fe5dd5b54c257343c17edfa55711bdb"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -3565,7 +3566,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.3",
+ "hashbrown 0.15.4",
  "serde",
 ]
 
@@ -3575,7 +3576,7 @@ version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
 ]
 
 [[package]]
@@ -3752,7 +3753,7 @@ version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "windows-targets 0.53.0",
 ]
 
@@ -3867,9 +3868,9 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -3920,7 +3921,7 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown 0.15.3",
+ "hashbrown 0.15.4",
 ]
 
 [[package]]
@@ -3974,7 +3975,7 @@ checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -3983,7 +3984,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "digest 0.10.7",
 ]
 
@@ -4077,9 +4078,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
 ]
@@ -4125,7 +4126,7 @@ checksum = "0ac7d860b767c6398e88fe93db73ce53eb496057aa6895ffa4d60cb02e1d1c6b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -4188,7 +4189,7 @@ source = "git+https://github.com/near/nearcore?rev=680b27eb0105655345535a20623aa
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -4639,7 +4640,7 @@ dependencies = [
  "near-crypto 2.6.3",
  "near-jsonrpc-primitives 2.6.3",
  "near-primitives 2.6.3",
- "reqwest 0.12.18",
+ "reqwest 0.12.19",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -4708,7 +4709,7 @@ dependencies = [
  "derive_builder",
  "futures",
  "near-indexer-primitives",
- "reqwest 0.12.18",
+ "reqwest 0.12.19",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -4761,7 +4762,7 @@ dependencies = [
  "near-schema-checker-lib",
  "near-store",
  "opentelemetry 0.22.0",
- "parking_lot 0.12.3",
+ "parking_lot 0.12.4",
  "pin-project",
  "protobuf 3.7.2",
  "protobuf-codegen",
@@ -4892,7 +4893,7 @@ version = "2.6.3"
 source = "git+https://github.com/near/nearcore?rev=680b27eb0105655345535a20623aaeb3b49b82e0#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -4917,7 +4918,7 @@ dependencies = [
  "base64 0.21.7",
  "borsh",
  "bytesize",
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "chrono",
  "derive_more 0.99.20",
  "easy-ext",
@@ -4960,7 +4961,7 @@ dependencies = [
  "borsh",
  "bytes",
  "bytesize",
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "chrono",
  "derive_more 1.0.0",
  "easy-ext",
@@ -5041,7 +5042,7 @@ checksum = "80fca203c51edd9595ec14db1d13359fb9ede32314990bf296b6c5c4502f6ab7"
 dependencies = [
  "quote",
  "serde",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -5053,7 +5054,7 @@ dependencies = [
  "fs2",
  "near-rpc-error-core",
  "serde",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -5204,7 +5205,7 @@ version = "2.6.3"
 source = "git+https://github.com/near/nearcore?rev=680b27eb0105655345535a20623aaeb3b49b82e0#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "backtrace",
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "enumset",
  "finite-wasm",
  "more-asserts",
@@ -5325,7 +5326,7 @@ source = "git+https://github.com/near/nearcore?rev=680b27eb0105655345535a20623aa
 dependencies = [
  "backtrace",
  "cc",
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "finite-wasm",
  "indexmap 2.9.0",
  "libc",
@@ -5369,7 +5370,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
 dependencies = [
  "bitflags 1.3.2",
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "libc",
  "memoffset 0.6.5",
 ]
@@ -5530,9 +5531,9 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
  "hermit-abi",
  "libc",
@@ -5545,7 +5546,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "crc32fast",
- "hashbrown 0.15.3",
+ "hashbrown 0.15.4",
  "indexmap 2.9.0",
  "memchr",
 ]
@@ -5575,7 +5576,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
 dependencies = [
  "bitflags 2.9.1",
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "foreign-types",
  "libc",
  "once_cell",
@@ -5591,7 +5592,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -5933,18 +5934,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
- "lock_api 0.4.12",
+ "lock_api 0.4.13",
  "parking_lot_core 0.8.6",
 ]
 
 [[package]]
 name = "parking_lot"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
 dependencies = [
- "lock_api 0.4.12",
- "parking_lot_core 0.9.10",
+ "lock_api 0.4.13",
+ "parking_lot_core 0.9.11",
 ]
 
 [[package]]
@@ -5967,7 +5968,7 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "instant",
  "libc",
  "redox_syscall 0.2.16",
@@ -5977,11 +5978,11 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "libc",
  "redox_syscall 0.5.12",
  "smallvec",
@@ -6072,7 +6073,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -6132,7 +6133,7 @@ checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
 dependencies = [
  "autocfg",
  "bitflags 1.3.2",
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "concurrent-queue",
  "libc",
  "log",
@@ -6184,12 +6185,12 @@ checksum = "aa06bd51638b6e76ac9ba9b6afb4164fa647bd2916d722f2623fbb6d1ed8bdba"
 
 [[package]]
 name = "prettyplease"
-version = "0.2.32"
+version = "0.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "664ec5419c51e34154eec046ebcba56312d5a2fc3b09a06da188e1ad21afadf6"
+checksum = "9dee91521343f4c5c6a63edd65e54f31f5c92fe8978c40a4282f8372194c6a7d"
 dependencies = [
  "proc-macro2",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -6254,7 +6255,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -6272,11 +6273,11 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "fnv",
  "lazy_static",
  "memchr",
- "parking_lot 0.12.3",
+ "parking_lot 0.12.4",
  "protobuf 2.28.0",
  "thiserror 1.0.69",
 ]
@@ -6344,7 +6345,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -6460,7 +6461,7 @@ checksum = "ca414edb151b4c8d125c12566ab0d74dc9cdba36fb80eb7b848c15f495fd32d1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -6811,7 +6812,7 @@ checksum = "dc06e6b318142614e4a48bc725abbf08ff166694835c43c9dae5a9009704639a"
 dependencies = [
  "allocator-api2",
  "bumpalo",
- "hashbrown 0.15.3",
+ "hashbrown 0.15.4",
  "log",
  "rustc-hash 2.1.1",
  "smallvec",
@@ -6941,9 +6942,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.18"
+version = "0.12.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e98ff6b0dbbe4d5a37318f433d4fc82babd21631f194d370409ceb2e40b2f0b5"
+checksum = "a2f8e5513d63f2e5b386eb5106dc67eaf3f84e95258e210489136b8b92ad6119"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -6954,7 +6955,7 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.6.0",
- "hyper-rustls 0.27.6",
+ "hyper-rustls 0.27.7",
  "hyper-tls 0.6.0",
  "hyper-util",
  "ipnet",
@@ -7014,7 +7015,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "getrandom 0.2.16",
  "libc",
  "untrusted 0.9.0",
@@ -7056,7 +7057,7 @@ checksum = "1e147371c75553e1e2fcdb483944a8540b8438c31426279553b9a8182a9b7b65"
 dependencies = [
  "bytecheck 0.8.1",
  "bytes",
- "hashbrown 0.15.3",
+ "hashbrown 0.15.4",
  "indexmap 2.9.0",
  "munge",
  "ptr_meta 0.3.0",
@@ -7086,7 +7087,7 @@ checksum = "246b40ac189af6c675d124b802e8ef6d5246c53e17367ce9501f8f66a81abb7a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -7134,7 +7135,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6d5f2436026b4f6e79dc829837d467cc7e9a55ee40e750d716713540715a2df"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "ordered-multimap",
 ]
 
@@ -7149,7 +7150,7 @@ dependencies = [
  "aws-region",
  "base64 0.13.1",
  "block_on_proc",
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "hex",
  "hmac",
  "http 0.2.12",
@@ -7172,9 +7173,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
 
 [[package]]
 name = "rustc-hash"
@@ -7451,7 +7452,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -7607,7 +7608,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -7630,14 +7631,14 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
 ]
@@ -7681,7 +7682,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -7703,7 +7704,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "cpufeatures",
  "digest 0.10.7",
 ]
@@ -7720,7 +7721,7 @@ version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "cpufeatures",
  "digest 0.10.7",
 ]
@@ -7828,9 +7829,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 dependencies = [
  "serde",
 ]
@@ -7854,7 +7855,7 @@ checksum = "0eb01866308440fc64d6c44d9e86c5cc17adfe33c4d6eed55da9145044d0ffc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -7896,7 +7897,7 @@ version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
- "lock_api 0.4.12",
+ "lock_api 0.4.13",
 ]
 
 [[package]]
@@ -7955,7 +7956,7 @@ dependencies = [
  "futures-intrusive",
  "futures-io",
  "futures-util",
- "hashbrown 0.15.3",
+ "hashbrown 0.15.4",
  "hashlink",
  "indexmap 2.9.0",
  "log",
@@ -7984,7 +7985,7 @@ dependencies = [
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -8007,7 +8008,7 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn 2.0.101",
+ "syn 2.0.102",
  "tokio",
  "url",
 ]
@@ -8226,9 +8227,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.101"
+version = "2.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
+checksum = "f6397daf94fa90f058bd0fd88429dd9e5738999cca8d701813c80723add80462"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8258,7 +8259,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -8267,7 +8268,7 @@ version = "0.24.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54cb4ebf3d49308b99e6e9dc95e989e2fdbdc210e4f67c39db0bb89ba927001c"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "core-foundation-sys",
  "libc",
  "ntapi",
@@ -8390,7 +8391,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -8401,7 +8402,7 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -8410,7 +8411,7 @@ version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "once_cell",
 ]
 
@@ -8512,7 +8513,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot 0.12.3",
+ "parking_lot 0.12.4",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -8539,7 +8540,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -8634,9 +8635,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.22"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ae329d1f08c4d17a59bed7ff5b5a769d062e64a62d34a3261b219e62cd5aae"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -8646,18 +8647,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.9"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.26"
+version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap 2.9.0",
  "serde",
@@ -8669,9 +8670,9 @@ dependencies = [
 
 [[package]]
 name = "toml_write"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfb942dfe1d8e29a7ee7fcbde5bd2b9a25fb89aa70caea2eba3bee836ff41076"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tonic"
@@ -8780,9 +8781,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.4"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fdb0c213ca27a9f57ab69ddb290fd80d970922355b83ae380b395d3986b8a2e"
+checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
  "bitflags 2.9.1",
  "bytes",
@@ -8847,20 +8848,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+checksum = "1b1ffbcf9c6f6b99d386e7444eb608ba646ae452a36b39737deb9663b610f662"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
  "valuable",
@@ -9002,7 +9003,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "static_assertions",
 ]
 
@@ -9207,7 +9208,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -9288,7 +9289,7 @@ version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
@@ -9304,7 +9305,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
  "wasm-bindgen-shared",
 ]
 
@@ -9314,7 +9315,7 @@ version = "0.4.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "js-sys",
  "once_cell",
  "wasm-bindgen",
@@ -9339,7 +9340,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -9445,7 +9446,7 @@ version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5f31c3d2850ac7957406d3c9581d9435ea8126a26478709fa7e931b6f562b4d"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "enumset",
  "leb128",
  "region",
@@ -9541,7 +9542,7 @@ checksum = "70a5585596f6e9915d606de944aece51626736fb1191aefb5b2ef108c6f7604a"
 dependencies = [
  "backtrace",
  "cc",
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "indexmap 1.9.3",
  "libc",
  "memoffset 0.6.5",
@@ -9592,7 +9593,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04f17a5917c2ddd3819e84c661fae0d6ba29d7b9c1f0e96c708c65a9c4188e11"
 dependencies = [
  "bitflags 2.9.1",
- "hashbrown 0.15.3",
+ "hashbrown 0.15.4",
  "indexmap 2.9.0",
  "semver 1.0.26",
  "serde",
@@ -9630,8 +9631,8 @@ dependencies = [
  "bitflags 2.9.1",
  "bumpalo",
  "cc",
- "cfg-if 1.0.0",
- "hashbrown 0.15.3",
+ "cfg-if 1.0.1",
+ "hashbrown 0.15.4",
  "indexmap 2.9.0",
  "libc",
  "log",
@@ -9667,7 +9668,7 @@ version = "30.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "236964b6b35af0f08879c9c56dbfbc5adc12e8d624672341a0121df31adaa3fa"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
 ]
 
 [[package]]
@@ -9677,7 +9678,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abcc9179097235c91f299a8ff56b358ee921266b61adff7d14d6e48428954dd2"
 dependencies = [
  "anyhow",
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "cranelift-codegen",
  "cranelift-control",
  "cranelift-entity",
@@ -9727,7 +9728,7 @@ checksum = "ba5c2ac21f0b39d72d2dac198218a12b3ddeb4ab388a8fa0d2e429855876783c"
 dependencies = [
  "anyhow",
  "cc",
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "rustix 0.38.44",
  "wasmtime-asm-macros",
  "wasmtime-versioned-export-macros",
@@ -9741,7 +9742,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f180cc0d2745e3a5df5d02231cd3046f49c75512eaa987b8202363b112e125d"
 dependencies = [
  "anyhow",
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "libc",
  "windows-sys 0.59.0",
 ]
@@ -9769,7 +9770,7 @@ checksum = "dd2fe69d04986a12fc759d2e79494100d600adcb3bb79e63dedfc8e6bb2ab03e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -9900,7 +9901,7 @@ dependencies = [
  "windows-interface",
  "windows-link",
  "windows-result",
- "windows-strings 0.4.2",
+ "windows-strings",
 ]
 
 [[package]]
@@ -9911,7 +9912,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -9922,7 +9923,7 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -9933,13 +9934,13 @@ checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
 
 [[package]]
 name = "windows-registry"
-version = "0.4.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
+checksum = "b3bab093bdd303a1240bb99b8aba8ea8a69ee19d34c9e2ef9594e708a4878820"
 dependencies = [
+ "windows-link",
  "windows-result",
- "windows-strings 0.3.1",
- "windows-targets 0.53.0",
+ "windows-strings",
 ]
 
 [[package]]
@@ -9947,15 +9948,6 @@ name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
 dependencies = [
  "windows-link",
 ]
@@ -10196,7 +10188,7 @@ version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "windows-sys 0.48.0",
 ]
 
@@ -10274,7 +10266,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
  "synstructure",
 ]
 
@@ -10286,7 +10278,7 @@ checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
  "synstructure",
 ]
 
@@ -10307,7 +10299,7 @@ checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -10327,7 +10319,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
  "synstructure",
 ]
 
@@ -10348,7 +10340,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -10394,7 +10386,7 @@ checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]

--- a/configuration/src/configs/database.rs
+++ b/configuration/src/configs/database.rs
@@ -5,7 +5,7 @@ use crate::configs::{deserialize_data_or_env, deserialize_optional_data_or_env};
 
 // Database connection URL
 // Example: "postgres://user:password@localhost:5432/dbname"
-type DatabaseConnectUrl = String;
+pub type DatabaseConnectUrl = String;
 
 #[derive(Validate, serde_derive::Deserialize, Debug, Clone, Default)]
 pub struct ShardDatabaseConfig {

--- a/configuration/src/configs/general.rs
+++ b/configuration/src/configs/general.rs
@@ -21,7 +21,7 @@ pub struct GeneralRpcServerConfig {
     pub block_cache_size: f64,
     pub shadow_data_consistency_rate: f64,
     pub prefetch_state_size_limit: u64,
-    pub available_data_ranges: u64,
+    pub keep_data_ranges_number: u64,
     pub archival_mode: bool,
 }
 
@@ -154,7 +154,7 @@ pub struct CommonGeneralRpcServerConfig {
         message = "Available data ranges must be greater than or equal to 1"
     ))]
     #[serde(deserialize_with = "deserialize_optional_data_or_env", default)]
-    pub available_data_ranges: Option<u64>,
+    pub keep_data_ranges_number: Option<u64>,
     #[serde(deserialize_with = "deserialize_optional_data_or_env", default)]
     pub archival_mode: Option<bool>,
 }
@@ -184,12 +184,12 @@ impl CommonGeneralRpcServerConfig {
         100_000
     }
 
-    pub fn default_available_data_ranges() -> u64 {
+    pub fn default_keep_data_ranges_number() -> u64 {
         1
     }
 
     pub fn default_archival_mode() -> bool {
-        false
+        true
     }
 }
 
@@ -202,7 +202,7 @@ impl Default for CommonGeneralRpcServerConfig {
             block_cache_size: Some(Self::default_block_cache_size()),
             shadow_data_consistency_rate: Some(Self::default_shadow_data_consistency_rate()),
             prefetch_state_size_limit: Some(Self::default_prefetch_state_size_limit()),
-            available_data_ranges: Some(Self::default_available_data_ranges()),
+            keep_data_ranges_number: Some(Self::default_keep_data_ranges_number()),
             archival_mode: Some(Self::default_archival_mode()),
         }
     }
@@ -312,10 +312,10 @@ impl From<CommonGeneralConfig> for GeneralRpcServerConfig {
                 .rpc_server
                 .prefetch_state_size_limit
                 .unwrap_or_else(CommonGeneralRpcServerConfig::default_prefetch_state_size_limit),
-            available_data_ranges: common_config
+            keep_data_ranges_number: common_config
                 .rpc_server
-                .available_data_ranges
-                .unwrap_or_else(CommonGeneralRpcServerConfig::default_available_data_ranges),
+                .keep_data_ranges_number
+                .unwrap_or_else(CommonGeneralRpcServerConfig::default_keep_data_ranges_number),
             archival_mode: common_config
                 .rpc_server
                 .archival_mode

--- a/configuration/src/configs/general.rs
+++ b/configuration/src/configs/general.rs
@@ -21,6 +21,8 @@ pub struct GeneralRpcServerConfig {
     pub block_cache_size: f64,
     pub shadow_data_consistency_rate: f64,
     pub prefetch_state_size_limit: u64,
+    pub available_data_ranges: u64,
+    pub archival_mode: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -147,6 +149,14 @@ pub struct CommonGeneralRpcServerConfig {
     pub shadow_data_consistency_rate: Option<f64>,
     #[serde(deserialize_with = "deserialize_optional_data_or_env", default)]
     pub prefetch_state_size_limit: Option<u64>,
+    #[validate(range(
+        min = 1,
+        message = "Available data ranges must be greater than or equal to 1"
+    ))]
+    #[serde(deserialize_with = "deserialize_optional_data_or_env", default)]
+    pub available_data_ranges: Option<u64>,
+    #[serde(deserialize_with = "deserialize_optional_data_or_env", default)]
+    pub archival_mode: Option<bool>,
 }
 
 impl CommonGeneralRpcServerConfig {
@@ -173,6 +183,14 @@ impl CommonGeneralRpcServerConfig {
     pub fn default_prefetch_state_size_limit() -> u64 {
         100_000
     }
+
+    pub fn default_available_data_ranges() -> u64 {
+        1
+    }
+
+    pub fn default_archival_mode() -> bool {
+        false
+    }
 }
 
 impl Default for CommonGeneralRpcServerConfig {
@@ -184,6 +202,8 @@ impl Default for CommonGeneralRpcServerConfig {
             block_cache_size: Some(Self::default_block_cache_size()),
             shadow_data_consistency_rate: Some(Self::default_shadow_data_consistency_rate()),
             prefetch_state_size_limit: Some(Self::default_prefetch_state_size_limit()),
+            available_data_ranges: Some(Self::default_available_data_ranges()),
+            archival_mode: Some(Self::default_archival_mode()),
         }
     }
 }
@@ -292,6 +312,14 @@ impl From<CommonGeneralConfig> for GeneralRpcServerConfig {
                 .rpc_server
                 .prefetch_state_size_limit
                 .unwrap_or_else(CommonGeneralRpcServerConfig::default_prefetch_state_size_limit),
+            available_data_ranges: common_config
+                .rpc_server
+                .available_data_ranges
+                .unwrap_or_else(CommonGeneralRpcServerConfig::default_available_data_ranges),
+            archival_mode: common_config
+                .rpc_server
+                .archival_mode
+                .unwrap_or_else(CommonGeneralRpcServerConfig::default_archival_mode),
         }
     }
 }

--- a/configuration/src/default_env_configs.rs
+++ b/configuration/src/default_env_configs.rs
@@ -30,6 +30,17 @@ rpc_auth_token = "${RPC_AUTH_TOKEN}"
 ## Default value is redis://127.0.0.1/
 redis_url = "${REDIS_URL}"
 
+## Represents the number of available data ranges.
+## 1 means it will be available last 500_000 blocks (~11 epochs).
+## 2 means it will be available last 1_000_000 blocks (~22 epochs) etc.
+## Default value is 1
+available_data_ranges = "${AVAILABLE_DATA_RANGES}"
+
+## If true, means we store whole state changes in the database 
+## and available_data_ranges will be ignored 
+## and genesis block_height will be used as earliest_available_block_height
+archival_mode = "${ARCHIVAL_MODE}"
+
 ### Rpc server general configuration
 [general.rpc_server]
 

--- a/configuration/src/default_env_configs.rs
+++ b/configuration/src/default_env_configs.rs
@@ -31,14 +31,15 @@ rpc_auth_token = "${RPC_AUTH_TOKEN}"
 redis_url = "${REDIS_URL}"
 
 ## Represents the number of available data ranges.
-## 1 means it will be available last 500_000 blocks (~11 epochs).
+## 1 means it will be available last 500_000 blocks (~11 epochs).cargo fmt
 ## 2 means it will be available last 1_000_000 blocks (~22 epochs) etc.
 ## Default value is 1
-available_data_ranges = "${AVAILABLE_DATA_RANGES}"
+keep_data_ranges_number = "${KEEP_DATA_RANGES_NUMBER}"
 
 ## If true, means we store whole state changes in the database 
-## and available_data_ranges will be ignored 
+## and keep_data_ranges_number will be ignored 
 ## and genesis block_height will be used as earliest_available_block_height
+## Default value is true
 archival_mode = "${ARCHIVAL_MODE}"
 
 ### Rpc server general configuration

--- a/configuration/src/lib.rs
+++ b/configuration/src/lib.rs
@@ -7,6 +7,7 @@ use validator::Validate;
 
 mod configs;
 mod default_env_configs;
+pub mod utils;
 
 pub use crate::configs::database::DatabaseConfig;
 pub use crate::configs::general::ChainId;

--- a/configuration/src/lib.rs
+++ b/configuration/src/lib.rs
@@ -9,7 +9,7 @@ mod configs;
 mod default_env_configs;
 pub mod utils;
 
-pub use crate::configs::database::DatabaseConfig;
+pub use crate::configs::database::{DatabaseConfig, DatabaseConnectUrl};
 pub use crate::configs::general::ChainId;
 pub use crate::configs::general::StorageProvider;
 pub use crate::configs::{

--- a/configuration/src/utils.rs
+++ b/configuration/src/utils.rs
@@ -1,0 +1,70 @@
+use near_lake_framework::near_indexer_primitives::near_primitives;
+
+/// This constant represents the block height range.
+/// It is set to 500_000, which means that the data splits avery 500_000 blocks.
+pub const BLOCK_HEIGHT_RANGE: u64 = 500_000;
+
+/// # Explanation of the logic:
+///
+/// 1. `block_height / 500000`
+///
+///     * This integer division truncates any remainder, effectively grouping numbers into bins of 500,000.
+///
+///     * Example: 73908345 / 500000 = 147 (as integer division discards the remainder).
+///
+/// 2. `* 5`
+///
+///     * Since each bin represents a multiple of 500,000, multiplying by 5 scales the result to match the pattern you provided.
+///
+/// # Example Calculations:
+/// Example 1: 73908345
+///
+///     1. 73908345 / 500000 = 147
+///
+///     2. 147 * 5 = 735
+///
+///     Output: 735
+///
+/// Example 2: 130501000
+///     
+///     1. 130501000 / 500000 = 261
+///
+///     2. 261 * 5 = 1305
+///
+///     Output: 1305
+pub async fn get_data_range_id(
+    block_height: &near_primitives::types::BlockHeight,
+) -> anyhow::Result<u64> {
+    Ok((block_height / BLOCK_HEIGHT_RANGE) * 5)
+}
+
+/// This function calculates the earliest available block height based on the final block height
+pub async fn get_earliest_available_block_height(
+    final_block_height: u64,
+    available_data_ranges: u64,
+) -> anyhow::Result<u64> {
+    let final_range_id = get_data_range_id(&final_block_height).await?;
+    Ok(final_range_id * 100_000 + available_data_ranges * BLOCK_HEIGHT_RANGE)
+}
+
+/// This function checks if the block height is available in the database
+/// It returns an error if the block height is less than the earliest available block
+pub async fn check_block_height(
+    block_height: &near_primitives::types::BlockHeight,
+    final_block_height: &near_primitives::types::BlockHeight,
+    available_data_ranges: u64,
+    archival_mode: bool,
+) -> anyhow::Result<()> {
+    if archival_mode {
+        return Ok(());
+    }
+    let earliest_available_block =
+        get_earliest_available_block_height(*final_block_height, available_data_ranges).await?;
+    if *block_height < earliest_available_block {
+        anyhow::bail!(
+            "The data for block #{} is garbage collected on this node, use an archival node to fetch historical data",
+            block_height
+        )
+    }
+    Ok(())
+}

--- a/configuration/src/utils.rs
+++ b/configuration/src/utils.rs
@@ -41,25 +41,25 @@ pub async fn get_data_range_id(
 /// This function calculates the earliest available block height based on the final block height
 pub async fn get_earliest_available_block_height(
     final_block_height: u64,
-    available_data_ranges: u64,
+    keep_data_ranges_number: u64,
 ) -> anyhow::Result<u64> {
     let final_range_id = get_data_range_id(&final_block_height).await?;
-    Ok(final_range_id * 100_000 + available_data_ranges * BLOCK_HEIGHT_RANGE)
+    Ok(final_range_id * 100_000 + keep_data_ranges_number * BLOCK_HEIGHT_RANGE)
 }
 
 /// This function checks if the block height is available in the database
 /// It returns an error if the block height is less than the earliest available block
-pub async fn check_block_height(
+pub async fn check_block_height_availability(
     block_height: &near_primitives::types::BlockHeight,
     final_block_height: &near_primitives::types::BlockHeight,
-    available_data_ranges: u64,
+    keep_data_ranges_number: u64,
     archival_mode: bool,
 ) -> anyhow::Result<()> {
     if archival_mode {
         return Ok(());
     }
     let earliest_available_block =
-        get_earliest_available_block_height(*final_block_height, available_data_ranges).await?;
+        get_earliest_available_block_height(*final_block_height, keep_data_ranges_number).await?;
     if *block_height < earliest_available_block {
         anyhow::bail!(
             "The data for block #{} is garbage collected on this node, use an archival node to fetch historical data",

--- a/database/src/base/state_indexer.rs
+++ b/database/src/base/state_indexer.rs
@@ -85,4 +85,6 @@ pub trait StateIndexerDbManager {
         block_height: u64,
         block_hash: near_primitives::hash::CryptoHash,
     ) -> anyhow::Result<()>;
+
+    async fn create_new_range_tables(&self, range_id: u64) -> anyhow::Result<()>;
 }

--- a/database/src/base/state_indexer.rs
+++ b/database/src/base/state_indexer.rs
@@ -59,7 +59,6 @@ pub trait StateIndexerDbManager {
         shard_id: near_primitives::types::ShardId,
         state_changes: Vec<near_primitives::views::StateChangeWithCauseView>,
         block_height: u64,
-        block_hash: near_primitives::hash::CryptoHash,
     ) -> anyhow::Result<()>;
 
     async fn save_state_changes_access_key(
@@ -67,7 +66,6 @@ pub trait StateIndexerDbManager {
         shard_id: near_primitives::types::ShardId,
         state_changes: Vec<near_primitives::views::StateChangeWithCauseView>,
         block_height: u64,
-        block_hash: near_primitives::hash::CryptoHash,
     ) -> anyhow::Result<()>;
 
     async fn save_state_changes_contract(
@@ -75,7 +73,6 @@ pub trait StateIndexerDbManager {
         shard_id: near_primitives::types::ShardId,
         state_changes: Vec<near_primitives::views::StateChangeWithCauseView>,
         block_height: u64,
-        block_hash: near_primitives::hash::CryptoHash,
     ) -> anyhow::Result<()>;
 
     async fn save_state_changes_account(
@@ -83,7 +80,6 @@ pub trait StateIndexerDbManager {
         shard_id: near_primitives::types::ShardId,
         state_changes: Vec<near_primitives::views::StateChangeWithCauseView>,
         block_height: u64,
-        block_hash: near_primitives::hash::CryptoHash,
     ) -> anyhow::Result<()>;
 
     async fn create_new_range_tables(&self, range_id: u64) -> anyhow::Result<()>;

--- a/database/src/postgres/docker-compose.yml
+++ b/database/src/postgres/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
   metadata:
     image: postgres:15.5
@@ -10,6 +8,11 @@ services:
       POSTGRES_PASSWORD: password
     ports:
       - "5422:5432"
+    command: ["postgres", "-c", "max_connections=4000"]
+    ulimits:
+      nofile:
+        soft: 1048576
+        hard: 1048576
 
   shard_0:
     image: postgres:15.5
@@ -20,6 +23,11 @@ services:
       POSTGRES_PASSWORD: password
     ports:
       - "5430:5432"
+    command: ["postgres", "-c", "max_connections=4000"]
+    ulimits:
+      nofile:
+        soft: 1048576
+        hard: 1048576
 
   shard_1:
     image: postgres:15.5
@@ -30,6 +38,11 @@ services:
       POSTGRES_PASSWORD: password
     ports:
       - "5431:5432"
+    command: ["postgres", "-c", "max_connections=4000"]
+    ulimits:
+      nofile:
+        soft: 1048576
+        hard: 1048576
 
   shard_2:
     image: postgres:15.5
@@ -40,6 +53,7 @@ services:
       POSTGRES_PASSWORD: password
     ports:
       - "5432:5432"
+    command: ["postgres", "-c", "max_connections=4000"]
 
   shard_3:
     image: postgres:15.5
@@ -50,6 +64,11 @@ services:
       POSTGRES_PASSWORD: password
     ports:
       - "5433:5432"
+    command: ["postgres", "-c", "max_connections=4000"]
+    ulimits:
+      nofile:
+        soft: 1048576
+        hard: 1048576
 
   shard_4:
     image: postgres:15.5
@@ -60,6 +79,11 @@ services:
       POSTGRES_PASSWORD: password
     ports:
       - "5434:5432"
+    command: ["postgres", "-c", "max_connections=4000"]
+    ulimits:
+      nofile:
+        soft: 1048576
+        hard: 1048576
 
   shard_5:
     image: postgres:15.5
@@ -70,3 +94,8 @@ services:
       POSTGRES_PASSWORD: password
     ports:
       - "5435:5432"
+    command: ["postgres", "-c", "max_connections=4000"]
+    ulimits:
+      nofile:
+        soft: 1048576
+        hard: 1048576

--- a/database/src/postgres/migrations/shard_db/20250430152143_procedure_create_new_range_tables.down.sql
+++ b/database/src/postgres/migrations/shard_db/20250430152143_procedure_create_new_range_tables.down.sql
@@ -1,0 +1,1 @@
+-- Add down migration script here

--- a/database/src/postgres/migrations/shard_db/20250430152143_procedure_create_new_range_tables.up.sql
+++ b/database/src/postgres/migrations/shard_db/20250430152143_procedure_create_new_range_tables.up.sql
@@ -1,4 +1,4 @@
-CREATE OR REPLACE PROCEDURE create_new_range_tables(range_id INT)
+CREATE OR REPLACE PROCEDURE create_new_range_tables(range_id numeric(20,0))
     LANGUAGE plpgsql
 AS $$
 DECLARE

--- a/database/src/postgres/migrations/shard_db/20250430152143_procedure_create_new_range_tables.up.sql
+++ b/database/src/postgres/migrations/shard_db/20250430152143_procedure_create_new_range_tables.up.sql
@@ -8,7 +8,6 @@ BEGIN
         CREATE TABLE IF NOT EXISTS state_changes_data_%s (
             account_id text NOT NULL,
             block_height numeric(20,0) NOT NULL,
-            block_hash text NOT NULL,
             data_key text NOT NULL,
             data_value bytea NULL,
             PRIMARY KEY (account_id, data_key, block_height)
@@ -27,7 +26,6 @@ BEGIN
         CREATE TABLE IF NOT EXISTS state_changes_access_key_%s (
             account_id text NOT NULL,
             block_height numeric(20,0) NOT NULL,
-            block_hash text NOT NULL,
             data_key text NOT NULL,
             data_value bytea NULL,
             PRIMARY KEY (account_id, data_key, block_height)
@@ -45,7 +43,6 @@ BEGIN
         CREATE TABLE IF NOT EXISTS state_changes_contract_%s (
             account_id text NOT NULL,
             block_height numeric(20,0) NOT NULL,
-            block_hash text NOT NULL,
             data_value bytea NULL,
             PRIMARY KEY (account_id, block_height)
         ) PARTITION BY HASH (account_id);
@@ -62,7 +59,6 @@ BEGIN
         CREATE TABLE IF NOT EXISTS state_changes_account_%s (
             account_id text NOT NULL,
             block_height numeric(20,0) NOT NULL,
-            block_hash text NOT NULL,
             data_value bytea NULL,
             PRIMARY KEY (account_id, block_height)
         ) PARTITION BY HASH (account_id);

--- a/database/src/postgres/migrations/shard_db/20250430152143_procedure_create_new_range_tables.up.sql
+++ b/database/src/postgres/migrations/shard_db/20250430152143_procedure_create_new_range_tables.up.sql
@@ -1,0 +1,78 @@
+CREATE OR REPLACE PROCEDURE create_new_range_tables(range_id INT)
+    LANGUAGE plpgsql
+AS $$
+DECLARE
+    i INT;
+BEGIN
+    EXECUTE format('
+        CREATE TABLE IF NOT EXISTS state_changes_data_%s (
+            account_id text NOT NULL,
+            block_height numeric(20,0) NOT NULL,
+            block_hash text NOT NULL,
+            data_key text NOT NULL,
+            data_value bytea NULL,
+            PRIMARY KEY (account_id, data_key, block_height)
+        ) PARTITION BY HASH (account_id);
+    ', range_id);
+
+    -- Create 100 partitions
+    FOR i IN 0..99 LOOP
+        EXECUTE format('
+            CREATE TABLE IF NOT EXISTS state_changes_data_%s_%s PARTITION OF state_changes_data_%s FOR VALUES WITH (MODULUS 100, REMAINDER %s);
+            ', range_id, i, range_id, i);
+    END LOOP;
+
+
+    EXECUTE format('
+        CREATE TABLE IF NOT EXISTS state_changes_access_key_%s (
+            account_id text NOT NULL,
+            block_height numeric(20,0) NOT NULL,
+            block_hash text NOT NULL,
+            data_key text NOT NULL,
+            data_value bytea NULL,
+            PRIMARY KEY (account_id, data_key, block_height)
+        ) PARTITION BY HASH (account_id);
+    ', range_id);
+
+    -- Create 100 partitions
+    FOR i IN 0..99 LOOP
+        EXECUTE format('
+            CREATE TABLE IF NOT EXISTS state_changes_access_key_%s_%s PARTITION OF state_changes_access_key_%s FOR VALUES WITH (MODULUS 100, REMAINDER %s);
+            ', range_id, i, range_id, i);
+    END LOOP;
+
+    EXECUTE format('
+        CREATE TABLE IF NOT EXISTS state_changes_contract_%s (
+            account_id text NOT NULL,
+            block_height numeric(20,0) NOT NULL,
+            block_hash text NOT NULL,
+            data_value bytea NULL,
+            PRIMARY KEY (account_id, block_height)
+        ) PARTITION BY HASH (account_id);
+    ', range_id);
+
+    -- Create 100 partitions
+    FOR i IN 0..99 LOOP
+        EXECUTE format('
+            CREATE TABLE IF NOT EXISTS state_changes_contract_%s_%s PARTITION OF state_changes_contract_%s FOR VALUES WITH (MODULUS 100, REMAINDER %s);
+            ', range_id, i, range_id, i);
+    END LOOP;
+
+    EXECUTE format('
+        CREATE TABLE IF NOT EXISTS state_changes_account_%s (
+            account_id text NOT NULL,
+            block_height numeric(20,0) NOT NULL,
+            block_hash text NOT NULL,
+            data_value bytea NULL,
+            PRIMARY KEY (account_id, block_height)
+        ) PARTITION BY HASH (account_id);
+    ', range_id);
+
+    -- Create 100 partitions
+    FOR i IN 0..99 LOOP
+        EXECUTE format('
+            CREATE TABLE IF NOT EXISTS state_changes_account_%s_%s PARTITION OF state_changes_account_%s FOR VALUES WITH (MODULUS 100, REMAINDER %s);
+            ', range_id, i, range_id, i);
+    END LOOP;
+END;
+$$;

--- a/database/src/postgres/migrations/shard_db/20250430152143_procedure_create_new_range_tables.up.sql
+++ b/database/src/postgres/migrations/shard_db/20250430152143_procedure_create_new_range_tables.up.sql
@@ -70,5 +70,77 @@ BEGIN
             CREATE TABLE IF NOT EXISTS state_changes_account_%s_%s PARTITION OF state_changes_account_%s FOR VALUES WITH (MODULUS 100, REMAINDER %s);
             ', range_id, i, range_id, i);
     END LOOP;
+
+
+    EXECUTE format('
+        CREATE TABLE IF NOT EXISTS state_changes_data_%s_compact (
+            account_id text NOT NULL,
+            block_height_from numeric(20,0) NOT NULL,
+            block_height_to numeric(20,0) NULL,
+            data_key text NOT NULL,
+            data_value bytea NOT NULL,
+            PRIMARY KEY (account_id, data_key, block_height_from)
+        ) PARTITION BY HASH (account_id);
+    ', range_id);
+
+    -- Create 100 partitions
+    FOR i IN 0..99 LOOP
+        EXECUTE format('
+            CREATE TABLE IF NOT EXISTS state_changes_data_%s_compact_%s PARTITION OF state_changes_data_%s_compact FOR VALUES WITH (MODULUS 100, REMAINDER %s);
+            ', range_id, i, range_id, i);
+    END LOOP;
+
+
+    EXECUTE format('
+        CREATE TABLE IF NOT EXISTS state_changes_access_key_%s_compact (
+            account_id text NOT NULL,
+            block_height_from numeric(20,0) NOT NULL,
+            block_height_to numeric(20,0) NULL,
+            data_key text NOT NULL,
+            data_value bytea NOT NULL,
+            PRIMARY KEY (account_id, data_key, block_height_from)
+        ) PARTITION BY HASH (account_id);
+    ', range_id);
+
+    -- Create 100 partitions
+    FOR i IN 0..99 LOOP
+        EXECUTE format('
+            CREATE TABLE IF NOT EXISTS state_changes_access_key_%s_compact_%s PARTITION OF state_changes_access_key_%s_compact FOR VALUES WITH (MODULUS 100, REMAINDER %s);
+            ', range_id, i, range_id, i);
+    END LOOP;
+
+    EXECUTE format('
+        CREATE TABLE IF NOT EXISTS state_changes_contract_%s_compact (
+            account_id text NOT NULL,
+            block_height_from numeric(20,0) NOT NULL,
+            block_height_to numeric(20,0) NULL,
+            data_value bytea,
+            PRIMARY KEY (account_id, block_height_from)
+        ) PARTITION BY HASH (account_id);
+    ', range_id);
+
+    -- Create 100 partitions
+    FOR i IN 0..99 LOOP
+        EXECUTE format('
+            CREATE TABLE IF NOT EXISTS state_changes_contract_%s_compact_%s PARTITION OF state_changes_contract_%s_compact FOR VALUES WITH (MODULUS 100, REMAINDER %s);
+            ', range_id, i, range_id, i);
+    END LOOP;
+
+    EXECUTE format('
+        CREATE TABLE IF NOT EXISTS state_changes_account_%s_compact (
+            account_id text NOT NULL,
+            block_height_from numeric(20,0) NOT NULL,
+            block_height_to numeric(20,0) NULL,
+            data_value bytea,
+            PRIMARY KEY (account_id, block_height_from)
+        ) PARTITION BY HASH (account_id);
+    ', range_id);
+
+    -- Create 100 partitions
+    FOR i IN 0..99 LOOP
+        EXECUTE format('
+            CREATE TABLE IF NOT EXISTS state_changes_account_%s_compact_%s PARTITION OF state_changes_account_%s_compact FOR VALUES WITH (MODULUS 100, REMAINDER %s);
+            ', range_id, i, range_id, i);
+    END LOOP;
 END;
 $$;

--- a/database/src/postgres/migrations/shard_db/20250521171609_drop_block_hash_from_state_changes.down.sql
+++ b/database/src/postgres/migrations/shard_db/20250521171609_drop_block_hash_from_state_changes.down.sql
@@ -1,0 +1,1 @@
+-- Add down migration script here

--- a/database/src/postgres/migrations/shard_db/20250521171609_drop_block_hash_from_state_changes.up.sql
+++ b/database/src/postgres/migrations/shard_db/20250521171609_drop_block_hash_from_state_changes.up.sql
@@ -1,0 +1,19 @@
+-- Add up migration script here
+DO $$
+DECLARE
+    i INT;
+BEGIN
+    -- Drop column from each partition
+    FOR i IN 0..99 LOOP
+        EXECUTE format('ALTER TABLE state_changes_data_%s DROP COLUMN IF EXISTS block_hash', i);
+        EXECUTE format('ALTER TABLE state_changes_access_key_%s DROP COLUMN IF EXISTS block_hash', i);
+        EXECUTE format('ALTER TABLE state_changes_contract_%s DROP COLUMN IF EXISTS block_hash', i);
+        EXECUTE format('ALTER TABLE state_changes_account_%s DROP COLUMN IF EXISTS block_hash', i);
+    END LOOP;
+
+    -- Drop column from parent table
+    ALTER TABLE state_changes_data DROP COLUMN IF EXISTS block_hash;
+    ALTER TABLE state_changes_access_key DROP COLUMN IF EXISTS block_hash;
+    ALTER TABLE state_changes_contract DROP COLUMN IF EXISTS block_hash;
+    ALTER TABLE state_changes_account DROP COLUMN IF EXISTS block_hash;
+END $$;

--- a/database/src/postgres/migrations/shard_db/20250521171609_drop_block_hash_from_state_changes.up.sql
+++ b/database/src/postgres/migrations/shard_db/20250521171609_drop_block_hash_from_state_changes.up.sql
@@ -3,14 +3,6 @@ DO $$
 DECLARE
     i INT;
 BEGIN
-    -- Drop column from each partition
-    FOR i IN 0..99 LOOP
-        EXECUTE format('ALTER TABLE state_changes_data_%s DROP COLUMN IF EXISTS block_hash', i);
-        EXECUTE format('ALTER TABLE state_changes_access_key_%s DROP COLUMN IF EXISTS block_hash', i);
-        EXECUTE format('ALTER TABLE state_changes_contract_%s DROP COLUMN IF EXISTS block_hash', i);
-        EXECUTE format('ALTER TABLE state_changes_account_%s DROP COLUMN IF EXISTS block_hash', i);
-    END LOOP;
-
     -- Drop column from parent table
     ALTER TABLE state_changes_data DROP COLUMN IF EXISTS block_hash;
     ALTER TABLE state_changes_access_key DROP COLUMN IF EXISTS block_hash;

--- a/database/src/postgres/migrations/shard_db/20250521171609_drop_block_hash_from_state_changes.up.sql
+++ b/database/src/postgres/migrations/shard_db/20250521171609_drop_block_hash_from_state_changes.up.sql
@@ -3,3 +3,9 @@ ALTER TABLE state_changes_data DROP COLUMN IF EXISTS block_hash;
 ALTER TABLE state_changes_access_key DROP COLUMN IF EXISTS block_hash;
 ALTER TABLE state_changes_contract DROP COLUMN IF EXISTS block_hash;
 ALTER TABLE state_changes_account DROP COLUMN IF EXISTS block_hash;
+
+-- TODO: REMOVE ALL DEPRECATED TABLES.
+DROP TABLE IF EXISTS state_changes_data;
+DROP TABLE IF EXISTS state_changes_access_key;
+DROP TABLE IF EXISTS state_changes_contract;
+DROP TABLE IF EXISTS state_changes_account;

--- a/database/src/postgres/migrations/shard_db/20250521171609_drop_block_hash_from_state_changes.up.sql
+++ b/database/src/postgres/migrations/shard_db/20250521171609_drop_block_hash_from_state_changes.up.sql
@@ -1,11 +1,5 @@
 -- Add up migration script here
-DO $$
-DECLARE
-    i INT;
-BEGIN
-    -- Drop column from parent table
-    ALTER TABLE state_changes_data DROP COLUMN IF EXISTS block_hash;
-    ALTER TABLE state_changes_access_key DROP COLUMN IF EXISTS block_hash;
-    ALTER TABLE state_changes_contract DROP COLUMN IF EXISTS block_hash;
-    ALTER TABLE state_changes_account DROP COLUMN IF EXISTS block_hash;
-END $$;
+ALTER TABLE state_changes_data DROP COLUMN IF EXISTS block_hash;
+ALTER TABLE state_changes_access_key DROP COLUMN IF EXISTS block_hash;
+ALTER TABLE state_changes_contract DROP COLUMN IF EXISTS block_hash;
+ALTER TABLE state_changes_account DROP COLUMN IF EXISTS block_hash;

--- a/database/src/postgres/mod.rs
+++ b/database/src/postgres/mod.rs
@@ -46,7 +46,7 @@ impl PageState {
 /// block_height 130_501_000, the `data_range_id` will be 1305 -> `state_changes_data_1305`
 ///
 /// How to get `data_range_id` from block_height
-/// see more details in the `get_data_range_id` function below.
+/// see more details in the function `configuration::utils::get_data_range_id`.
 pub struct ShardIdPool<'a> {
     shard_id: near_primitives::types::ShardId,
     data_range_id: u64,

--- a/database/src/postgres/mod.rs
+++ b/database/src/postgres/mod.rs
@@ -107,14 +107,14 @@ impl PostgresDBManager {
             ))?,
         })
     }
-    
+
     async fn get_shard_connection_by_id(
         &self,
         shard_id: &near_primitives::types::ShardId,
     ) -> anyhow::Result<ShardIdPool> {
         Ok(ShardIdPool {
             shard_id: *shard_id,
-            table_number: 0, // Table number is not used in this case
+            data_range_id: 0, // Table number is not used in this case
             pool: self.shards_pool.get(shard_id).ok_or(anyhow::anyhow!(
                 "Database connection for shard_{} not found",
                 shard_id

--- a/database/src/postgres/rpc_server.rs
+++ b/database/src/postgres/rpc_server.rs
@@ -310,7 +310,7 @@ impl crate::ReaderDbManager for crate::PostgresDBManager {
         let data_range_id = shard_id_pool.data_range_id;
         let sql_query = format!(
             "
-                SELECT block_height, block_hash, data_value
+                SELECT data_value, block_height 
                 FROM state_changes_account_{data_range_id}
                 WHERE account_id = $1
                     AND block_height <= $2
@@ -318,18 +318,12 @@ impl crate::ReaderDbManager for crate::PostgresDBManager {
                 LIMIT 1;
             "
         );
-        let (block_height, block_hash, data_value): (bigdecimal::BigDecimal, String, Vec<u8>) =
-            sqlx::query_as(&sql_query)
-                .bind(account_id.to_string())
-                .bind(bigdecimal::BigDecimal::from(request_block_height))
-                .fetch_one(shard_id_pool.pool)
-                .await?;
-        let block = readnode_primitives::BlockRecord::try_from((block_hash, block_height))?;
-        readnode_primitives::QueryData::<near_primitives::account::Account>::try_from((
-            data_value,
-            block.height,
-            block.hash,
-        ))
+        let result: (Vec<u8>, bigdecimal::BigDecimal) = sqlx::query_as(&sql_query)
+            .bind(account_id.to_string())
+            .bind(bigdecimal::BigDecimal::from(request_block_height))
+            .fetch_one(shard_id_pool.pool)
+            .await?;
+        readnode_primitives::QueryData::<near_primitives::account::Account>::try_from(result)
     }
 
     async fn get_contract_code(
@@ -351,7 +345,7 @@ impl crate::ReaderDbManager for crate::PostgresDBManager {
         let data_range_id = shard_id_pool.data_range_id;
         let sql_query = format!(
             "
-                SELECT block_height, block_hash, data_value
+                SELECT data_value, block_height
                 FROM state_changes_contract_{data_range_id}
                 WHERE account_id = $1
                     AND block_height <= $2
@@ -359,18 +353,12 @@ impl crate::ReaderDbManager for crate::PostgresDBManager {
                 LIMIT 1;
             "
         );
-        let (block_height, block_hash, contract_code): (bigdecimal::BigDecimal, String, Vec<u8>) =
-            sqlx::query_as(&sql_query)
-                .bind(account_id.to_string())
-                .bind(bigdecimal::BigDecimal::from(request_block_height))
-                .fetch_one(shard_id_pool.pool)
-                .await?;
-        let block = readnode_primitives::BlockRecord::try_from((block_hash, block_height))?;
-        Ok(readnode_primitives::QueryData {
-            data: contract_code,
-            block_height: block.height,
-            block_hash: block.hash,
-        })
+        let result: (Vec<u8>, bigdecimal::BigDecimal) = sqlx::query_as(&sql_query)
+            .bind(account_id.to_string())
+            .bind(bigdecimal::BigDecimal::from(request_block_height))
+            .fetch_one(shard_id_pool.pool)
+            .await?;
+        readnode_primitives::QueryData::<Vec<u8>>::try_from(result)
     }
 
     async fn get_access_key(
@@ -394,7 +382,7 @@ impl crate::ReaderDbManager for crate::PostgresDBManager {
         let data_range_id = shard_id_pool.data_range_id;
         let sql_query = format!(
             "
-                SELECT block_height, block_hash, data_value
+                SELECT data_value, block_height
                 FROM state_changes_access_key_{data_range_id}
                 WHERE account_id = $1 
                     AND data_key = $2
@@ -403,19 +391,13 @@ impl crate::ReaderDbManager for crate::PostgresDBManager {
                 LIMIT 1;
             "
         );
-        let (block_height, block_hash, data_value): (bigdecimal::BigDecimal, String, Vec<u8>) =
-            sqlx::query_as(&sql_query)
-                .bind(account_id.to_string())
-                .bind(hex::encode(&key_data).to_string())
-                .bind(bigdecimal::BigDecimal::from(request_block_height))
-                .fetch_one(shard_id_pool.pool)
-                .await?;
-        let block = readnode_primitives::BlockRecord::try_from((block_hash, block_height))?;
-        readnode_primitives::QueryData::<near_primitives::account::AccessKey>::try_from((
-            data_value,
-            block.height,
-            block.hash,
-        ))
+        let result: (Vec<u8>, bigdecimal::BigDecimal) = sqlx::query_as(&sql_query)
+            .bind(account_id.to_string())
+            .bind(hex::encode(&key_data).to_string())
+            .bind(bigdecimal::BigDecimal::from(request_block_height))
+            .fetch_one(shard_id_pool.pool)
+            .await?;
+        readnode_primitives::QueryData::<near_primitives::account::AccessKey>::try_from(result)
     }
 
     async fn get_account_access_keys(

--- a/database/src/postgres/rpc_server.rs
+++ b/database/src/postgres/rpc_server.rs
@@ -74,15 +74,15 @@ impl crate::ReaderDbManager for crate::PostgresDBManager {
         } else {
             crate::postgres::PageState::new(1000)
         };
-        let table_number = shard_id_pool.table_number;
+        let data_range_id = shard_id_pool.data_range_id;
         let sql_query = format!(
             "
                 WITH latest_blocks AS (
                     SELECT
                         data_key,
                         MAX(block_height) AS max_block_height
-                    FROM 
-                        state_changes_data_{table_number}
+                    FROM
+                        state_changes_data_{data_range_id}
                     WHERE
                         account_id = $1
                         AND block_height <= $2
@@ -93,7 +93,7 @@ impl crate::ReaderDbManager for crate::PostgresDBManager {
                     sc.data_key,
                     sc.data_value
                 FROM
-                    state_changes_data_{table_number} sc
+                    state_changes_data_{data_range_id} sc
                 INNER JOIN latest_blocks lb
                 ON
                     sc.data_key = lb.data_key
@@ -153,15 +153,15 @@ impl crate::ReaderDbManager for crate::PostgresDBManager {
             ])
             .inc();
         let mut items = std::collections::HashMap::new();
-        let table_number = shard_id_pool.table_number;
+        let data_range_id = shard_id_pool.data_range_id;
         let sql_query = format!(
             "
                 WITH latest_blocks AS (
                     SELECT
                         data_key,
                         MAX(block_height) AS max_block_height
-                    FROM 
-                        state_changes_data_{table_number}
+                    FROM
+                        state_changes_data_{data_range_id}
                     WHERE
                         account_id = $1
                         AND data_key LIKE $2
@@ -173,7 +173,7 @@ impl crate::ReaderDbManager for crate::PostgresDBManager {
                     sc.data_key,
                     sc.data_value
                 FROM
-                    state_changes_data_{table_number} sc
+                    state_changes_data_{data_range_id} sc
                 INNER JOIN latest_blocks lb
                 ON
                     sc.data_key = lb.data_key
@@ -212,15 +212,15 @@ impl crate::ReaderDbManager for crate::PostgresDBManager {
             ])
             .inc();
         let mut items = std::collections::HashMap::new();
-        let table_number = shard_id_pool.table_number;
+        let data_range_id = shard_id_pool.data_range_id;
         let sql_query = format!(
             "
                 WITH latest_blocks AS (
                     SELECT
                         data_key,
                         MAX(block_height) AS max_block_height
-                    FROM 
-                        state_changes_data_{table_number}
+                    FROM
+                        state_changes_data_{data_range_id}
                     WHERE
                         account_id = $1
                         AND block_height <= $2
@@ -231,7 +231,7 @@ impl crate::ReaderDbManager for crate::PostgresDBManager {
                     sc.data_key,
                     sc.data_value
                 FROM
-                    state_changes_data_{table_number} sc
+                    state_changes_data_{data_range_id} sc
                 INNER JOIN latest_blocks lb
                 ON
                     sc.data_key = lb.data_key
@@ -270,11 +270,11 @@ impl crate::ReaderDbManager for crate::PostgresDBManager {
                 "state_changes_data",
             ])
             .inc();
-        let table_number = shard_id_pool.table_number;
+        let data_range_id = shard_id_pool.data_range_id;
         let sql_query = format!(
             "
                 SELECT data_value
-                FROM state_changes_data_{table_number}
+                FROM state_changes_data_{data_range_id}
                 WHERE account_id = $1 
                     AND data_key = $2
                     AND block_height <= $3
@@ -307,11 +307,11 @@ impl crate::ReaderDbManager for crate::PostgresDBManager {
                 "state_changes_account",
             ])
             .inc();
-        let table_number = shard_id_pool.table_number;
+        let data_range_id = shard_id_pool.data_range_id;
         let sql_query = format!(
             "
                 SELECT block_height, block_hash, data_value
-                FROM state_changes_account_{table_number}
+                FROM state_changes_account_{data_range_id}
                 WHERE account_id = $1
                     AND block_height <= $2
                 ORDER BY block_height DESC
@@ -348,11 +348,11 @@ impl crate::ReaderDbManager for crate::PostgresDBManager {
                 "state_changes_contract",
             ])
             .inc();
-        let table_number = shard_id_pool.table_number;
+        let data_range_id = shard_id_pool.data_range_id;
         let sql_query = format!(
             "
                 SELECT block_height, block_hash, data_value
-                FROM state_changes_contract_{table_number}
+                FROM state_changes_contract_{data_range_id}
                 WHERE account_id = $1
                     AND block_height <= $2
                 ORDER BY block_height DESC
@@ -391,11 +391,11 @@ impl crate::ReaderDbManager for crate::PostgresDBManager {
             ])
             .inc();
         let key_data = borsh::to_vec(&public_key)?;
-        let table_number = shard_id_pool.table_number;
+        let data_range_id = shard_id_pool.data_range_id;
         let sql_query = format!(
             "
                 SELECT block_height, block_hash, data_value
-                FROM state_changes_access_key_{table_number}
+                FROM state_changes_access_key_{data_range_id}
                 WHERE account_id = $1 
                     AND data_key = $2
                     AND block_height <= $3
@@ -433,7 +433,7 @@ impl crate::ReaderDbManager for crate::PostgresDBManager {
             ])
             .inc();
         let mut access_keys = vec![];
-        let table_number = shard_id_pool.table_number;
+        let data_range_id = shard_id_pool.data_range_id;
         let sql_query = format!(
             "
                 WITH latest_blocks AS (
@@ -441,8 +441,8 @@ impl crate::ReaderDbManager for crate::PostgresDBManager {
                         data_key,
                         account_id,
                         MAX(block_height) as max_block_height
-                    FROM 
-                        state_changes_access_key_{table_number}
+                    FROM
+                        state_changes_access_key_{data_range_id}
                     WHERE
                         account_id = $1
                         AND block_height <= $2
@@ -455,7 +455,7 @@ impl crate::ReaderDbManager for crate::PostgresDBManager {
                     sc.data_value,
                     sc.block_height
                 FROM
-                    state_changes_access_key_{table_number} sc
+                    state_changes_access_key_{data_range_id} sc
                 INNER JOIN latest_blocks lb
                 ON
                     sc.data_key = lb.data_key

--- a/database/src/postgres/state_indexer.rs
+++ b/database/src/postgres/state_indexer.rs
@@ -438,4 +438,14 @@ impl crate::StateIndexerDbManager for crate::PostgresDBManager {
             .await?;
         Ok(())
     }
+
+    async fn create_new_range_tables(&self, range_id: u64) -> anyhow::Result<()> {
+        for (_, pool) in self.shards_pool.iter() {
+            sqlx::query("CALL create_new_range_tables($1);")
+                .bind(range_id as i64)
+                .execute(pool)
+                .await?;
+        }
+        Ok(())
+    }
 }

--- a/database/src/postgres/state_indexer.rs
+++ b/database/src/postgres/state_indexer.rs
@@ -216,7 +216,6 @@ impl crate::StateIndexerDbManager for crate::PostgresDBManager {
         shard_id: near_primitives::types::ShardId,
         state_changes: Vec<near_primitives::views::StateChangeWithCauseView>,
         block_height: u64,
-        block_hash: near_primitives::hash::CryptoHash,
     ) -> anyhow::Result<()> {
         crate::metrics::SHARD_DATABASE_WRITE_QUERIES
             .with_label_values(&[
@@ -225,8 +224,9 @@ impl crate::StateIndexerDbManager for crate::PostgresDBManager {
                 "state_changes_data",
             ])
             .inc();
+        let range_id = configuration::utils::get_data_range_id(&block_height).await?;
         let mut query_builder: sqlx::QueryBuilder<sqlx::Postgres> = sqlx::QueryBuilder::new(
-            "INSERT INTO state_changes_data (account_id, block_height, block_hash, data_key, data_value) ",
+            format!("INSERT INTO state_changes_data_{range_id} (account_id, block_height, data_key, data_value) "),
         );
         query_builder.push_values(state_changes.iter(), |mut values, state_change| {
             match &state_change.value {
@@ -240,7 +240,6 @@ impl crate::StateIndexerDbManager for crate::PostgresDBManager {
                     values
                         .push_bind(account_id.to_string())
                         .push_bind(bigdecimal::BigDecimal::from(block_height))
-                        .push_bind(block_hash.to_string())
                         .push_bind(hex::encode(data_key).to_string())
                         .push_bind(data_value);
                 }
@@ -250,7 +249,6 @@ impl crate::StateIndexerDbManager for crate::PostgresDBManager {
                     values
                         .push_bind(account_id.to_string())
                         .push_bind(bigdecimal::BigDecimal::from(block_height))
-                        .push_bind(block_hash.to_string())
                         .push_bind(hex::encode(data_key).to_string())
                         .push_bind(data_value);
                 }
@@ -273,7 +271,6 @@ impl crate::StateIndexerDbManager for crate::PostgresDBManager {
         shard_id: near_primitives::types::ShardId,
         state_changes: Vec<near_primitives::views::StateChangeWithCauseView>,
         block_height: u64,
-        block_hash: near_primitives::hash::CryptoHash,
     ) -> anyhow::Result<()> {
         crate::metrics::SHARD_DATABASE_WRITE_QUERIES
             .with_label_values(&[
@@ -282,8 +279,9 @@ impl crate::StateIndexerDbManager for crate::PostgresDBManager {
                 "state_changes_access_key",
             ])
             .inc();
+        let range_id = configuration::utils::get_data_range_id(&block_height).await?;
         let mut query_builder: sqlx::QueryBuilder<sqlx::Postgres> = sqlx::QueryBuilder::new(
-            "INSERT INTO state_changes_access_key (account_id, block_height, block_hash, data_key, data_value) ",
+            format!("INSERT INTO state_changes_access_key_{range_id} (account_id, block_height, data_key, data_value) "),
         );
         query_builder.push_values(state_changes.iter(), |mut values, state_change| {
             match &state_change.value {
@@ -299,7 +297,6 @@ impl crate::StateIndexerDbManager for crate::PostgresDBManager {
                     values
                         .push_bind(account_id.to_string())
                         .push_bind(bigdecimal::BigDecimal::from(block_height))
-                        .push_bind(block_hash.to_string())
                         .push_bind(hex::encode(data_key).to_string())
                         .push_bind(data_value);
                 }
@@ -313,7 +310,6 @@ impl crate::StateIndexerDbManager for crate::PostgresDBManager {
                     values
                         .push_bind(account_id.to_string())
                         .push_bind(bigdecimal::BigDecimal::from(block_height))
-                        .push_bind(block_hash.to_string())
                         .push_bind(hex::encode(data_key).to_string())
                         .push_bind(data_value);
                 }
@@ -336,7 +332,6 @@ impl crate::StateIndexerDbManager for crate::PostgresDBManager {
         shard_id: near_primitives::types::ShardId,
         state_changes: Vec<near_primitives::views::StateChangeWithCauseView>,
         block_height: u64,
-        block_hash: near_primitives::hash::CryptoHash,
     ) -> anyhow::Result<()> {
         crate::metrics::SHARD_DATABASE_WRITE_QUERIES
             .with_label_values(&[
@@ -345,8 +340,9 @@ impl crate::StateIndexerDbManager for crate::PostgresDBManager {
                 "state_changes_contract",
             ])
             .inc();
+        let range_id = configuration::utils::get_data_range_id(&block_height).await?;
         let mut query_builder: sqlx::QueryBuilder<sqlx::Postgres> = sqlx::QueryBuilder::new(
-            "INSERT INTO state_changes_contract (account_id, block_height, block_hash, data_value) ",
+            format!("INSERT INTO state_changes_contract_{range_id} (account_id, block_height, data_value) "),
         );
         query_builder.push_values(state_changes.iter(), |mut values, state_change| {
             match &state_change.value {
@@ -358,7 +354,6 @@ impl crate::StateIndexerDbManager for crate::PostgresDBManager {
                     values
                         .push_bind(account_id.to_string())
                         .push_bind(bigdecimal::BigDecimal::from(block_height))
-                        .push_bind(block_hash.to_string())
                         .push_bind(data_value);
                 }
                 near_primitives::views::StateChangeValueView::ContractCodeDeletion {
@@ -368,7 +363,6 @@ impl crate::StateIndexerDbManager for crate::PostgresDBManager {
                     values
                         .push_bind(account_id.to_string())
                         .push_bind(bigdecimal::BigDecimal::from(block_height))
-                        .push_bind(block_hash.to_string())
                         .push_bind(data_value);
                 }
                 _ => {}
@@ -390,7 +384,6 @@ impl crate::StateIndexerDbManager for crate::PostgresDBManager {
         shard_id: near_primitives::types::ShardId,
         state_changes: Vec<near_primitives::views::StateChangeWithCauseView>,
         block_height: u64,
-        block_hash: near_primitives::hash::CryptoHash,
     ) -> anyhow::Result<()> {
         crate::metrics::SHARD_DATABASE_WRITE_QUERIES
             .with_label_values(&[
@@ -399,8 +392,9 @@ impl crate::StateIndexerDbManager for crate::PostgresDBManager {
                 "state_changes_account",
             ])
             .inc();
+        let range_id = configuration::utils::get_data_range_id(&block_height).await?;
         let mut query_builder: sqlx::QueryBuilder<sqlx::Postgres> = sqlx::QueryBuilder::new(
-            "INSERT INTO state_changes_account (account_id, block_height, block_hash, data_value) ",
+            format!("INSERT INTO state_changes_account_{range_id} (account_id, block_height, data_value) "),
         );
         query_builder.push_values(state_changes.iter(), |mut values, state_change| {
             match &state_change.value {
@@ -414,7 +408,6 @@ impl crate::StateIndexerDbManager for crate::PostgresDBManager {
                     values
                         .push_bind(account_id.to_string())
                         .push_bind(bigdecimal::BigDecimal::from(block_height))
-                        .push_bind(block_hash.to_string())
                         .push_bind(data_value);
                 }
                 near_primitives::views::StateChangeValueView::AccountDeletion { account_id } => {
@@ -422,7 +415,6 @@ impl crate::StateIndexerDbManager for crate::PostgresDBManager {
                     values
                         .push_bind(account_id.to_string())
                         .push_bind(bigdecimal::BigDecimal::from(block_height))
-                        .push_bind(block_hash.to_string())
                         .push_bind(data_value);
                 }
                 _ => {}

--- a/database/src/postgres/tx_indexer.rs
+++ b/database/src/postgres/tx_indexer.rs
@@ -31,7 +31,7 @@ impl crate::base::tx_indexer::TxIndexerDbManager for crate::postgres::PostgresDB
         data: Vec<u8>,
         block_height: u64,
     ) -> Result<()> {
-        let shard_conn = self.get_shard_connection(sender_id).await?;
+        let shard_conn = self.get_shard_connection(sender_id, &0).await?;
         sqlx::query(
             "
             INSERT INTO transactions (transaction_hash, sender_account_id, block_height, transaction_details)

--- a/logic-state-indexer/src/lib.rs
+++ b/logic-state-indexer/src/lib.rs
@@ -230,10 +230,7 @@ pub async fn handle_streamer_message(
 
     let current_epoch_id = streamer_message.block.header.epoch_id;
     let next_epoch_id = streamer_message.block.header.next_epoch_id;
-    println!(
-        "current_epoch_id {}, next_epoch_id {}",
-        current_epoch_id, next_epoch_id
-    );
+
     tracing::debug!(target: INDEXER, "Block height {}", block_height,);
 
     stats

--- a/logic-state-indexer/src/lib.rs
+++ b/logic-state-indexer/src/lib.rs
@@ -166,15 +166,17 @@ async fn task_migrate_and_compact_db(
     current_range_id: u64,
     current_range_start_block_height: u64,
 ) {
-    for (_, shard_database_url) in shard_db_config {
+    for (shard_id, shard_database_url) in shard_db_config {
         let output = std::process::Command::new("migrate_compact_with_state/shard_migration.sh")
             .arg(shard_database_url)
             .arg(previous_range_id.to_string())
             .arg(current_range_id.to_string())
             .arg(current_range_start_block_height.to_string())
+            .arg(shard_id.to_string())
             .output();
 
-        println!(
+        tracing::info!(
+            target: INDEXER,
             "Task_migrate_and_compact_db exited with status: {:?}",
             output
         );

--- a/logic-state-indexer/src/lib.rs
+++ b/logic-state-indexer/src/lib.rs
@@ -174,7 +174,10 @@ async fn task_migrate_and_compact_db(
             .arg(current_range_start_block_height.to_string())
             .output();
 
-        println!("Task_migrate_and_compact_db exited with status: {:?}", output);
+        println!(
+            "Task_migrate_and_compact_db exited with status: {:?}",
+            output
+        );
     }
 }
 
@@ -212,19 +215,25 @@ pub async fn handle_streamer_message(
         if current_range_id > 0 {
             // We spawn a task to do this in the background
             tracing::info!(target: INDEXER, "Migrating and compacting DB for range {}", current_range_id);
-            tokio::spawn(async move { task_migrate_and_compact_db(
-                shard_db_config,
-                current_range_id,
-                range_id,
-                block_height,
-            ).await });
+            tokio::spawn(async move {
+                task_migrate_and_compact_db(
+                    shard_db_config,
+                    current_range_id,
+                    range_id,
+                    block_height,
+                )
+                .await
+            });
         }
         stats.write().await.current_range_id = range_id;
     }
 
     let current_epoch_id = streamer_message.block.header.epoch_id;
     let next_epoch_id = streamer_message.block.header.next_epoch_id;
-    println!("current_epoch_id {}, next_epoch_id {}", current_epoch_id, next_epoch_id);
+    println!(
+        "current_epoch_id {}, next_epoch_id {}",
+        current_epoch_id, next_epoch_id
+    );
     tracing::debug!(target: INDEXER, "Block height {}", block_height,);
 
     stats

--- a/logic-state-indexer/src/metrics.rs
+++ b/logic-state-indexer/src/metrics.rs
@@ -65,6 +65,7 @@ pub struct Stats {
     pub last_processed_block_height: u64,
     pub current_epoch_id: Option<near_indexer_primitives::CryptoHash>,
     pub current_epoch_height: u64,
+    pub current_range_id: u64,
 }
 
 pub async fn state_logger(

--- a/readnode-primitives/src/lib.rs
+++ b/readnode-primitives/src/lib.rs
@@ -220,12 +220,11 @@ pub type StateValue = Vec<u8>;
 pub struct BlockHeightShardId(pub u64, pub u64);
 pub struct QueryData<T: borsh::BorshDeserialize> {
     pub data: T,
-    // block_height and block_hash we return here represents the moment
+    // block_height we return here represents the moment
     // when the data was last updated in the database
     // We used to return it in the `QueryResponse` but it was replaced with
     // the logic that corresponds the logic of the `nearcore` RPC API
     pub block_height: near_indexer_primitives::types::BlockHeight,
-    pub block_hash: CryptoHash,
 }
 
 #[derive(Debug, Clone)]
@@ -300,31 +299,20 @@ where
     }
 }
 
-impl<T>
-    TryFrom<(
-        Vec<u8>,
-        near_indexer_primitives::types::BlockHeight,
-        CryptoHash,
-    )> for QueryData<T>
+impl<T, B> TryFrom<(Vec<u8>, B)> for QueryData<T>
 where
     T: borsh::BorshDeserialize,
+    B: ToPrimitive,
 {
     type Error = anyhow::Error;
 
-    fn try_from(
-        value: (
-            Vec<u8>,
-            near_indexer_primitives::types::BlockHeight,
-            CryptoHash,
-        ),
-    ) -> Result<Self, Self::Error> {
+    fn try_from(value: (Vec<u8>, B)) -> Result<Self, Self::Error> {
         let data = T::try_from_slice(&value.0)?;
-
-        Ok(Self {
-            data,
-            block_height: value.1,
-            block_hash: value.2,
-        })
+        let block_height = value
+            .1
+            .to_u64()
+            .ok_or_else(|| anyhow::anyhow!("Failed to parse `block_height` to u64"))?;
+        Ok(Self { data, block_height })
     }
 }
 

--- a/rpc-server/src/config.rs
+++ b/rpc-server/src/config.rs
@@ -75,9 +75,9 @@ pub struct ServerContext {
     /// Binary version.
     pub version: near_primitives::version::Version,
     /// Available data ranges for regular node mode.
-    pub available_data_ranges: u64,
+    pub keep_data_ranges_number: u64,
     /// Archival mode.
-    /// If true, available_data_ranges will be ignored
+    /// If true, keep_data_ranges_number will be ignored
     pub archival_mode: bool,
 }
 
@@ -209,7 +209,7 @@ impl ServerContext {
                 commit: NEARD_COMMIT.to_string(),
                 rustc_version: RUSTC_VERSION.to_string(),
             },
-            available_data_ranges: rpc_server_config.general.available_data_ranges,
+            keep_data_ranges_number: rpc_server_config.general.keep_data_ranges_number,
             archival_mode: rpc_server_config.general.archival_mode,
         })
     }

--- a/rpc-server/src/config.rs
+++ b/rpc-server/src/config.rs
@@ -74,6 +74,11 @@ pub struct ServerContext {
     pub boot_time_seconds: i64,
     /// Binary version.
     pub version: near_primitives::version::Version,
+    /// Available data ranges for regular node mode.
+    pub available_data_ranges: u64,
+    /// Archival mode.
+    /// If true, available_data_ranges will be ignored
+    pub archival_mode: bool,
 }
 
 impl ServerContext {
@@ -204,6 +209,8 @@ impl ServerContext {
                 commit: NEARD_COMMIT.to_string(),
                 rustc_version: RUSTC_VERSION.to_string(),
             },
+            available_data_ranges: rpc_server_config.general.available_data_ranges,
+            archival_mode: rpc_server_config.general.archival_mode,
         })
     }
 }

--- a/rpc-server/src/modules/blocks/methods.rs
+++ b/rpc-server/src/modules/blocks/methods.rs
@@ -408,7 +408,7 @@ pub async fn fetch_block(
             Ok(data.genesis_info.genesis_block.header.height)
         }
     }?;
-    configuration::utils::check_block_height(
+    configuration::utils::check_block_height_availability(
         &block_height,
         &data
             .blocks_info_by_finality
@@ -416,7 +416,7 @@ pub async fn fetch_block(
             .await
             .header
             .height,
-        data.available_data_ranges,
+        data.keep_data_ranges_number,
         data.archival_mode,
     )
     .await
@@ -531,7 +531,7 @@ pub async fn fetch_chunk(
             .map(|block_height_shard_id| (block_height_shard_id.0, block_height_shard_id.1))?,
     };
 
-    configuration::utils::check_block_height(
+    configuration::utils::check_block_height_availability(
         &block_height,
         &data
             .blocks_info_by_finality
@@ -539,7 +539,7 @@ pub async fn fetch_chunk(
             .await
             .header
             .height,
-        data.available_data_ranges,
+        data.keep_data_ranges_number,
         data.archival_mode,
     )
     .await

--- a/rpc-server/src/modules/blocks/methods.rs
+++ b/rpc-server/src/modules/blocks/methods.rs
@@ -408,6 +408,23 @@ pub async fn fetch_block(
             Ok(data.genesis_info.genesis_block.header.height)
         }
     }?;
+    configuration::utils::check_block_height(
+        &block_height,
+        &data
+            .blocks_info_by_finality
+            .optimistic_block_view()
+            .await
+            .header
+            .height,
+        data.available_data_ranges,
+        data.archival_mode,
+    )
+    .await
+    .map_err(
+        |err| near_jsonrpc::primitives::types::blocks::RpcBlockError::UnknownBlock {
+            error_message: err.to_string(),
+        },
+    )?;
     let block_view = if block_height
         == data
             .blocks_info_by_finality
@@ -513,6 +530,24 @@ pub async fn fetch_chunk(
             )
             .map(|block_height_shard_id| (block_height_shard_id.0, block_height_shard_id.1))?,
     };
+
+    configuration::utils::check_block_height(
+        &block_height,
+        &data
+            .blocks_info_by_finality
+            .optimistic_block_view()
+            .await
+            .header
+            .height,
+        data.available_data_ranges,
+        data.archival_mode,
+    )
+    .await
+    .map_err(
+        |err| near_jsonrpc::primitives::types::chunks::RpcChunkError::UnknownBlock {
+            error_message: err.to_string(),
+        },
+    )?;
 
     let chunks_info = if block_height
         == data

--- a/rpc-server/src/modules/blocks/utils.rs
+++ b/rpc-server/src/modules/blocks/utils.rs
@@ -128,6 +128,23 @@ pub async fn fetch_block_from_cache_or_get(
                         }
                     })?,
             };
+            configuration::utils::check_block_height(
+                &block_height,
+                &data
+                    .blocks_info_by_finality
+                    .optimistic_block_view()
+                    .await
+                    .header
+                    .height,
+                data.available_data_ranges,
+                data.archival_mode,
+            )
+            .await
+            .map_err(|err| {
+                near_jsonrpc::primitives::types::blocks::RpcBlockError::UnknownBlock {
+                    error_message: err.to_string(),
+                }
+            })?;
             data.blocks_cache.get(&block_height).await
         }
         near_primitives::types::BlockReference::Finality(finality) => {

--- a/rpc-server/src/modules/blocks/utils.rs
+++ b/rpc-server/src/modules/blocks/utils.rs
@@ -128,7 +128,7 @@ pub async fn fetch_block_from_cache_or_get(
                         }
                     })?,
             };
-            configuration::utils::check_block_height(
+            configuration::utils::check_block_height_availability(
                 &block_height,
                 &data
                     .blocks_info_by_finality
@@ -136,7 +136,7 @@ pub async fn fetch_block_from_cache_or_get(
                     .await
                     .header
                     .height,
-                data.available_data_ranges,
+                data.keep_data_ranges_number,
                 data.archival_mode,
             )
             .await

--- a/state-indexer/migrate_compact_with_state/migrate_access_keys.sh
+++ b/state-indexer/migrate_compact_with_state/migrate_access_keys.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+DATABASE_URL=$1
+PREVIOUS_RANGE_ID=$2
+CURRENT_RANGE_ID=$3
+CURRENT_RANGE_BLOCK_HEIGHT_START=$4
+MAX_PARALLEL=${MAX_PARALLEL_JOBS}
+
+# Function to migrate a single partition
+migrate_partition() {
+    local partition=$1
+
+    psql "$DATABASE_URL" -c "
+        WITH ordered_data AS (
+            SELECT
+                account_id,
+                data_key,
+                data_value,
+                block_height AS block_height_from,
+                LAG(block_height) OVER (
+                    PARTITION BY account_id, data_key
+                    ORDER BY block_height DESC
+                ) AS block_height_to
+            FROM state_changes_access_key_${PREVIOUS_RANGE_ID}_$partition
+        ),
+        insert_compact AS (
+            INSERT INTO state_changes_access_key_${PREVIOUS_RANGE_ID}_compact_$partition (
+                account_id, data_key, data_value, block_height_from, block_height_to
+            )
+            SELECT
+                account_id, data_key, data_value, block_height_from, block_height_to
+            FROM ordered_data
+            WHERE data_value IS NOT NULL
+            ON CONFLICT (account_id, data_key, block_height_from) DO NOTHING
+        )
+        INSERT INTO state_changes_access_key_${CURRENT_RANGE_ID}_$partition (
+            account_id, block_height, data_key, data_value
+        )
+        SELECT
+            account_id,
+            block_height_from AS block_height,
+            data_key,
+            data_value
+        FROM ordered_data
+        WHERE data_value IS NOT NULL
+          AND block_height_from <= ${CURRENT_RANGE_BLOCK_HEIGHT_START}
+          AND (block_height_to IS NULL OR block_height_to > ${CURRENT_RANGE_BLOCK_HEIGHT_START})
+        ON CONFLICT (account_id, data_key, block_height) DO NOTHING;
+    "
+}
+
+# Run migrations in parallel for partitions 0 to 99
+running=0
+for i in $(seq 0 99); do
+    migrate_partition "$i" &
+
+    ((running+=1))
+    if ((running >= MAX_PARALLEL)); then
+        wait -n  # Wait for at least one job to finish
+        ((running-=1))
+    fi
+done
+
+# Wait for all background jobs to finish
+wait

--- a/state-indexer/migrate_compact_with_state/migrate_access_keys.sh
+++ b/state-indexer/migrate_compact_with_state/migrate_access_keys.sh
@@ -10,6 +10,10 @@ MAX_PARALLEL=${MAX_PARALLEL_JOBS}
 migrate_partition() {
     local partition=$1
 
+    # shellcheck disable=SC2155
+    local start_time=$(date +"%T")
+    echo "[INFO] Starting partition state_changes_access_key_$partition at $start_time" >> "$LOG_FILE"
+        
     psql "$DATABASE_URL" -c "
         WITH ordered_data AS (
             SELECT
@@ -46,7 +50,11 @@ migrate_partition() {
           AND block_height_from <= ${CURRENT_RANGE_BLOCK_HEIGHT_START}
           AND (block_height_to IS NULL OR block_height_to > ${CURRENT_RANGE_BLOCK_HEIGHT_START})
         ON CONFLICT (account_id, data_key, block_height) DO NOTHING;
-    "
+    " 2>&1 | tee -a "$LOG_FILE"
+    
+    # shellcheck disable=SC2155
+    local end_time=$(date +"%T")
+    echo "[INFO] Finished partition state_changes_access_key_$partition at $end_time" >> "$LOG_FILE"
 }
 
 # Run migrations in parallel for partitions 0 to 99

--- a/state-indexer/migrate_compact_with_state/migrate_accounts.sh
+++ b/state-indexer/migrate_compact_with_state/migrate_accounts.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+DATABASE_URL=$1
+PREVIOUS_RANGE_ID=$2
+CURRENT_RANGE_ID=$3
+CURRENT_RANGE_BLOCK_HEIGHT_START=$4
+MAX_PARALLEL=${MAX_PARALLEL_JOBS}
+
+# Function to migrate a single partition
+migrate_partition() {
+    local partition=$1
+
+    psql "$DATABASE_URL" -c "
+        WITH ordered_data AS (
+            SELECT
+                account_id,
+                data_value,
+                block_height AS block_height_from,
+                LAG(block_height) OVER (
+                    PARTITION BY account_id
+                    ORDER BY block_height DESC
+                ) AS block_height_to
+            FROM state_changes_account_${PREVIOUS_RANGE_ID}_$partition
+        ),
+        insert_compact AS (
+            INSERT INTO state_changes_account_${PREVIOUS_RANGE_ID}_compact_$partition (
+                account_id, data_value, block_height_from, block_height_to
+            )
+            SELECT
+                account_id, data_value, block_height_from, block_height_to
+            FROM ordered_data
+            WHERE data_value IS NOT NULL
+            ON CONFLICT (account_id, block_height_from) DO NOTHING
+        )
+        INSERT INTO state_changes_account_${CURRENT_RANGE_ID}_$partition (
+            account_id, block_height, data_value
+        )
+        SELECT
+            account_id,
+            block_height_from AS block_height,
+            data_value
+        FROM ordered_data
+        WHERE data_value IS NOT NULL
+          AND block_height_from <= ${CURRENT_RANGE_BLOCK_HEIGHT_START}
+          AND (block_height_to IS NULL OR block_height_to > ${CURRENT_RANGE_BLOCK_HEIGHT_START})
+        ON CONFLICT (account_id, block_height) DO NOTHING;
+    "
+}
+
+# Run migrations in parallel for partitions 0 to 99
+running=0
+for i in $(seq 0 99); do
+    migrate_partition "$i" &
+
+    ((running+=1))
+    if ((running >= MAX_PARALLEL)); then
+        wait -n  # Wait for at least one job to finish
+        ((running-=1))
+    fi
+done
+
+# Wait for all background jobs to finish
+wait

--- a/state-indexer/migrate_compact_with_state/migrate_accounts.sh
+++ b/state-indexer/migrate_compact_with_state/migrate_accounts.sh
@@ -9,6 +9,10 @@ MAX_PARALLEL=${MAX_PARALLEL_JOBS}
 # Function to migrate a single partition
 migrate_partition() {
     local partition=$1
+    
+    # shellcheck disable=SC2155
+    local start_time=$(date +"%T")
+    echo "[INFO] Starting partition state_changes_account_$partition at $start_time" >> "$LOG_FILE"
 
     psql "$DATABASE_URL" -c "
         WITH ordered_data AS (
@@ -44,7 +48,11 @@ migrate_partition() {
           AND block_height_from <= ${CURRENT_RANGE_BLOCK_HEIGHT_START}
           AND (block_height_to IS NULL OR block_height_to > ${CURRENT_RANGE_BLOCK_HEIGHT_START})
         ON CONFLICT (account_id, block_height) DO NOTHING;
-    "
+    " 2>&1 | tee -a "$LOG_FILE"
+    
+    # shellcheck disable=SC2155
+    local end_time=$(date +"%T")
+    echo "[INFO] Finished partition state_changes_account_$partition at $end_time" >> "$LOG_FILE"
 }
 
 # Run migrations in parallel for partitions 0 to 99

--- a/state-indexer/migrate_compact_with_state/migrate_contracts.sh
+++ b/state-indexer/migrate_compact_with_state/migrate_contracts.sh
@@ -10,6 +10,10 @@ MAX_PARALLEL=${MAX_PARALLEL_JOBS}
 migrate_partition() {
     local partition=$1
 
+    # shellcheck disable=SC2155
+    local start_time=$(date +"%T")
+    echo "[INFO] Starting partition state_changes_contract_$partition at $start_time" >> "$LOG_FILE"
+        
     psql "$DATABASE_URL" -c "
         WITH ordered_data AS (
             SELECT
@@ -44,7 +48,11 @@ migrate_partition() {
           AND block_height_from <= ${CURRENT_RANGE_BLOCK_HEIGHT_START}
           AND (block_height_to IS NULL OR block_height_to > ${CURRENT_RANGE_BLOCK_HEIGHT_START})
         ON CONFLICT (account_id, block_height) DO NOTHING;
-    "
+    " 2>&1 | tee -a "$LOG_FILE"
+    
+    # shellcheck disable=SC2155
+    local end_time=$(date +"%T")
+    echo "[INFO] Finished partition state_changes_contract_$partition at $end_time" >> "$LOG_FILE"
 }
 
 # Run migrations in parallel for partitions 0 to 99

--- a/state-indexer/migrate_compact_with_state/migrate_contracts.sh
+++ b/state-indexer/migrate_compact_with_state/migrate_contracts.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+DATABASE_URL=$1
+PREVIOUS_RANGE_ID=$2
+CURRENT_RANGE_ID=$3
+CURRENT_RANGE_BLOCK_HEIGHT_START=$4
+MAX_PARALLEL=${MAX_PARALLEL_JOBS}
+
+# Function to migrate a single partition
+migrate_partition() {
+    local partition=$1
+
+    psql "$DATABASE_URL" -c "
+        WITH ordered_data AS (
+            SELECT
+                account_id,
+                data_value,
+                block_height AS block_height_from,
+                LAG(block_height) OVER (
+                    PARTITION BY account_id
+                    ORDER BY block_height DESC
+                ) AS block_height_to
+            FROM state_changes_contract_${PREVIOUS_RANGE_ID}_$partition
+        ),
+        insert_compact AS (
+            INSERT INTO state_changes_contract_${PREVIOUS_RANGE_ID}_compact_$partition (
+                account_id, data_value, block_height_from, block_height_to
+            )
+            SELECT
+                account_id, data_value, block_height_from, block_height_to
+            FROM ordered_data
+            WHERE data_value IS NOT NULL
+            ON CONFLICT (account_id, block_height_from) DO NOTHING
+        )
+        INSERT INTO state_changes_contract_${CURRENT_RANGE_ID}_$partition (
+            account_id, block_height, data_value
+        )
+        SELECT
+            account_id,
+            block_height_from AS block_height,
+            data_value
+        FROM ordered_data
+        WHERE data_value IS NOT NULL
+          AND block_height_from <= ${CURRENT_RANGE_BLOCK_HEIGHT_START}
+          AND (block_height_to IS NULL OR block_height_to > ${CURRENT_RANGE_BLOCK_HEIGHT_START})
+        ON CONFLICT (account_id, block_height) DO NOTHING;
+    "
+}
+
+# Run migrations in parallel for partitions 0 to 99
+running=0
+for i in $(seq 0 99); do
+    migrate_partition "$i" &
+
+    ((running+=1))
+    if ((running >= MAX_PARALLEL)); then
+        wait -n  # Wait for at least one job to finish
+        ((running-=1))
+    fi
+done
+
+# Wait for all background jobs to finish
+wait

--- a/state-indexer/migrate_compact_with_state/migrate_state_changes.sh
+++ b/state-indexer/migrate_compact_with_state/migrate_state_changes.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+DATABASE_URL=$1
+PREVIOUS_RANGE_ID=$2
+CURRENT_RANGE_ID=$3
+CURRENT_RANGE_BLOCK_HEIGHT_START=$4
+MAX_PARALLEL=${MAX_PARALLEL_JOBS}
+
+# Function to migrate a single partition
+migrate_partition() {
+    local partition=$1
+
+    psql "$DATABASE_URL" -c "
+        WITH ordered_data AS (
+            SELECT
+                account_id,
+                data_key,
+                data_value,
+                block_height AS block_height_from,
+                LAG(block_height) OVER (
+                    PARTITION BY account_id, data_key
+                    ORDER BY block_height DESC
+                ) AS block_height_to
+            FROM state_changes_data_${PREVIOUS_RANGE_ID}_$partition
+        ),
+        insert_compact AS (
+            INSERT INTO state_changes_data_${PREVIOUS_RANGE_ID}_compact_$partition (
+                account_id, data_key, data_value, block_height_from, block_height_to
+            )
+            SELECT
+                account_id, data_key, data_value, block_height_from, block_height_to
+            FROM ordered_data
+            WHERE data_value IS NOT NULL
+            ON CONFLICT (account_id, data_key, block_height_from) DO NOTHING
+        )
+        INSERT INTO state_changes_data_${CURRENT_RANGE_ID}_$partition (
+            account_id, block_height, data_key, data_value
+        )
+        SELECT
+            account_id,
+            block_height_from AS block_height,
+            data_key,
+            data_value
+        FROM ordered_data
+        WHERE data_value IS NOT NULL
+          AND block_height_from <= ${CURRENT_RANGE_BLOCK_HEIGHT_START}
+          AND (block_height_to IS NULL OR block_height_to > ${CURRENT_RANGE_BLOCK_HEIGHT_START})
+        ON CONFLICT (account_id, data_key, block_height) DO NOTHING;
+    "
+}
+
+# Run migrations in parallel for partitions 0 to 99
+running=0
+for i in $(seq 0 99); do
+    migrate_partition "$i" &
+
+    ((running+=1))
+    if ((running >= MAX_PARALLEL)); then
+        wait -n  # Wait for at least one job to finish
+        ((running-=1))
+    fi
+done
+
+# Wait for all background jobs to finish
+wait

--- a/state-indexer/migrate_compact_with_state/migrate_state_changes.sh
+++ b/state-indexer/migrate_compact_with_state/migrate_state_changes.sh
@@ -10,6 +10,10 @@ MAX_PARALLEL=${MAX_PARALLEL_JOBS}
 migrate_partition() {
     local partition=$1
 
+    # shellcheck disable=SC2155
+    local start_time=$(date +"%T")
+    echo "[INFO] Starting partition state_changes_data_$partition at $start_time" >> "$LOG_FILE"
+
     psql "$DATABASE_URL" -c "
         WITH ordered_data AS (
             SELECT
@@ -46,7 +50,11 @@ migrate_partition() {
           AND block_height_from <= ${CURRENT_RANGE_BLOCK_HEIGHT_START}
           AND (block_height_to IS NULL OR block_height_to > ${CURRENT_RANGE_BLOCK_HEIGHT_START})
         ON CONFLICT (account_id, data_key, block_height) DO NOTHING;
-    "
+    " 2>&1 | tee -a "$LOG_FILE"
+
+    # shellcheck disable=SC2155
+    local end_time=$(date +"%T")
+    echo "[INFO] Finished partition state_changes_data_$partition at $end_time" >> "$LOG_FILE"
 }
 
 # Run migrations in parallel for partitions 0 to 99

--- a/state-indexer/migrate_compact_with_state/shard_migration.sh
+++ b/state-indexer/migrate_compact_with_state/shard_migration.sh
@@ -6,10 +6,16 @@
 # Here we use a simple approach to limit the number of parallel jobs.
 export MAX_PARALLEL_JOBS=100 # Maximum number of parallel jobs
 
+# Set log file
+export LOG_FILE="migration_$5.log"
+# Remove old log file if it exists
+rm -f "$LOG_FILE"
+touch "$LOG_FILE"
+
 # Get the directory where this script is located
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-echo "Starting snapshot state for $2 and compact for $3 at $(date)"
+echo "Starting snapshot state for $2 and compact for $3 at $(date)" | tee -a "$LOG_FILE"
 
 # wait -n is only supported in Bash version 4.3 and above — but on macOS use older Bash version (e.g., 3.2).
 # You can also install a newer Bash with Homebrew:
@@ -32,4 +38,4 @@ fi
 
 wait
 
-echo "Snapshot state for $2 and compact for $3 completed at $(date)"
+echo "Snapshot state for $2 and compact for $3 completed at $(date)" | tee -a "$LOG_FILE"

--- a/state-indexer/migrate_compact_with_state/shard_migration.sh
+++ b/state-indexer/migrate_compact_with_state/shard_migration.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Optional: Limit parallelism
+# Spawning 100 parallel psql connections may overwhelm your PostgreSQL server.
+# You can control parallelism with a semaphore.
+# Here we use a simple approach to limit the number of parallel jobs.
+export MAX_PARALLEL_JOBS=100 # Maximum number of parallel jobs
+
+# Get the directory where this script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "Starting snapshot state for $2 and compact for $3 at $(date)"
+
+# wait -n is only supported in Bash version 4.3 and above — but on macOS use older Bash version (e.g., 3.2).
+# You can also install a newer Bash with Homebrew:
+# brew install bash
+# Then run script with the new Bash:
+# /opt/homebrew/bin/bash "$SCRIPT_DIR/migrate_access_keys.sh" "$@" &
+# Then wait -n will work just fine!
+# If you are using macOS, you can use the Homebrew-installed Bash to run the scripts.
+if [[ "$(uname)" == "Darwin" ]]; then
+    /opt/homebrew/bin/bash "$SCRIPT_DIR/migrate_access_keys.sh" "$@" &
+    /opt/homebrew/bin/bash "$SCRIPT_DIR/migrate_accounts.sh" "$@" &
+    /opt/homebrew/bin/bash "$SCRIPT_DIR/migrate_contracts.sh" "$@" &
+    /opt/homebrew/bin/bash "$SCRIPT_DIR/migrate_state_changes.sh" "$@" &
+else
+    "$SCRIPT_DIR/migrate_access_keys.sh" "$@" &
+    "$SCRIPT_DIR/migrate_accounts.sh" "$@" &
+    "$SCRIPT_DIR/migrate_contracts.sh" "$@" &
+    "$SCRIPT_DIR/migrate_state_changes.sh" "$@" &
+fi
+
+wait
+
+echo "Snapshot state for $2 and compact for $3 completed at $(date)"

--- a/state-indexer/src/main.rs
+++ b/state-indexer/src/main.rs
@@ -19,7 +19,11 @@ async fn main() -> anyhow::Result<()> {
 
     // Here we have to get the latest ProtocolConfigView to get the up-to-date ShardLayout
     // we use the Referer header to ensure we take it from the native RPC node
-    let near_rpc_url = indexer_config.general.near_archival_rpc_url.clone().unwrap_or(indexer_config.general.near_rpc_url.clone());
+    let near_rpc_url = indexer_config
+        .general
+        .near_archival_rpc_url
+        .clone()
+        .unwrap_or(indexer_config.general.near_rpc_url.clone());
     let mut rpc_client = near_jsonrpc_client::JsonRpcClient::connect(near_rpc_url);
     if let Some(auth_token) = &indexer_config.general.rpc_auth_token {
         rpc_client = rpc_client.header(near_jsonrpc_client::auth::Authorization::bearer(auth_token)?);

--- a/state-indexer/src/main.rs
+++ b/state-indexer/src/main.rs
@@ -19,7 +19,8 @@ async fn main() -> anyhow::Result<()> {
 
     // Here we have to get the latest ProtocolConfigView to get the up-to-date ShardLayout
     // we use the Referer header to ensure we take it from the native RPC node
-    let mut rpc_client = near_jsonrpc_client::JsonRpcClient::connect(&indexer_config.general.near_rpc_url);
+    let near_rpc_url = indexer_config.general.near_archival_rpc_url.clone().unwrap_or(indexer_config.general.near_rpc_url.clone());
+    let mut rpc_client = near_jsonrpc_client::JsonRpcClient::connect(near_rpc_url);
     if let Some(auth_token) = &indexer_config.general.rpc_auth_token {
         rpc_client = rpc_client.header(near_jsonrpc_client::auth::Authorization::bearer(auth_token)?);
     }
@@ -30,7 +31,7 @@ async fn main() -> anyhow::Result<()> {
         .clone()
         .expect("Shard Layout is missing in the config.");
     let near_client = logic_state_indexer::NearJsonRpc::new(rpc_client);
-
+    let shard_db_config = indexer_config.database.shards_config.clone();
     let db_manager = database::prepare_db_manager::<database::PostgresDBManager>(&indexer_config.database).await?;
     let start_block_height = configs::get_start_block_height(
         &near_client,
@@ -59,6 +60,7 @@ async fn main() -> anyhow::Result<()> {
             handle_streamer_message(
                 streamer_message,
                 &db_manager,
+                shard_db_config.clone(),
                 &near_client,
                 indexer_config.clone(),
                 std::sync::Arc::clone(&stats),


### PR DESCRIPTION
This pull request introduces significant changes to enhance the database's handling of state changes by implementing data range partitioning, adding configuration options for archival mode and data ranges, and updating database schema and logic accordingly. These changes improve scalability, allow for more efficient data storage, and provide flexibility in managing historical data.

### Configuration Enhancements:
* Added `keep_data_ranges_number` and `archival_mode` fields to `GeneralRpcServerConfig` and `CommonGeneralRpcServerConfig` to allow configuration of data ranges and archival mode. Default values and validation logic were also implemented. [[1]](diffhunk://#diff-5ea05362ed45b1c41175b83422c73a2ffef1f92c09aa6b2768ff69955aaba9eeR24-R25) [[2]](diffhunk://#diff-5ea05362ed45b1c41175b83422c73a2ffef1f92c09aa6b2768ff69955aaba9eeR125-R132) [[3]](diffhunk://#diff-5ea05362ed45b1c41175b83422c73a2ffef1f92c09aa6b2768ff69955aaba9eeR159-R166) [[4]](diffhunk://#diff-5ea05362ed45b1c41175b83422c73a2ffef1f92c09aa6b2768ff69955aaba9eeR178-R179) [[5]](diffhunk://#diff-5ea05362ed45b1c41175b83422c73a2ffef1f92c09aa6b2768ff69955aaba9eeR285-R292)
* Updated `default_env_configs.rs` to include environment variables for `KEEP_DATA_RANGES_NUMBER` and `ARCHIVAL_MODE`.

### Utility Functions:
* Added `get_data_range_id`, `get_earliest_available_block_height`, and `check_block_height_availability` utility functions in `utils.rs` to calculate data range IDs, determine earliest available blocks, and validate block height availability.

### Database Schema and Partitioning:
* Introduced a new procedure `create_new_range_tables` to dynamically create partitioned tables for state changes based on data range IDs.
* Dropped the unused `block_hash` column from state changes tables to simplify the schema.

### Database Logic Updates:
* Updated `StateIndexerDbManager` to include a method for creating new range tables and removed the `block_hash` parameter from state change methods.
* Modified `PostgresDBManager` to calculate `data_range_id` dynamically and use it in SQL queries to access partitioned tables. [[1]](diffhunk://#diff-785e8ea8f3ad3548c157059e3a39d21692c86debd0ac19845113db8a19fb6dc4R31-R51) [[2]](diffhunk://#diff-785e8ea8f3ad3548c157059e3a39d21692c86debd0ac19845113db8a19fb6dc4R96-R101) [[3]](diffhunk://#diff-5634f6eb99c5770c9d69db83e48b56fc8c68b5a438b08a2f3ad958e588887b7bL64-R64) [[4]](diffhunk://#diff-5634f6eb99c5770c9d69db83e48b56fc8c68b5a438b08a2f3ad958e588887b7bL77-R85) [[5]](diffhunk://#diff-5634f6eb99c5770c9d69db83e48b56fc8c68b5a438b08a2f3ad958e588887b7bL95-R96) [[6]](diffhunk://#diff-5634f6eb99c5770c9d69db83e48b56fc8c68b5a438b08a2f3ad958e588887b7bL110-R113) [[7]](diffhunk://#diff-5634f6eb99c5770c9d69db83e48b56fc8c68b5a438b08a2f3ad958e588887b7bL145-R147) [[8]](diffhunk://#diff-5634f6eb99c5770c9d69db83e48b56fc8c68b5a438b08a2f3ad958e588887b7bL154-R164) [[9]](diffhunk://#diff-5634f6eb99c5770c9d69db83e48b56fc8c68b5a438b08a2f3ad958e588887b7bL173-R186) [[10]](diffhunk://#diff-5634f6eb99c5770c9d69db83e48b56fc8c68b5a438b08a2f3ad958e588887b7bL202-R206) [[11]](diffhunk://#diff-5634f6eb99c5770c9d69db83e48b56fc8c68b5a438b08a2f3ad958e588887b7bL211-R223)

### Documentation and Comments:
* Added detailed comments to explain the logic behind data range partitioning, including examples of how `data_range_id` is calculated and used.