### PR TITLE
fix parse config.toml

### DIFF
--- a/configuration/src/configs/general.rs
+++ b/configuration/src/configs/general.rs
@@ -21,6 +21,7 @@ pub struct GeneralRpcServerConfig {
     pub block_cache_size: f64,
     pub shadow_data_consistency_rate: f64,
     pub prefetch_state_size_limit: u64,
+    pub tx_details_storage_provider: StorageProvider,
 }
 
 #[derive(Debug, Clone)]
@@ -68,7 +69,7 @@ pub struct CommonGeneralConfig {
     pub tx_indexer: CommonGeneralTxIndexerConfig,
     #[serde(default)]
     pub state_indexer: CommonGeneralStateIndexerConfig,
-    #[serde(default)]
+    #[serde(deserialize_with = "deserialize_data_or_env")]
     pub tx_details_storage_provider: StorageProvider,
 }
 
@@ -194,8 +195,6 @@ pub struct CommonGeneralTxIndexerConfig {
     pub indexer_id: Option<String>,
     #[serde(deserialize_with = "deserialize_optional_data_or_env", default)]
     pub metrics_server_port: Option<u16>,
-    #[serde(deserialize_with = "deserialize_optional_data_or_env", default)]
-    pub tx_details_storage_provider: Option<StorageProvider>,
 }
 
 impl CommonGeneralTxIndexerConfig {
@@ -213,7 +212,6 @@ impl Default for CommonGeneralTxIndexerConfig {
         Self {
             indexer_id: Some(Self::default_indexer_id()),
             metrics_server_port: Some(Self::default_metrics_server_port()),
-            tx_details_storage_provider: Some(StorageProvider::Postgres),
         }
     }
 }
@@ -292,6 +290,7 @@ impl From<CommonGeneralConfig> for GeneralRpcServerConfig {
                 .rpc_server
                 .prefetch_state_size_limit
                 .unwrap_or_else(CommonGeneralRpcServerConfig::default_prefetch_state_size_limit),
+            tx_details_storage_provider: common_config.tx_details_storage_provider,
         }
     }
 }

