### PR TITLE
update nearcore to 2.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   * Refactor the configuration of the `rpc-server` crate to use the `ShardLayout` from the `configuration` crate
 
 ### Supported Nearcore Version
-- nearcore v2.6.2
+- nearcore v2.6.3
 - rust v1.85.0
 
 ## [0.3.3](https://github.com/near/read-rpc/releases/tag/v0.3.3)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1708,9 +1708,9 @@ dependencies = [
  "anyhow",
  "dotenv",
  "lazy_static",
- "near-chain-configs 2.6.2",
+ "near-chain-configs 2.6.3",
  "near-lake-framework",
- "near-primitives 2.6.2",
+ "near-primitives 2.6.3",
  "openssl",
  "opentelemetry 0.19.0",
  "opentelemetry-jaeger",
@@ -2183,8 +2183,8 @@ dependencies = [
  "futures",
  "hex",
  "lazy_static",
- "near-crypto 2.6.2",
- "near-primitives 2.6.2",
+ "near-crypto 2.6.3",
+ "near-primitives 2.6.3",
  "prometheus",
  "readnode-primitives",
  "serde_json",
@@ -3910,7 +3910,7 @@ dependencies = [
  "lazy_static",
  "near-indexer-primitives",
  "near-jsonrpc-client 0.17.0",
- "near-primitives 2.6.2",
+ "near-primitives 2.6.3",
  "prometheus",
  "readnode-primitives",
  "tokio",
@@ -4176,14 +4176,14 @@ dependencies = [
 
 [[package]]
 name = "near-async"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?rev=2f9ddb711ebd94a306eaec06030d87ef8dfc51fa#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?rev=680b27eb0105655345535a20623aaeb3b49b82e0#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "actix",
  "derive_more 1.0.0",
  "futures",
  "near-async-derive",
- "near-o11y 2.6.2",
+ "near-o11y 2.6.3",
  "near-performance-metrics",
  "near-time",
  "once_cell",
@@ -4196,8 +4196,8 @@ dependencies = [
 
 [[package]]
 name = "near-async-derive"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?rev=2f9ddb711ebd94a306eaec06030d87ef8dfc51fa#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?rev=680b27eb0105655345535a20623aaeb3b49b82e0#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4206,16 +4206,16 @@ dependencies = [
 
 [[package]]
 name = "near-cache"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?rev=2f9ddb711ebd94a306eaec06030d87ef8dfc51fa#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?rev=680b27eb0105655345535a20623aaeb3b49b82e0#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "lru 0.12.5",
 ]
 
 [[package]]
 name = "near-chain"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?rev=2f9ddb711ebd94a306eaec06030d87ef8dfc51fa#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?rev=680b27eb0105655345535a20623aaeb3b49b82e0#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "actix",
  "anyhow",
@@ -4231,22 +4231,22 @@ dependencies = [
  "more-asserts",
  "near-async",
  "near-cache",
- "near-chain-configs 2.6.2",
+ "near-chain-configs 2.6.3",
  "near-chain-primitives",
  "near-client-primitives",
- "near-crypto 2.6.2",
+ "near-crypto 2.6.3",
  "near-epoch-manager",
  "near-mainnet-res",
  "near-network",
- "near-o11y 2.6.2",
- "near-parameters 2.6.2",
+ "near-o11y 2.6.3",
+ "near-parameters 2.6.3",
  "near-performance-metrics",
  "near-performance-metrics-macros",
  "near-pool",
- "near-primitives 2.6.2",
+ "near-primitives 2.6.3",
  "near-schema-checker-lib",
  "near-store",
- "near-vm-runner 2.6.2",
+ "near-vm-runner 2.6.3",
  "node-runtime",
  "num-rational",
  "once_cell",
@@ -4287,18 +4287,18 @@ dependencies = [
 
 [[package]]
 name = "near-chain-configs"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?rev=2f9ddb711ebd94a306eaec06030d87ef8dfc51fa#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?rev=680b27eb0105655345535a20623aaeb3b49b82e0#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "anyhow",
  "bytesize",
  "chrono",
  "derive_more 1.0.0",
- "near-config-utils 2.6.2",
- "near-crypto 2.6.2",
- "near-o11y 2.6.2",
- "near-parameters 2.6.2",
- "near-primitives 2.6.2",
+ "near-config-utils 2.6.3",
+ "near-crypto 2.6.3",
+ "near-o11y 2.6.3",
+ "near-parameters 2.6.3",
+ "near-primitives 2.6.3",
  "near-time",
  "num-rational",
  "serde",
@@ -4311,11 +4311,11 @@ dependencies = [
 
 [[package]]
 name = "near-chain-primitives"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?rev=2f9ddb711ebd94a306eaec06030d87ef8dfc51fa#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?rev=680b27eb0105655345535a20623aaeb3b49b82e0#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
- "near-crypto 2.6.2",
- "near-primitives 2.6.2",
+ "near-crypto 2.6.3",
+ "near-primitives 2.6.3",
  "near-time",
  "thiserror 2.0.12",
  "time",
@@ -4324,8 +4324,8 @@ dependencies = [
 
 [[package]]
 name = "near-chunks"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?rev=2f9ddb711ebd94a306eaec06030d87ef8dfc51fa#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?rev=680b27eb0105655345535a20623aaeb3b49b82e0#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "actix",
  "borsh",
@@ -4336,16 +4336,16 @@ dependencies = [
  "lru 0.12.5",
  "near-async",
  "near-chain",
- "near-chain-configs 2.6.2",
+ "near-chain-configs 2.6.3",
  "near-chunks-primitives",
- "near-crypto 2.6.2",
+ "near-crypto 2.6.3",
  "near-epoch-manager",
  "near-network",
- "near-o11y 2.6.2",
+ "near-o11y 2.6.3",
  "near-performance-metrics",
  "near-performance-metrics-macros",
  "near-pool",
- "near-primitives 2.6.2",
+ "near-primitives 2.6.3",
  "near-store",
  "rand 0.8.5",
  "reed-solomon-erasure 6.0.0",
@@ -4356,17 +4356,17 @@ dependencies = [
 
 [[package]]
 name = "near-chunks-primitives"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?rev=2f9ddb711ebd94a306eaec06030d87ef8dfc51fa#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?rev=680b27eb0105655345535a20623aaeb3b49b82e0#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "near-chain-primitives",
- "near-primitives 2.6.2",
+ "near-primitives 2.6.3",
 ]
 
 [[package]]
 name = "near-client"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?rev=2f9ddb711ebd94a306eaec06030d87ef8dfc51fa#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?rev=680b27eb0105655345535a20623aaeb3b49b82e0#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "actix",
  "actix-rt",
@@ -4383,23 +4383,23 @@ dependencies = [
  "near-async",
  "near-cache",
  "near-chain",
- "near-chain-configs 2.6.2",
+ "near-chain-configs 2.6.3",
  "near-chain-primitives",
  "near-chunks",
  "near-client-primitives",
- "near-crypto 2.6.2",
+ "near-crypto 2.6.3",
  "near-dyn-configs",
  "near-epoch-manager",
  "near-network",
- "near-o11y 2.6.2",
- "near-parameters 2.6.2",
+ "near-o11y 2.6.3",
+ "near-parameters 2.6.3",
  "near-performance-metrics",
  "near-performance-metrics-macros",
  "near-pool",
- "near-primitives 2.6.2",
+ "near-primitives 2.6.3",
  "near-store",
  "near-telemetry",
- "near-vm-runner 2.6.2",
+ "near-vm-runner 2.6.3",
  "num-rational",
  "once_cell",
  "percent-encoding",
@@ -4425,16 +4425,16 @@ dependencies = [
 
 [[package]]
 name = "near-client-primitives"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?rev=2f9ddb711ebd94a306eaec06030d87ef8dfc51fa#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?rev=680b27eb0105655345535a20623aaeb3b49b82e0#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "actix",
  "chrono",
- "near-chain-configs 2.6.2",
+ "near-chain-configs 2.6.3",
  "near-chain-primitives",
  "near-chunks-primitives",
- "near-crypto 2.6.2",
- "near-primitives 2.6.2",
+ "near-crypto 2.6.3",
+ "near-primitives 2.6.3",
  "near-time",
  "serde",
  "serde_json",
@@ -4458,8 +4458,8 @@ dependencies = [
 
 [[package]]
 name = "near-config-utils"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?rev=2f9ddb711ebd94a306eaec06030d87ef8dfc51fa#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?rev=680b27eb0105655345535a20623aaeb3b49b82e0#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "anyhow",
  "json_comments",
@@ -4496,8 +4496,8 @@ dependencies = [
 
 [[package]]
 name = "near-crypto"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?rev=2f9ddb711ebd94a306eaec06030d87ef8dfc51fa#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?rev=680b27eb0105655345535a20623aaeb3b49b82e0#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "blake2 0.10.6",
  "borsh",
@@ -4507,9 +4507,9 @@ dependencies = [
  "ed25519-dalek",
  "hex",
  "near-account-id",
- "near-config-utils 2.6.2",
+ "near-config-utils 2.6.3",
  "near-schema-checker-lib",
- "near-stdx 2.6.2",
+ "near-stdx 2.6.3",
  "primitive-types",
  "rand 0.8.5",
  "secp256k1",
@@ -4521,14 +4521,14 @@ dependencies = [
 
 [[package]]
 name = "near-dyn-configs"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?rev=2f9ddb711ebd94a306eaec06030d87ef8dfc51fa#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?rev=680b27eb0105655345535a20623aaeb3b49b82e0#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "anyhow",
- "near-chain-configs 2.6.2",
- "near-crypto 2.6.2",
- "near-o11y 2.6.2",
- "near-primitives 2.6.2",
+ "near-chain-configs 2.6.3",
+ "near-crypto 2.6.3",
+ "near-o11y 2.6.3",
+ "near-primitives 2.6.3",
  "near-time",
  "prometheus",
  "serde",
@@ -4540,17 +4540,17 @@ dependencies = [
 
 [[package]]
 name = "near-epoch-manager"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?rev=2f9ddb711ebd94a306eaec06030d87ef8dfc51fa#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?rev=680b27eb0105655345535a20623aaeb3b49b82e0#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "borsh",
  "itertools 0.12.1",
  "near-cache",
- "near-chain-configs 2.6.2",
+ "near-chain-configs 2.6.3",
  "near-chain-primitives",
- "near-crypto 2.6.2",
- "near-o11y 2.6.2",
- "near-primitives 2.6.2",
+ "near-crypto 2.6.3",
+ "near-o11y 2.6.3",
+ "near-primitives 2.6.3",
  "near-schema-checker-lib",
  "near-store",
  "num-bigint 0.3.3",
@@ -4575,26 +4575,26 @@ dependencies = [
 
 [[package]]
 name = "near-fmt"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?rev=2f9ddb711ebd94a306eaec06030d87ef8dfc51fa#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?rev=680b27eb0105655345535a20623aaeb3b49b82e0#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
- "near-primitives-core 2.6.2",
+ "near-primitives-core 2.6.3",
 ]
 
 [[package]]
 name = "near-indexer-primitives"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?rev=2f9ddb711ebd94a306eaec06030d87ef8dfc51fa#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?rev=680b27eb0105655345535a20623aaeb3b49b82e0#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
- "near-primitives 2.6.2",
+ "near-primitives 2.6.3",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "near-jsonrpc"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?rev=2f9ddb711ebd94a306eaec06030d87ef8dfc51fa#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?rev=680b27eb0105655345535a20623aaeb3b49b82e0#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "actix",
  "actix-cors 0.6.5",
@@ -4605,14 +4605,14 @@ dependencies = [
  "futures",
  "hex",
  "near-async",
- "near-chain-configs 2.6.2",
+ "near-chain-configs 2.6.3",
  "near-client",
  "near-client-primitives",
  "near-jsonrpc-client-internal",
- "near-jsonrpc-primitives 2.6.2",
+ "near-jsonrpc-primitives 2.6.3",
  "near-network",
- "near-o11y 2.6.2",
- "near-primitives 2.6.2",
+ "near-o11y 2.6.3",
+ "near-primitives 2.6.3",
  "serde",
  "serde_json",
  "serde_with",
@@ -4643,15 +4643,15 @@ dependencies = [
 [[package]]
 name = "near-jsonrpc-client"
 version = "0.17.0"
-source = "git+https://github.com/kobayurii/near-jsonrpc-client-rs.git?branch=fork%2F0.17.0#522601a74c0c0d457c544c14208ac2cd587dc123"
+source = "git+https://github.com/kobayurii/near-jsonrpc-client-rs.git?branch=fork%2F0.17.1#f2af1d3f098da2a73a442aee93bd221cd96a34a0"
 dependencies = [
  "borsh",
  "lazy_static",
  "log",
- "near-chain-configs 2.6.2",
- "near-crypto 2.6.2",
- "near-jsonrpc-primitives 2.6.2",
- "near-primitives 2.6.2",
+ "near-chain-configs 2.6.3",
+ "near-crypto 2.6.3",
+ "near-jsonrpc-primitives 2.6.3",
+ "near-primitives 2.6.3",
  "reqwest 0.12.15",
  "serde",
  "serde_json",
@@ -4660,14 +4660,14 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-client-internal"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?rev=2f9ddb711ebd94a306eaec06030d87ef8dfc51fa#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?rev=680b27eb0105655345535a20623aaeb3b49b82e0#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "actix-http",
  "awc",
  "futures",
- "near-jsonrpc-primitives 2.6.2",
- "near-primitives 2.6.2",
+ "near-jsonrpc-primitives 2.6.3",
+ "near-primitives 2.6.3",
  "serde",
  "serde_json",
 ]
@@ -4690,14 +4690,14 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-primitives"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?rev=2f9ddb711ebd94a306eaec06030d87ef8dfc51fa#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?rev=680b27eb0105655345535a20623aaeb3b49b82e0#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "arbitrary",
- "near-chain-configs 2.6.2",
+ "near-chain-configs 2.6.3",
  "near-client-primitives",
- "near-crypto 2.6.2",
- "near-primitives 2.6.2",
+ "near-crypto 2.6.3",
+ "near-primitives 2.6.3",
  "near-schema-checker-lib",
  "serde",
  "serde_json",
@@ -4708,7 +4708,7 @@ dependencies = [
 [[package]]
 name = "near-lake-framework"
 version = "0.0.0"
-source = "git+https://github.com/kobayurii/near-lake-framework-rs.git?branch=fork%2F0.7.16#3544665064921e0401b5dbe6f40492af30dc7e5f"
+source = "git+https://github.com/kobayurii/near-lake-framework-rs.git?branch=fork%2F0.7.17#c1919120a4be4d0cae3667024c0638bac693d0fd"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4728,23 +4728,24 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
+ "url",
 ]
 
 [[package]]
 name = "near-mainnet-res"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?rev=2f9ddb711ebd94a306eaec06030d87ef8dfc51fa#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?rev=680b27eb0105655345535a20623aaeb3b49b82e0#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "near-account-id",
- "near-chain-configs 2.6.2",
- "near-primitives 2.6.2",
+ "near-chain-configs 2.6.3",
+ "near-primitives 2.6.3",
  "serde_json",
 ]
 
 [[package]]
 name = "near-network"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?rev=2f9ddb711ebd94a306eaec06030d87ef8dfc51fa#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?rev=680b27eb0105655345535a20623aaeb3b49b82e0#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "actix",
  "anyhow",
@@ -4763,13 +4764,13 @@ dependencies = [
  "itertools 0.12.1",
  "lru 0.12.5",
  "near-async",
- "near-chain-configs 2.6.2",
- "near-crypto 2.6.2",
- "near-fmt 2.6.2",
- "near-o11y 2.6.2",
+ "near-chain-configs 2.6.3",
+ "near-crypto 2.6.3",
+ "near-fmt 2.6.3",
+ "near-o11y 2.6.3",
  "near-performance-metrics",
  "near-performance-metrics-macros",
- "near-primitives 2.6.2",
+ "near-primitives 2.6.3",
  "near-schema-checker-lib",
  "near-store",
  "opentelemetry 0.22.0",
@@ -4823,14 +4824,14 @@ dependencies = [
 
 [[package]]
 name = "near-o11y"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?rev=2f9ddb711ebd94a306eaec06030d87ef8dfc51fa#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?rev=680b27eb0105655345535a20623aaeb3b49b82e0#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "actix",
  "base64 0.21.7",
  "clap",
- "near-crypto 2.6.2",
- "near-primitives-core 2.6.2",
+ "near-crypto 2.6.3",
+ "near-primitives-core 2.6.3",
  "opentelemetry 0.22.0",
  "opentelemetry-otlp 0.15.0",
  "opentelemetry-semantic-conventions 0.14.0",
@@ -4867,13 +4868,13 @@ dependencies = [
 
 [[package]]
 name = "near-parameters"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?rev=2f9ddb711ebd94a306eaec06030d87ef8dfc51fa#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?rev=680b27eb0105655345535a20623aaeb3b49b82e0#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "borsh",
  "enum-map",
  "near-account-id",
- "near-primitives-core 2.6.2",
+ "near-primitives-core 2.6.3",
  "near-schema-checker-lib",
  "num-rational",
  "serde",
@@ -4885,8 +4886,8 @@ dependencies = [
 
 [[package]]
 name = "near-performance-metrics"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?rev=2f9ddb711ebd94a306eaec06030d87ef8dfc51fa#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?rev=680b27eb0105655345535a20623aaeb3b49b82e0#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "actix",
  "bitflags 1.3.2",
@@ -4900,8 +4901,8 @@ dependencies = [
 
 [[package]]
 name = "near-performance-metrics-macros"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?rev=2f9ddb711ebd94a306eaec06030d87ef8dfc51fa#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?rev=680b27eb0105655345535a20623aaeb3b49b82e0#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "quote",
  "syn 2.0.100",
@@ -4909,13 +4910,13 @@ dependencies = [
 
 [[package]]
 name = "near-pool"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?rev=2f9ddb711ebd94a306eaec06030d87ef8dfc51fa#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?rev=680b27eb0105655345535a20623aaeb3b49b82e0#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "borsh",
- "near-crypto 2.6.2",
- "near-o11y 2.6.2",
- "near-primitives 2.6.2",
+ "near-crypto 2.6.3",
+ "near-o11y 2.6.3",
+ "near-primitives 2.6.3",
  "rand 0.8.5",
 ]
 
@@ -4963,8 +4964,8 @@ dependencies = [
 
 [[package]]
 name = "near-primitives"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?rev=2f9ddb711ebd94a306eaec06030d87ef8dfc51fa#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?rev=680b27eb0105655345535a20623aaeb3b49b82e0#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -4979,12 +4980,12 @@ dependencies = [
  "enum-map",
  "hex",
  "itertools 0.12.1",
- "near-crypto 2.6.2",
- "near-fmt 2.6.2",
- "near-parameters 2.6.2",
- "near-primitives-core 2.6.2",
+ "near-crypto 2.6.3",
+ "near-fmt 2.6.3",
+ "near-parameters 2.6.3",
+ "near-primitives-core 2.6.3",
  "near-schema-checker-lib",
- "near-stdx 2.6.2",
+ "near-stdx 2.6.3",
  "near-time",
  "num-rational",
  "ordered-float 4.6.0",
@@ -5027,8 +5028,8 @@ dependencies = [
 
 [[package]]
 name = "near-primitives-core"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?rev=2f9ddb711ebd94a306eaec06030d87ef8dfc51fa#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?rev=680b27eb0105655345535a20623aaeb3b49b82e0#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -5070,13 +5071,13 @@ dependencies = [
 
 [[package]]
 name = "near-schema-checker-core"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?rev=2f9ddb711ebd94a306eaec06030d87ef8dfc51fa#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?rev=680b27eb0105655345535a20623aaeb3b49b82e0#680b27eb0105655345535a20623aaeb3b49b82e0"
 
 [[package]]
 name = "near-schema-checker-lib"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?rev=2f9ddb711ebd94a306eaec06030d87ef8dfc51fa#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?rev=680b27eb0105655345535a20623aaeb3b49b82e0#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "near-schema-checker-core",
  "near-schema-checker-macro",
@@ -5084,8 +5085,8 @@ dependencies = [
 
 [[package]]
 name = "near-schema-checker-macro"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?rev=2f9ddb711ebd94a306eaec06030d87ef8dfc51fa#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?rev=680b27eb0105655345535a20623aaeb3b49b82e0#680b27eb0105655345535a20623aaeb3b49b82e0"
 
 [[package]]
 name = "near-stdx"
@@ -5095,13 +5096,13 @@ checksum = "855fd5540e3b4ff6fedf12aba2db1ee4b371b36f465da1363a6d022b27cb43b8"
 
 [[package]]
 name = "near-stdx"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?rev=2f9ddb711ebd94a306eaec06030d87ef8dfc51fa#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?rev=680b27eb0105655345535a20623aaeb3b49b82e0#680b27eb0105655345535a20623aaeb3b49b82e0"
 
 [[package]]
 name = "near-store"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?rev=2f9ddb711ebd94a306eaec06030d87ef8dfc51fa#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?rev=680b27eb0105655345535a20623aaeb3b49b82e0#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "actix",
  "actix-rt",
@@ -5116,17 +5117,17 @@ dependencies = [
  "itertools 0.12.1",
  "itoa",
  "lru 0.12.5",
- "near-chain-configs 2.6.2",
+ "near-chain-configs 2.6.3",
  "near-chain-primitives",
- "near-crypto 2.6.2",
- "near-fmt 2.6.2",
- "near-o11y 2.6.2",
- "near-parameters 2.6.2",
- "near-primitives 2.6.2",
+ "near-crypto 2.6.3",
+ "near-fmt 2.6.3",
+ "near-o11y 2.6.3",
+ "near-parameters 2.6.3",
+ "near-primitives 2.6.3",
  "near-schema-checker-lib",
- "near-stdx 2.6.2",
+ "near-stdx 2.6.3",
  "near-time",
- "near-vm-runner 2.6.2",
+ "near-vm-runner 2.6.3",
  "num_cpus",
  "rand 0.8.5",
  "rayon",
@@ -5147,14 +5148,14 @@ dependencies = [
 
 [[package]]
 name = "near-telemetry"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?rev=2f9ddb711ebd94a306eaec06030d87ef8dfc51fa#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?rev=680b27eb0105655345535a20623aaeb3b49b82e0#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "actix",
  "awc",
  "futures",
  "near-async",
- "near-o11y 2.6.2",
+ "near-o11y 2.6.3",
  "near-performance-metrics",
  "near-performance-metrics-macros",
  "near-time",
@@ -5166,8 +5167,8 @@ dependencies = [
 
 [[package]]
 name = "near-time"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?rev=2f9ddb711ebd94a306eaec06030d87ef8dfc51fa#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?rev=680b27eb0105655345535a20623aaeb3b49b82e0#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "serde",
  "time",
@@ -5176,8 +5177,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?rev=2f9ddb711ebd94a306eaec06030d87ef8dfc51fa#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?rev=680b27eb0105655345535a20623aaeb3b49b82e0#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "enumset",
  "finite-wasm",
@@ -5192,8 +5193,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler-singlepass"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?rev=2f9ddb711ebd94a306eaec06030d87ef8dfc51fa#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?rev=680b27eb0105655345535a20623aaeb3b49b82e0#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "dynasm 2.0.0",
  "dynasmrt 2.0.0",
@@ -5212,8 +5213,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-engine"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?rev=2f9ddb711ebd94a306eaec06030d87ef8dfc51fa#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?rev=680b27eb0105655345535a20623aaeb3b49b82e0#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "backtrace",
  "cfg-if 1.0.0",
@@ -5264,8 +5265,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?rev=2f9ddb711ebd94a306eaec06030d87ef8dfc51fa#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?rev=680b27eb0105655345535a20623aaeb3b49b82e0#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "anyhow",
  "blst",
@@ -5276,12 +5277,12 @@ dependencies = [
  "finite-wasm",
  "lru 0.12.5",
  "memoffset 0.8.0",
- "near-crypto 2.6.2",
- "near-o11y 2.6.2",
- "near-parameters 2.6.2",
- "near-primitives-core 2.6.2",
+ "near-crypto 2.6.3",
+ "near-o11y 2.6.3",
+ "near-parameters 2.6.3",
+ "near-primitives-core 2.6.3",
  "near-schema-checker-lib",
- "near-stdx 2.6.2",
+ "near-stdx 2.6.3",
  "near-vm-compiler",
  "near-vm-compiler-singlepass",
  "near-vm-engine",
@@ -5321,8 +5322,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-types"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?rev=2f9ddb711ebd94a306eaec06030d87ef8dfc51fa#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?rev=680b27eb0105655345535a20623aaeb3b49b82e0#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "indexmap 2.8.0",
  "num-traits",
@@ -5332,8 +5333,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-vm"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?rev=2f9ddb711ebd94a306eaec06030d87ef8dfc51fa#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?rev=680b27eb0105655345535a20623aaeb3b49b82e0#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "backtrace",
  "cc",
@@ -5353,12 +5354,12 @@ dependencies = [
 
 [[package]]
 name = "near-wallet-contract"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?rev=2f9ddb711ebd94a306eaec06030d87ef8dfc51fa#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?rev=680b27eb0105655345535a20623aaeb3b49b82e0#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "anyhow",
- "near-primitives-core 2.6.2",
- "near-vm-runner 2.6.2",
+ "near-primitives-core 2.6.3",
+ "near-vm-runner 2.6.3",
 ]
 
 [[package]]
@@ -5388,19 +5389,19 @@ dependencies = [
 
 [[package]]
 name = "node-runtime"
-version = "2.6.2"
-source = "git+https://github.com/near/nearcore?rev=2f9ddb711ebd94a306eaec06030d87ef8dfc51fa#2f9ddb711ebd94a306eaec06030d87ef8dfc51fa"
+version = "2.6.3"
+source = "git+https://github.com/near/nearcore?rev=680b27eb0105655345535a20623aaeb3b49b82e0#680b27eb0105655345535a20623aaeb3b49b82e0"
 dependencies = [
  "borsh",
  "bytesize",
  "itertools 0.12.1",
- "near-crypto 2.6.2",
- "near-o11y 2.6.2",
- "near-parameters 2.6.2",
- "near-primitives 2.6.2",
- "near-primitives-core 2.6.2",
+ "near-crypto 2.6.3",
+ "near-o11y 2.6.3",
+ "near-parameters 2.6.3",
+ "near-primitives 2.6.3",
+ "near-primitives-core 2.6.3",
  "near-store",
- "near-vm-runner 2.6.2",
+ "near-vm-runner 2.6.3",
  "near-wallet-contract",
  "num-bigint 0.3.3",
  "num-traits",
@@ -6682,15 +6683,15 @@ dependencies = [
  "lru 0.12.5",
  "mimalloc",
  "near-async",
- "near-chain-configs 2.6.2",
- "near-crypto 2.6.2",
+ "near-chain-configs 2.6.3",
+ "near-crypto 2.6.3",
  "near-indexer-primitives",
  "near-jsonrpc",
  "near-jsonrpc-client 0.17.0",
  "near-lake-framework",
- "near-parameters 2.6.2",
- "near-primitives 2.6.2",
- "near-vm-runner 2.6.2",
+ "near-parameters 2.6.3",
+ "near-primitives 2.6.3",
+ "near-vm-runner 2.6.3",
  "prometheus",
  "readnode-primitives",
  "rustc_version 0.4.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,19 +50,19 @@ tx-details-storage = { path = "tx-details-storage" }
 logic-state-indexer = { path = "logic-state-indexer" }
 
 # Please, update the supported nearcore version in .cargo/config.toml file
-near-async = { git = "https://github.com/near/nearcore", rev = "2f9ddb711ebd94a306eaec06030d87ef8dfc51fa" }
-near-indexer-primitives = { git = "https://github.com/near/nearcore", rev = "2f9ddb711ebd94a306eaec06030d87ef8dfc51fa" }
-near-primitives = { git = "https://github.com/near/nearcore", rev = "2f9ddb711ebd94a306eaec06030d87ef8dfc51fa" }
-near-chain-configs = { git = "https://github.com/near/nearcore", rev = "2f9ddb711ebd94a306eaec06030d87ef8dfc51fa" }
-near-crypto = { git = "https://github.com/near/nearcore", rev = "2f9ddb711ebd94a306eaec06030d87ef8dfc51fa" }
-near-jsonrpc = { git = "https://github.com/near/nearcore", rev = "2f9ddb711ebd94a306eaec06030d87ef8dfc51fa" }
-near-parameters = { git = "https://github.com/near/nearcore", rev = "2f9ddb711ebd94a306eaec06030d87ef8dfc51fa" }
-near-vm-runner = { git = "https://github.com/near/nearcore", rev = "2f9ddb711ebd94a306eaec06030d87ef8dfc51fa" , features = [
+near-async = { git = "https://github.com/near/nearcore", rev = "680b27eb0105655345535a20623aaeb3b49b82e0" }
+near-indexer-primitives = { git = "https://github.com/near/nearcore", rev = "680b27eb0105655345535a20623aaeb3b49b82e0" }
+near-primitives = { git = "https://github.com/near/nearcore", rev = "680b27eb0105655345535a20623aaeb3b49b82e0" }
+near-chain-configs = { git = "https://github.com/near/nearcore", rev = "680b27eb0105655345535a20623aaeb3b49b82e0" }
+near-crypto = { git = "https://github.com/near/nearcore", rev = "680b27eb0105655345535a20623aaeb3b49b82e0" }
+near-jsonrpc = { git = "https://github.com/near/nearcore", rev = "680b27eb0105655345535a20623aaeb3b49b82e0" }
+near-parameters = { git = "https://github.com/near/nearcore", rev = "680b27eb0105655345535a20623aaeb3b49b82e0" }
+near-vm-runner = { git = "https://github.com/near/nearcore", rev = "680b27eb0105655345535a20623aaeb3b49b82e0" , features = [
     "wasmer0_vm",
     "wasmer2_vm",
     "wasmtime_vm",
     "near_vm",
 ] }
 
-near-jsonrpc-client = { git = 'https://github.com/kobayurii/near-jsonrpc-client-rs.git', branch = 'fork/0.17.0' }
-near-lake-framework = { git = 'https://github.com/kobayurii/near-lake-framework-rs.git', branch = 'fork/0.7.16' }
+near-jsonrpc-client = { git = 'https://github.com/kobayurii/near-jsonrpc-client-rs.git', branch = 'fork/0.17.1' }
+near-lake-framework = { git = 'https://github.com/kobayurii/near-lake-framework-rs.git', branch = 'fork/0.7.17' }


### PR DESCRIPTION
This pull request updates dependencies and documentation to align with the latest versions of `nearcore` and related libraries. The most important changes include updating the supported `nearcore` version in the changelog and upgrading multiple dependencies in `Cargo.toml` to newer revisions.

### Dependency Updates:

* Updated the `near-async`, `near-indexer-primitives`, `near-primitives`, `near-chain-configs`, `near-crypto`, `near-jsonrpc`, `near-parameters`, and `near-vm-runner` dependencies to use the `680b27eb0105655345535a20623aaeb3b49b82e0` revision from the `nearcore` repository. This ensures compatibility with the latest `nearcore` version. (`Cargo.toml`, [Cargo.tomlL53-R68](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L53-R68))
* Updated `near-jsonrpc-client` to branch `fork/0.17.1` and `near-lake-framework` to branch `fork/0.7.17` to pull in the latest changes from their respective repositories. (`Cargo.toml`, [Cargo.tomlL53-R68](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L53-R68))

### Documentation Updates:

* Updated the supported `nearcore` version in the changelog from `v2.6.2` to `v2.6.3` to reflect compatibility with the latest release. (`CHANGELOG.md`, [CHANGELOG.mdL24-R24](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL24-R24))