--- a/configuration/src/configs/mod.rs
+++ b/configuration/src/configs/mod.rs
@@ -120,13 +120,11 @@ pub struct RpcServerConfig {
     pub lake_config: lake::LakeConfig,
     pub database: database::DatabaseConfig,
     pub tx_details_storage: tx_details_storage::TxDetailsStorageConfig,
-    pub tx_details_storage_provider: general::StorageProvider,
 }
 
 impl Config for RpcServerConfig {
     fn from_common_config(common_config: CommonConfig) -> Self {
         Self {
-            tx_details_storage_provider: common_config.general.tx_details_storage_provider.clone(),
             general: common_config.general.into(),
             lake_config: common_config.lake_config.into(),
             database: database::DatabaseConfig::from(common_config.database).to_read_only(),
@@ -144,7 +142,6 @@ pub struct TxIndexerConfig {
     pub lake_config: lake::LakeConfig,
     pub database: database::DatabaseConfig,
     pub tx_details_storage: tx_details_storage::TxDetailsStorageConfig,
-    pub tx_details_storage_provider: general::StorageProvider,
 }
 
 impl TxIndexerConfig {
@@ -159,7 +156,6 @@ impl TxIndexerConfig {
 impl Config for TxIndexerConfig {
     fn from_common_config(common_config: CommonConfig) -> Self {
         Self {
-            tx_details_storage_provider: common_config.general.tx_details_storage_provider.clone(),
             general: common_config.general.into(),
             rightsizing: common_config.rightsizing.into(),
             lake_config: common_config.lake_config.into(),

--- a/configuration/src/default_env_configs.rs
+++ b/configuration/src/default_env_configs.rs
@@ -30,6 +30,11 @@ rpc_auth_token = "${RPC_AUTH_TOKEN}"
 ## Default value is redis://127.0.0.1/
 redis_url = "${REDIS_URL}"
 
+## Transaction details storage provider
+## Options: "scylladb", "postgres"
+## Default value is "postgres"
+tx_details_storage_provider = "${TX_DETAILS_STORAGE_PROVIDER}"
+
 ### Rpc server general configuration
 [general.rpc_server]
 
@@ -77,11 +82,6 @@ indexer_id = "${TX_INDEXER_ID}"
 ## Port for metrics server
 ## By default it 8080 for tx-indexer and 8081 for state-indexer
 metrics_server_port = "${TX_SERVER_PORT}"
-
-## Transaction details storage provider
-## Options: "scylla", "postgres"
-## Default value is "postgres"
-#tx_details_storage_provider = "${TX_DETAILS_STORAGE_PROVIDER}"
 
 ### State indexer general configuration
 [general.state_indexer]

--- a/rpc-server/src/config.rs
+++ b/rpc-server/src/config.rs
@@ -141,7 +141,7 @@ impl ServerContext {
         .await?;
 
         let tx_details_storage: std::sync::Arc<dyn tx_details_storage::Storage + Send + Sync> =
-            match rpc_server_config.tx_details_storage_provider {
+            match rpc_server_config.general.tx_details_storage_provider {
                 configuration::StorageProvider::ScyllaDb => {
                     let scylla_session = rpc_server_config
                         .tx_details_storage

--- a/tx-indexer/src/main.rs
+++ b/tx-indexer/src/main.rs
@@ -30,9 +30,9 @@ async fn main() -> anyhow::Result<()> {
         .lake_client(indexer_config.general.chain_id.clone())
         .await?;
 
-    tracing::info!(target: INDEXER, "Instantiating the tx_details storage client with {:?} provider...", &indexer_config.tx_details_storage_provider);
+    tracing::info!(target: INDEXER, "Instantiating the tx_details storage client with {:?} provider...", &indexer_config.general.tx_details_storage_provider);
     let tx_details_storage: std::sync::Arc<dyn tx_details_storage::Storage + Send + Sync> =
-        match indexer_config.tx_details_storage_provider {
+        match indexer_config.general.tx_details_storage_provider {
             configuration::StorageProvider::ScyllaDb => {
                 let scylla_session = indexer_config
                     .tx_details_storage


### PR DESCRIPTION
This pull request refactors how the transaction details storage provider is configured and accessed throughout the codebase. The main change is to move the `tx_details_storage_provider` field from specific sub-configs (like `TxIndexerConfig` and `CommonGeneralTxIndexerConfig`) to the top-level general configuration, ensuring consistent access and simplifying configuration management. The environment variable handling and default config files have also been updated to reflect this change.

**Configuration refactoring:**

* Moved the `tx_details_storage_provider` field from `CommonGeneralTxIndexerConfig` and `TxIndexerConfig` to `CommonGeneralConfig` and `GeneralRpcServerConfig`, making it a top-level field in the general configuration. This change ensures a single source of truth for the storage provider setting. [[1]](diffhunk://#diff-5ea05362ed45b1c41175b83422c73a2ffef1f92c09aa6b2768ff69955aaba9eeR24) [[2]](diffhunk://#diff-5ea05362ed45b1c41175b83422c73a2ffef1f92c09aa6b2768ff69955aaba9eeL71-R72) [[3]](diffhunk://#diff-5ea05362ed45b1c41175b83422c73a2ffef1f92c09aa6b2768ff69955aaba9eeL197-L198) [[4]](diffhunk://#diff-2b276f5036f11e1afbcc8e577d7da71475e77fe0a3c73dfac58e799407ed6a81L147)
* Updated the deserialization logic for the `tx_details_storage_provider` field to use `deserialize_data_or_env`, allowing it to be set via environment variables more consistently.

**Default configuration and environment variables:**

* Added `tx_details_storage_provider` to the default environment configuration file, documenting available options and the default value. Removed redundant or outdated configuration lines from sub-config sections. [[1]](diffhunk://#diff-fad850b4b8b5926e3a623b1a695005689b522ae1c77e4f4c307d8263e7d8e983R33-R37) [[2]](diffhunk://#diff-fad850b4b8b5926e3a623b1a695005689b522ae1c77e4f4c307d8263e7d8e983L81-L85)

**Code usage updates:**

* Updated all references to `tx_details_storage_provider` in the codebase to use the new location in the general configuration, including in `ServerContext` and the `tx-indexer` main function. [[1]](diffhunk://#diff-937a88d8dbcd7fdfdf763e6c1c00e9a85e5fb02771a42fcdd661105940c81844L144-R144) [[2]](diffhunk://#diff-c1f19fe0bb3acc7237dfdeae0e407c00dacab3a3bc778d4be2fa21858d488080L33-R35)

**Code cleanup:**

* Removed now-unnecessary fields and default logic for `tx_details_storage_provider` from sub-configs and constructors. [[1]](diffhunk://#diff-5ea05362ed45b1c41175b83422c73a2ffef1f92c09aa6b2768ff69955aaba9eeL216) [[2]](diffhunk://#diff-2b276f5036f11e1afbcc8e577d7da71475e77fe0a3c73dfac58e799407ed6a81L123-L129) [[3]](diffhunk://#diff-2b276f5036f11e1afbcc8e577d7da71475e77fe0a3c73dfac58e799407ed6a81L162) [[4]](diffhunk://#diff-5ea05362ed45b1c41175b83422c73a2ffef1f92c09aa6b2768ff69955aaba9eeR293)